### PR TITLE
Solve build errors

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'ubuntu-16.04'
 
 trigger:
 - master
@@ -21,6 +21,9 @@ steps:
 
 - script: pip install -r source/requirements.txt
   displayName: 'Install Requirements'
+
+- script: sudo apt-get update && sudo apt-get install -qy --force-yes texlive-full
+    displayName: 'Install LaTeX'
 
 - script: make html
   displayName: 'Compile Docs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
 - script: pip install -r source/requirements.txt
   displayName: 'Install Requirements'
 
-- script: sudo apt-get update && sudo apt-get install -qy --force-yes texlive-full
+- script: sudo apt-get update && sudo apt-get install -qy --force-yes texlive latexmk
   displayName: 'Install LaTeX'
 
 - script: make html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
   displayName: 'Install Requirements'
 
 - script: sudo apt-get update && sudo apt-get install -qy --force-yes texlive-full
-    displayName: 'Install LaTeX'
+  displayName: 'Install LaTeX'
 
 - script: make html
   displayName: 'Compile Docs'

--- a/source/docs/hardware/getting-started/status-lights-ref.rst
+++ b/source/docs/hardware/getting-started/status-lights-ref.rst
@@ -1,33 +1,31 @@
 Status Light Quick Reference
-====================================
+============================
 
 Many of the components of the FRC Control System have indicator lights that can be used to quickly diagnose problems with your robot. This guide shows each of the hardware components and describes the meaning of the indicators. Photos and information from Innovation FIRST and Cross the Road Electronics.
 
 Robot Signal Light (RSL)
----------------------------------------
+------------------------
 
 .. image:: images/status-lights/rslLight.png
-    :width: 300
 
 - Solid ON - Robot On and Disabled
 - Blinking - Robot On and Enabled
 - Off - Robot Off, roboRIO not powered or RSL not wired properly.
 
-RoboRIO
----------
+roboRIO
+-------
 
 .. image:: images/status-lights/rioLight.png
-    :width: 300
 
-Power
-~~~~~~~~~~
+roboRIO Power
+^^^^^^^^^^^^^
 
 - Green - Power is good
 - Amber - Brownout protection tripped, outputs disabled
 - Red - Power fault, check user rails for short circuit
 
-Status
-~~~~~~~~~~
+roboRIO Status
+^^^^^^^^^^^^^^
 
 - On while the controller is booting, then should turn off
 - 2 blinks - Software error, reimage roboRIO
@@ -35,53 +33,52 @@ Status
 - 4 blinks - Software crashed twice without rebooting, reboot roboRIO, reimage if not resolved
 - Constant flash or stays solid on - Unrecoverable error
 
-Radio
-~~~~~~~~~~
+roboRIO Radio
+^^^^^^^^^^^^^
 
 - Not currently implemented
 
-Comm
-~~~~~~~~~~
+roboRIO Comm
+^^^^^^^^^^^^
 
 - Off - No Communication
 - Red Solid - Communication with DS, but no user code
 - Red Blinking - E-stop
 - Green Solid - Good communication with DS
 
-Mode
-~~~~~~~~~~
+roboRIO Mode
+^^^^^^^^^^^^
 
 - Off - Outputs disabled (robot in Disabled, brown-out, etc.)
 - Amber/Orange - Autonomous Enabled
 - Green - Teleop Enabled
 - Red - Test Enabled
 
-RSL
-~~~~~~~~~~
+roboRIO RSL
+^^^^^^^^^^^
 
 - See above
 
 
 OpenMesh Radio
----------------------------
+--------------
 
 .. image:: images/status-lights/radioLight.png
-    :width: 300
 
-Power
-~~~~~~~~~~
+Radio Power
+^^^^^^^^^^^
 
 - Blue - On or Powering Up
 - Blue Blinking - Powering Up
 
-Eth Link
-~~~~~~~~~~
+Radio Eth Link
+^^^^^^^^^^^^^^
 
 - Blue - Link Up
 - Blue Blinking - Link Up + Traffic Present
 
-WiFi
-~~~~~~~~~~
+Radio WiFi
+^^^^^^^^^^
 
 - Off - Bridge Mode Unlinked or Non-FRC Firmware
 - Red - AP Mode Unlinked
@@ -89,34 +86,34 @@ WiFi
 - Green - Bridge Mode Linked
 
 Power Distribution Panel
-------------------------------------
+------------------------
 
 .. image:: images/status-lights/pdpLight.png
     :width: 300
 
 Voltage Regulator Module
----------------------------
+------------------------
 
 .. image:: images/status-lights/vrmLight.png
     :width: 300
 
 The status LEDs on the VRM indicate the state of the two power supplies. If the supply is functioning properly the LED should be lit bright green. If the LED is not lit or is dim, the output may be shorted or drawing too much current.
 
-Pneumatics Control Module
----------------------------
+Pneumatics Control Module (PCM)
+-------------------------------
 
 .. image:: images/status-lights/pcmLight.png
     :width: 300
 
 Solenoid Channel LEDs - These LEDs are lit red if the Solenoid channel is enabled and not lit if it is disabled.
 
-Comp 
-~~~~~~~~~~
+PCM Comp 
+^^^^^^^^
 
 This is the Compressor LED. This LED is green when the compressor output is active (compressor is currently on) and off when the compressor output is not active.
 
-Status
-~~~~~~~~~~
+PCM Status
+^^^^^^^^^^
 
 The status LED indicates device status as indicated by the two tables above. For more information on resolving PCM faults see the PCM User Manual. Note that the No CAN Comm fault will not occur only if the device cannot see communicate with any other device, if the PCM and PDP can communicate with each other, but not the roboRIO you will NOT see a No Can Comm fault.
 
@@ -124,17 +121,14 @@ Digilent DMC-60
 ---------------------------
 
 .. image:: images/status-lights/digilentLight.png
-    :width: 300
 
 When the center LED is off the device is operating in coast mode. When the center LED is illuminated the device is operating in brake mode. The Brake/Coast mode can be toggled by pressing down on the center of the triangle and then releasing the button.
 
 Jaguar speed controllers
----------------------------
+------------------------
 
 .. image:: images/status-lights/jagLight.png
     :width: 300
-
-image here
 
 Mindsensors SD 540
 ------------------
@@ -143,7 +137,7 @@ Mindsensors SD 540
     :width: 300
 
 REV Robotics Servo Power Module
-------------------------------------
+-------------------------------
 
 .. image:: images/status-lights/servoLight.png
     :width: 300
@@ -151,17 +145,15 @@ REV Robotics Servo Power Module
 - 6V Power LED off, dim or flickering with power applied = Over-current shutdown
 
 REV Robotics SPARK
----------------------------------
+------------------
 
 .. image:: images/status-lights/sparkLight.png
     :width: 300
 
 Talon speed controllers
----------------------------------
+-----------------------
 
 .. image:: images/status-lights/ogTalonLight.png
-    :width: 300
-
 
 The LED is used to indicate the direction and percentage of throttle and state of calibration. The LED may be one of three colors; red, orange or green. A solid green LED indicates positive output voltage equal to the input voltage of the Talon. A solid Red LED indicates an output voltage that is equal to the input voltage multiplied by -1(input voltage = 12 volts, output equals -12 volts). The LED will blink it’s corresponding color for any throttle less than 100% (red indicates negative polarity, green indicates positive). The rate at which the led blinks is proportional to the percent throttle. The faster the LED blinks the closer the output is to 100% in either polarity.
 
@@ -170,10 +162,10 @@ The LED will blink orange any time the Talon is in the disabled state. This will
 Flashing Red/Green indicate ready for calibration. Several green flashes indicates successful calibration, and red several times indicates unsuccessful calibration.
 
 Victor speed controllers
----------------------------
+------------------------
 
 LED Indicator Status:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^
 
 - Green - full forward
 - Orange - neutral / brake
@@ -184,15 +176,14 @@ LED Indicator Status:
 - Flashing red - unsuccessful calibration
 
 Victor-SP speed controllers
----------------------------------
+---------------------------
 
 .. image:: images/status-lights/victorSPLight.png
-    :width: 300
 
 Brake/Coast/Cal Button/LED - Red if the controller is in brake mode, off if the controller is in coast mode
 
 Status
-~~~~~~~~~~
+^^^^^^
 
 The Status LEDs are used to indicate the direction and percentage of throttle and state of calibration. The LEDs may be one of three colors; red, orange or green. Solid green LEDs indicate positive output voltage equal to the input voltage of the Victor-SP. Solid Red LEDs indicate an output voltage that is equal to the input voltage multiplied by -1(input voltage = 12 volts, output equals -12 volts). The LEDs will blink in the corresponding color for any throttle less than 100% (red indicates negative polarity, green indicates positive). The rate at which the LEDs blink is proportional to the percent throttle. The faster the LEDs blink the closer the output is to 100% in either polarity.
 
@@ -201,19 +192,16 @@ The LEDs will blink orange any time the Victor-SP is in the disabled state. This
 Flashing Red/Green indicate ready for calibration. Several green flashes indicates successful calibration, and red several times indicates unsuccessful calibration.
 
 Talon-SRX speed controllers
-------------------------------------
+---------------------------
 
 .. image:: images/status-lights/talonSRXLight.png
-    :width: 300
 
 Spike relay configured as a motor, light, or solenoid switch
----------------------------------------------------------------
+------------------------------------------------------------
 
 .. image:: images/status-lights/spikeRelay1Light.png
-    :width: 300
 
 Spike relay configured as for one or two solenoids
-------------------------------------------------------
+--------------------------------------------------
 
 .. image:: images/status-lights/spikeRelay2Light.png
-    :width: 300

--- a/source/docs/hardware/sensors/analog-inputs-hardware.rst
+++ b/source/docs/hardware/sensors/analog-inputs-hardware.rst
@@ -1,0 +1,2 @@
+Analog Inputs - Hardware
+========================

--- a/source/docs/hardware/sensors/analog-potentiometers-hardware.rst
+++ b/source/docs/hardware/sensors/analog-potentiometers-hardware.rst
@@ -1,0 +1,2 @@
+Analog Potentiometers - Hardware
+================================

--- a/source/docs/hardware/sensors/digital-inputs-hardware.rst
+++ b/source/docs/hardware/sensors/digital-inputs-hardware.rst
@@ -1,0 +1,2 @@
+Digital Inputs - Hardware
+=========================

--- a/source/docs/networking/ip-networking.rst
+++ b/source/docs/networking/ip-networking.rst
@@ -1,18 +1,12 @@
-.. _ip-networking:
-
 IP Networking
 =============
 
-.. note:: This document describes the IP configuration used at
- events, both on the fields and in the pits, potential issues
- and workaround configurations.
+.. note:: This document describes the IP configuration used at events, both on the fields and in the pits, potential issues and workaround configurations.
 
 TE.AM IP Notation
 -----------------
 
-The notation TE.AM is used as part of IPs in numerous places in this
-document. This notation refers to splitting your four digit team number
-into two digit pairs for the IP address octets.
+The notation TE.AM is used as part of IPs in numerous places in this document. This notation refers to splitting your four digit team number into two digit pairs for the IP address octets.
 
 Example: 10.TE.AM.2
 
@@ -27,16 +21,13 @@ Team 3456 - 10.34.56.2
 On the Field
 ------------
 
-This section describes networking when connected to the Field Network
-for match play
+This section describes networking when connected to the Field Network for match play
 
-DHCP (typical configuration)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+On the Field DHCP Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Field Network runs a DHCP server with pools for each team that will
-hand our addresses in the range of 10.TE.AM.20 and up with subnet masks
-of 255.0.0.0
-
+The Field Network runs a DHCP server with pools for each team that will hand our addresses in the range of 10.TE.AM.20 and up with subnet masks
+ 
 -  OpenMesh OM5P-AN or OM5P-AC radio - Static 10.TE.AM.1 programmed by
    Kiosk
 -  roboRIO - DHCP 10.TE.AM.2 assigned by the Robot Radio
@@ -45,17 +36,10 @@ of 255.0.0.0
 -  IP camera (if used) - DHCP 10.TE.AM.Y assigned by Robot Radio
 -  Other devices (if used) - DHCP 10.TE.AM.Z assigned by Robot Radio
 
-Static (workaround configuration)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+On the Field Static Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is also possible to configure static IPs on your devices to
-accommodate devices or software which do not support mDNS. When doing so
-you want to make sure to avoid addresses that will be in use when the
-robot is on the field network. These addresses are 10.TE.AM.1 and
-10.TE.AM.4 for the OpenMesh radio and the field access point and
-anything 10.TE.AM.20 and up which may be assigned to a device still
-configured for DHCP. The roboRIO network configuration can be set from
-the webdashboard.
+It is also possible to configure static IPs on your devices to accommodate devices or software which do not support mDNS. When doing so you want to make sure to avoid addresses that will be in use when the robot is on the field network. These addresses are 10.TE.AM.1 and 10.TE.AM.4 for the OpenMesh radio and the field access point and anything 10.TE.AM.20 and up which may be assigned to a device still configured for DHCP. The roboRIO network configuration can be set from the webdashboard.
 
 -  OpenMesh radio - Static 10.TE.AM.1 programmed by Kiosk
 -  roboRIO - Static 10.TE.AM.2 would be a reasonable choice, subnet mask
@@ -70,13 +54,10 @@ the webdashboard.
 In the Pits
 -----------
 
-**New for 2018: There is now a DHCP server running on the wired side of
-the Robot Radio in the event configuration.**
+..note:: New for 2018: There is now a DHCP server running on the wired side of the Robot Radio in the event configuration.**
 
-.. _dhcp-typical-configuration-1:
-
-DHCP (typical configuration)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In the Pits DHCP Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  OpenMesh radio - Static 10.TE.AM.1 programmed by Kiosk.
 -  roboRIO - 10.TE.AM.2, assigned by Robot Radio
@@ -85,13 +66,7 @@ DHCP (typical configuration)
 -  IP camera (if used) - DHCP, 10.TE.AM.Y, assigned by Robot Radio
 -  Other devices (if used) - DHCP, 10.TE.AM.Z, assigned by Robot Radio
 
-.. _static-workaround-configuration-1:
+In the Pits Static Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Static (workaround configuration)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-It is also possible to configure static IPs on your devices to
-accommodate devices or software which do not support mDNS. When doing so
-you want to make sure to avoid addresses that will be in use when the
-robot is on the field network. These addresses are 10.TE.AM.1 and
-10.TE.AM.4 for the OpenMesh radio
+It is also possible to configure static IPs on your devices to accommodate devices or software which do not support mDNS. When doing so you want to make sure to avoid addresses that will be in use when the robot is on the field network. These addresses are 10.TE.AM.1 and 10.TE.AM.4 for the OpenMesh radio

--- a/source/docs/networking/roborio-networking.rst
+++ b/source/docs/networking/roborio-networking.rst
@@ -1,11 +1,9 @@
-.. _roborio-networking:
-
 RoboRIO Networking
 ==================
 
 The network setup used on the roboRIO system is a little bit different than the previous Control System. The new scheme utilizes mDNS to allow for the use of DHCP addressing and seamless transition from ethernet to USB and back.
 
-This document discusses the  typical setup at home. For more information about the networking environment at events, or about using Static IPs see IP Networking at the Event
+This document discusses the  typical setup at home. For more information about the networking environment at events, or about using Static IPs see :ref:`docs/networking/ip-networking:IP Networking`
 
 mDNS
 ----
@@ -24,24 +22,32 @@ To use mDNS, an mDNS implementation is required to be installed on your PC. Here
 
 Windows:
 
-- NI mDNS Responder - **Installed with the NI FRC Update Suite**
-- Apple Bonjour - Installed with iTunes
+- **NI mDNS Responder:** Installed with the NI FRC Update Suite
+- **Apple Bonjour:** Installed with iTunes
 
 OSX:
 
-- Apple Bonjour - **Installed by default**
+- **Apple Bonjour:** Installed by default
 
 Linux:
 
-- nss-mDNS/Avahi/Zeroconf - Installed and enabled by default on some Linux variants (such as Ubuntu or Mint). May need to be installed or enabled on others (such as Arch)
+- **nss-mDNS/Avahi/Zeroconf:** Installed and enabled by default on some Linux variants (such as Ubuntu or Mint). May need to be installed or enabled on others (such as Arch)
 
 mDNS - Firewalls
 ^^^^^^^^^^^^^^^^
 
-To work properly mDNS must be allowed to pass through your firewall. **Depending on your PC configuration, no changes may be required, this section is provided to assist with troubleshooting.** Because the network traffic comes from the mDNS implementation and not directly from the Driver Station or IDE, allowing those applications through may not be sufficient. There are two main ways to resolve mDNS firewall issues:
+.. note:: Depending on your PC configuration, no changes may be required, this section is provided to assist with troubleshooting.
 
-- Add an application/service exception for the mDNS implementation (NI mDNS Responder is C:\Program Files\National Instruments\Shared\mDNS Responder\nimdnsResponder.exe)
-- Add a port exception for traffic to/from UDP 5353 (IP ranges 10.0.0.0-10.255.255.255   172.16.0.0-172.31.255.255   192.168.0.0-192.168.255.255   169.254.0.0-169.254.255.255   224.0.0.251)
+To work properly mDNS must be allowed to pass through your firewall. Because the network traffic comes from the mDNS implementation and not directly from the Driver Station or IDE, allowing those applications through may not be sufficient. There are two main ways to resolve mDNS firewall issues:
+
+- Add an application/service exception for the mDNS implementation (NI mDNS Responder is ``C:\Program Files\National Instruments\Shared\mDNS Responder\nimdnsResponder.exe``)
+- Add a port exception for traffic to/from UDP 5353. IP Ranges:
+
+  - 10.0.0.0 - 10.255.255.255
+  - 172.16.0.0 - 172.31.255.255
+  - 192.168.0.0 - 192.168.255.255
+  - 169.254.0.0 - 169.254.255.255   
+  - 224.0.0.251
 
 mDNS - Browser support
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -51,24 +57,28 @@ Most web-browsers should be able to utilize the mDNS address to access the roboR
 USB
 ---
 
-If using the USB interface, no network setup is required (you do need the :ref:`NI Update Suite <installing_FRC_update_suite>` installed to provide the roboRIO USB Driver). The roboRIO driver will automatically configure the IP address of the host (your computer) and roboRIO and the software listed above should be able to locate and utilize your roboRIO.
+If using the USB interface, no network setup is required (you do need the :ref:`docs/software/getting-started/frc-update-suite:Installing the FRC Update Suite` installed to provide the roboRIO USB Driver). The roboRIO driver will automatically configure the IP address of the host (your computer) and roboRIO and the software listed above should be able to locate and utilize your roboRIO.
 
 Ethernet/Wireless
 -----------------
 
-The :ref:`FRC Radio Configuration Utility <radio-programming>` will enable the DHCP server on the OpenMesh radio in the home use case (AP mode), if you are putting the OpenMesh in bridge mode and using a router, you can enable DHCP addressing on the router. The bridge is set to the same team based IP address as before (10.TE.AM.1) and will hand out DHCP address from 10.TE.AM.20 to 10.TE.AM.199. When connected to the field, FMS will also hand out addresses in the same IP range.
+The :ref:`docs/software/getting-started/radio-programming:Programming your Radio` will enable the DHCP server on the OpenMesh radio in the home use case (AP mode), if you are putting the OpenMesh in bridge mode and using a router, you can enable DHCP addressing on the router. The bridge is set to the same team based IP address as before (10.TE.AM.1) and will hand out DHCP address from **10.TE.AM.20** to **10.TE.AM.199**. When connected to the field, FMS will also hand out addresses in the same IP range.
 
 roboRIO Ethernet Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**The roboRIO Ethernet interface should be set to DHCP.** When connected to the OpenMesh bridge, the roboRIO will receive an IP from the bridge. When tethered directly to a PC, both devices will self-assign IPs.
+.. important:: The roboRIO Ethernet interface should be set to DHCP. 
+
+When connected to the OpenMesh bridge, the roboRIO will receive an IP from the bridge. When tethered directly to a PC, both devices will self-assign IPs.
 
 PC Adapter Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-**When connecting via Ethernet (to either the radio or directly to the roboRIO) or Wireless (to the OpenMesh radio), your computer adapter should be set to DHCP.** When connecting through the OpenMesh, your PC will receive an IP address from the radio. If tethered directly to the roboRIO both devices will self-assign IPs.
+.. important:: When connecting via Ethernet (to either the radio or directly to the roboRIO) or Wireless (to the OpenMesh radio), your computer adapter should be set to DHCP.
+
+When connecting through the OpenMesh, your PC will receive an IP address from the radio. If tethered directly to the roboRIO both devices will self-assign IPs.
 
 IP List
 -------
 
-See :ref:`IP Networking <ip-networking>` for more information
+See :ref:`docs/networking/ip-networking:IP Networking` for more information

--- a/source/docs/software/advanced-programming/common-control-algorithms.rst
+++ b/source/docs/software/advanced-programming/common-control-algorithms.rst
@@ -1,0 +1,2 @@
+Common Control Algorithms
+=========================

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -16,7 +16,7 @@ Cross-the-Road Electronics
 Cross-the-Road Electronics (CTRE) offers several CAN peripherals with external libraries:
 
 Motor Controllers
-~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^
 
 - **Talon SRX**
 
@@ -28,8 +28,8 @@ Motor Controllers
     - API Documentation (`Java <http://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_victor_s_p_x.html>`__, `C++ <http://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_victor_s_p_x.html>`__)
     - `Technical Manual <http://www.ctr-electronics.com/downloads/pdf/Victor%20SPX%20User's%20Guide.pdf>`__
 
-Sensors
-~~~~~~~
+CTRE Sensors
+^^^^^^^^^^^^
 
 - **Pigeon IMU**
 
@@ -47,7 +47,7 @@ REV Robotics
 REV Robotics currently offers the SPARK MAX motor controller, which has a simiilar feature-set to the Talon SRX.
 
 Motor Controllers
-~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^
 
 - **SPARK MAX**
 

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -15,8 +15,8 @@ Cross-the-Road Electronics
 
 Cross-the-Road Electronics (CTRE) offers several CAN peripherals with external libraries:
 
-Motor Controllers
-^^^^^^^^^^^^^^^^^
+CTRE Motor Controllers
+^^^^^^^^^^^^^^^^^^^^^^
 
 - **Talon SRX**
 
@@ -46,8 +46,8 @@ REV Robotics
 
 REV Robotics currently offers the SPARK MAX motor controller, which has a simiilar feature-set to the Talon SRX.
 
-Motor Controllers
-^^^^^^^^^^^^^^^^^
+REV Motor Controllers
+^^^^^^^^^^^^^^^^^^^^^
 
 - **SPARK MAX**
 

--- a/source/docs/software/sensors/analog-inputs-software.rst
+++ b/source/docs/software/sensors/analog-inputs-software.rst
@@ -3,7 +3,7 @@
 Analog Inputs
 =============
 
-.. note:: This section covers analog inputs in software.  For a hardware guide to analog inputs, see :ref:`analog-inputs-hardware`.
+.. note:: This section covers analog inputs in software.  For a hardware guide to analog inputs, see :ref:`docs/hardware/sensors/analog-inputs-hardware:Analog Inputs - Hardware`.
 
 The RoboRIO's FPGA supports up to 8 analog input channels that can be used to read the value of an analog voltage from a sensor.  Analog inputs may be used for any sensor that outputs a simple voltage.
 
@@ -12,7 +12,7 @@ Analog inputs from the FPGA by default return a 12-bit integer proportional to t
 The AnalogInput class
 ---------------------
 
-.. note:: It is often more convenient to use the :ref:`AnalogPotentiometer <analog-potentiometers-software>` wrapper class than to use :code:`AnalogInput` directly, as it supports scaling to meaningful units.
+.. note:: It is often more convenient to use the :doc:`Analog Potentiometers <analog-potentiometers-software>` wrapper class than to use :code:`AnalogInput` directly, as it supports scaling to meaningful units.
 
 Support for reading the voltages on the FPGA analog inputs is provided through the :code:`AnalogInput` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/AnalogInput.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1AnalogInput.html>`__).
 

--- a/source/docs/software/sensors/analog-potentiometers-software.rst
+++ b/source/docs/software/sensors/analog-potentiometers-software.rst
@@ -1,13 +1,11 @@
-.. _analog-potentiometers-software:
-
 Analog Potentiometers - Software
 ================================
 
-.. note:: This section covers analog potentiometers in software.  For a hardware guide to analog potentiometers, see :ref:`analog-potentiometers-hardware`.
+.. note:: This section covers analog potentiometers in software.  For a hardware guide to analog potentiometers, see :ref:`docs/hardware/sensors/analog-potentiometers-hardware:Analog Potentiometers - Hardware`.
 
 Potentiometers are variable resistors that allow information about position to be converted into an analog voltage signal.  This signal can be read by the RoboRIO to control whatever device is attached to the potentiometer.
 
-While it is possible to read information from a potentiometer directly with an :ref:`AnalogInput <analog-inputs-software>`, WPILib provides an :code:`AnalogPotentiometer` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/AnalogPotentiometer.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1AnalogPotentiometer.html>`__) that handles re-scaling the values into meaningful units for the user.  It is strongly encouraged to use this class.
+While it is possible to read information from a potentiometer directly with an :doc:`analog-inputs-software`, WPILib provides an :code:`AnalogPotentiometer` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/AnalogPotentiometer.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1AnalogPotentiometer.html>`__) that handles re-scaling the values into meaningful units for the user.  It is strongly encouraged to use this class.
 
 In fact, the :code:`AnalogPotentiometer` name is something of a misnomer - this class should be used for the vast majority of sensors that return their signal as a simple, linearly-scaled analog voltage.
 
@@ -87,6 +85,6 @@ The scaled value can be read by simply calling the :code:`get` method:
 Using AnalogPotentiometers in code
 ----------------------------------
 
-Analog sensors can be used in code much in the way other sensors that measure the same thing can be.  If the analog sensor is a potentiometer measuring an arm angle, it can be used similarly to an :ref:`encoder <encoders-software>`.  If it is an ultrasonic sensor, it can be used similarly to other :ref:`ultrasonic sensors <ultrasonics-software>`.
+Analog sensors can be used in code much in the way other sensors that measure the same thing can be.  If the analog sensor is a potentiometer measuring an arm angle, it can be used similarly to an :doc:`encoder <encoders-software>`.  If it is an ultrasonic sensor, it can be used similarly to other :doc:`ultrasonics <ultrasonics-software>`.
 
 It is very important to keep in mind that actual, physical potentiometers generally have a limited range of motion.  Safeguards should be present in both the physical mechanism and the code to ensure that the mechanism does not break the sensor by traveling past its maximum throw.

--- a/source/docs/software/sensors/digital-inputs-software.rst
+++ b/source/docs/software/sensors/digital-inputs-software.rst
@@ -3,11 +3,11 @@
 Digital Inputs - Software
 =========================
 
-.. note:: This section covers digital inputs in software.  For a hardware guide to digital inputs, see :ref:`digital-inputs-hardware`.
+.. note:: This section covers digital inputs in software.  For a hardware guide to digital inputs, see :ref:`docs/hardware/sensors/digital-inputs-hardware:Digital Inputs - Hardware`.
 
 The RoboRIO's FPGA supports up to 26 digital inputs.  10 of these are made available through the built-in DIO ports on the RIO itself, while the other 16 are available through the MXP breakout port.
 
-Digital inputs read one of two states - "high" or "low."  By default, the built-in ports on the RIO will read "high" due to internal pull-up resistors (for more information, see :ref:`digital-inputs-hardware`).  Accordingly, digital inputs are most-commonly used with switches of some sort.  Support for this usage is provided through the :code:`DigitalInput` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/DigitalInput.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1DigitalInput.html>`__).
+Digital inputs read one of two states - "high" or "low."  By default, the built-in ports on the RIO will read "high" due to internal pull-up resistors (for more information, see :ref:`docs/hardware/sensors/digital-inputs-hardware:Digital Inputs - Hardware`).  Accordingly, digital inputs are most-commonly used with switches of some sort.  Support for this usage is provided through the :code:`DigitalInput` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/DigitalInput.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1DigitalInput.html>`__).
 
 The DigitalInput class
 ----------------------
@@ -81,7 +81,7 @@ An :code:`AnalogTrigger` may be initialized as follows.  As with :code:`AnalogPo
 Setting the trigger points
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note:: For details on the scaling of "raw" :code:`AnalogInput` values, see :ref:`analog-inputs-software`.
+.. note:: For details on the scaling of "raw" :code:`AnalogInput` values, see :doc:`analog-inputs-software`.
 
 To convert the analog signal to a digital one, it is necessary to specify at what values the trigger will enable and disable.  These values may be different to avoid "dithering" around the transition point:
 

--- a/source/docs/software/sensors/encoders-software.rst
+++ b/source/docs/software/sensors/encoders-software.rst
@@ -395,7 +395,7 @@ More-advanced implementations can use more-complicated control loops.  Closing a
 PID Control
 ~~~~~~~~~~~
 
-Encoders are particularly useful as inputs to PID controllers (the heading stabilization example above is a simple P loop).  For more information on PID control, see :ref:`PID Control <pid-control>`.
+Encoders are particularly useful as inputs to PID controllers (the heading stabilization example above is a simple P loop).  For more information on PID control, see ref:`docs/software/advanced-programming/common-control-algorithms:Common Control Algorithms`.
 
 .. _homing-an-encodered-mechanism:
 

--- a/source/docs/software/sensors/ultrasonics-software.rst
+++ b/source/docs/software/sensors/ultrasonics-software.rst
@@ -48,7 +48,7 @@ It is highly recommended to use ping-response ultrasonics in "automatic mode," a
 Analog ultrasonics
 ------------------
 
-Some ultrasonic sensors simply return an analog voltage corresponding to the measured distance.  These sensors can may simply be used with the :ref:`AnalogPotentiometer <analog-potentiometers-software>` class.
+Some ultrasonic sensors simply return an analog voltage corresponding to the measured distance.  These sensors can may simply be used with the :doc:`AnalogPotentiometer <analog-potentiometers-software>` class.
 
 Third-party ultrasonics
 -----------------------

--- a/source/docs/software/vision-processing/configuring-an-axis-camera.rst
+++ b/source/docs/software/vision-processing/configuring-an-axis-camera.rst
@@ -71,29 +71,29 @@ It is recommended to use the Setup Axis Camera Tool to configure the Axis Camera
 
 If you do not see the camera webpage come up, you may need to reset the camera to factory defaults. To do this, remove power from the camera, hold the reset button while applying power to the camera and continue holding it until the lights on the camera face turn on, then release the reset button and wait for the lights to turn green. The camera is now reset to factory settings and should be accessible via the ``192.168.0.90`` address.
 
-Setup Page
-^^^^^^^^^^
+Manual - Setup Page
+^^^^^^^^^^^^^^^^^^^
 
 .. image:: images/configuring-an-axis-camera/setup-page.png
 
 Click Setup to go to the setup page.
 
-Configure Users
-^^^^^^^^^^^^^^^
+Manual - Configure Users
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. image:: images/configuring-an-axis-camera/configure-users.png
 
 On the left side click Users to open the users page. Click Add then enter the Username FRC Password FRC and click the Administrator bubble, then click OK. If using the SmartDashboard, check the Enable anonymous viewer login box. Then click Save.
 
-Configure Image Settings
-^^^^^^^^^^^^^^^^^^^^^^^^
+Manual - Configure Image Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. image:: images/configuring-an-axis-camera/configure-image-settings.png
 
 Click Video & Image on the left side to open the image settings page. Set the Resolution and Compression to the desired values (recommended 320x240, 30). To limit the framerate to under 30 FPS, select the Limited to bubble under Maximum frame rate and enter the desired rate in the box. Color, Brightness and Sharpness may also be set on this screen if desired. Click Save when finished.
 
-Configure Basic Network Settings
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Manual - Configure Basic Network Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. image:: images/configuring-an-axis-camera/configure-basic-network-settings.png
 
@@ -101,8 +101,8 @@ To configure the network settings of the camera, click the arrow to expand the S
 
 Click Save.
 
-Configure Advanced Network Settings
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Manual - Configure Advanced Network Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. image:: images/configuring-an-axis-camera/configure-advanced-network-settings.png
 

--- a/source/docs/software/wpilib-tools/path-planning/creating-pathweaver-project.rst
+++ b/source/docs/software/wpilib-tools/path-planning/creating-pathweaver-project.rst
@@ -10,8 +10,8 @@ PathWeaver is started by clicking on the ellipsis icon in the top right of the c
 
 .. image:: images/pathweaver-2.png
 
-Creating a PathWeaver project 
------------------------------
+Creating the project
+--------------------
 To create a PathWeave project, click on "Create project" then fill out the project creation form. Notice that hovering ove any of the fields in the form will display more information about what is required.
 
 .. image:: images/pathweaver-3.png
@@ -47,4 +47,3 @@ The PathWeaver user interface consists of:
 4. The individual paths that a robot will follow, The paths may be grouped together as a Path Group in order to better visualize the total robot movement in a multi-path sequence.
 5. The drawn paths are used to create the set of wheel velocities the robot will use when following your path. There is one velocity generated for every unit of time as described in the Time Base parameter of your project.
 6. Allows the PathWeaver project properties to be edited (includes Project directory, time step, field drawing, etc.) as described at the beginning of this article.
-

--- a/source/docs/software/wpilib-tools/smartdashboard/displaying-expressions.rst
+++ b/source/docs/software/wpilib-tools/smartdashboard/displaying-expressions.rst
@@ -1,5 +1,3 @@
-.. _smartdashboard-displaying-expressions:
-
 Displaying Expressions from a Robot Program
 ===========================================
 

--- a/source/docs/software/wpilib-tools/smartdashboard/smartdashboard-intro.rst
+++ b/source/docs/software/wpilib-tools/smartdashboard/smartdashboard-intro.rst
@@ -1,5 +1,3 @@
-.. _smartdashboard-intro:
-
 SmartDashboard Introduction
 ===========================
 
@@ -56,4 +54,4 @@ Adding Widgets to the SmartDashboard
 
 .. image:: images/smartdashboard-intro-6.png
 
-Widgets are automatically added to the SmartDashboard for each "key" sent by the robot code. For instructions on adding robot code to write to the SmartDashboard see :ref:`Displaying Expressions from Within the Robot Program <smartdashboard-expressions>`.
+Widgets are automatically added to the SmartDashboard for each "key" sent by the robot code. For instructions on adding robot code to write to the SmartDashboard see :doc:`Displaying Expressions from Within the Robot Program <displaying-expressions>`.

--- a/source/hardware.rst
+++ b/source/hardware.rst
@@ -19,6 +19,9 @@ Sensors
    :maxdepth: 1
    
    docs/hardware/sensors/sensor-overview-hardware
+   docs/hardware/sensors/analog-inputs-hardware
+   docs/hardware/sensors/analog-potentiometers-hardware
+   docs/hardware/sensors/digital-inputs-hardware
    docs/hardware/sensors/accelerometers-hardware
    docs/hardware/sensors/gyros-hardware
    docs/hardware/sensors/ultrasonics-hardware

--- a/source/index.rst
+++ b/source/index.rst
@@ -6,6 +6,8 @@
 Welcome to FIRST Robotics Documentation
 ========================================================
 
+Welcome to the FIRST Robotics Documentation! This documentation is very much a work-in-progress, so please excuse the constant house-keeping. If you'd like to contribute, check out :doc:`contributing`.
+
 .. toctree::
    :maxdepth: 1
    :caption: Software Introduction

--- a/source/software.rst
+++ b/source/software.rst
@@ -214,3 +214,18 @@ Autonomous Path Planning
    docs/software/wpilib-tools/path-planning/pathweaver-limits
    docs/software/wpilib-tools/path-planning/integrating-robot-program
    docs/software/wpilib-tools/path-planning/adding-field-images
+
+Basic Programming
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+
+Advanced Programming
+====================
+
+.. toctree::
+   :maxdepth: 1
+
+   docs/software/advanced-programming/common-control-algorithms


### PR DESCRIPTION
This PR solves numerous build errors related to duplicate section titles and references. 

- Adds several blank stub pages
- Adds a section called `Basic Programming`
- Adds a section called `Advanced Programming`
- Cleans up status-lights-ref
- Cleans up ip-networking
- Cleans up third-party-devices

Appropriate issues will be opened up in regards to the stub articles, as well as reworking different pages to follow the style guide. 

@PeterJohnson Any issues to this?
