### PR TITLE
fix sensors tab order and links

### DIFF
--- a/source/docs/software/sensors/accelerometers-software.rst
+++ b/source/docs/software/sensors/accelerometers-software.rst
@@ -1,9 +1,7 @@
-.. _accelerometers-software:
-
 Accelerometers - Software
 =========================
 
-.. note:: This section covers accelerometers in software.  For a hardware guide to accelerometers, see :ref:`accelerometers-hardware`.
+.. note:: This section covers accelerometers in software.  For a hardware guide to accelerometers, see :ref:`docs/hardware/sensors/accelerometers-hardware:Accelerometers - Hardware`.
 
 An accelerometer is a device that measures acceleration.
 
@@ -25,21 +23,6 @@ The :code:`AnalogAccelerometer` class (`Java <https://first.wpi.edu/FRC/roborio/
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Creates an analog accelerometer on analog input 0
-        frc::AnalogAccelerometer accelerometer{0};
-
-        // Sets the sensitivity of the accelerometer to 1 volt per G
-        accelerometer.SetSensitivity(1);
-
-        // Sets the zero voltage of the accelerometer to 3 volts
-        accelerometer.SetZero(3);
-
-        // Gets the current acceleration
-        double accel = accelerometer.GetAcceleration();
-
-
     .. code-tab:: java
 
         // Creates an analog accelerometer on analog input 0
@@ -53,6 +36,20 @@ The :code:`AnalogAccelerometer` class (`Java <https://first.wpi.edu/FRC/roborio/
 
         // Gets the current acceleration
         double accel = accelerometer.getAcceleration();
+
+    .. code-tab:: c++
+
+        // Creates an analog accelerometer on analog input 0
+        frc::AnalogAccelerometer accelerometer{0};
+
+        // Sets the sensitivity of the accelerometer to 1 volt per G
+        accelerometer.SetSensitivity(1);
+
+        // Sets the zero voltage of the accelerometer to 3 volts
+        accelerometer.SetZero(3);
+
+        // Gets the current acceleration
+        double accel = accelerometer.GetAcceleration();
 
 If users have a 3-axis analog accelerometer, they can use three instances of this class, one for each axis.
 
@@ -68,15 +65,15 @@ The :code:`Accelerometer` interface contains getters for the acceleration along 
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Sets the accelerometer to measure between -8 and 8 G's
-        accelerometer.SetRange(Accelerometer::Range::kRange_8G);
-
     .. code-tab:: java
 
         // Sets the accelerometer to measure between -8 and 8 G's
         accelerometer.setRange(Accelerometer.Range.k8G);
+
+    .. code-tab:: c++
+
+        // Sets the accelerometer to measure between -8 and 8 G's
+        accelerometer.SetRange(Accelerometer::Range::kRange_8G);
 
 ADXL345_I2C
 ^^^^^^^^^^^
@@ -85,17 +82,17 @@ The :code:`ADXL345_I2C` class (`Java <https://first.wpi.edu/FRC/roborio/release/
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Creates an ADXL345 accelerometer object on the MXP I2C port
-        // with a measurement range from -8 to 8 G's
-        frc::ADXL345_I2C accelerometer{I2C::Port::kMXP, Accelerometer::Range::kRange_8G};
-
     .. code-tab:: java
 
         // Creates an ADXL345 accelerometer object on the MXP I2C port
         // with a measurement range from -8 to 8 G's
         Accelerometer accelerometer = new ADXL345_I2C(I2C.Port.kMXP, Accelerometer.Range.k8G);
+
+    .. code-tab:: c++
+
+        // Creates an ADXL345 accelerometer object on the MXP I2C port
+        // with a measurement range from -8 to 8 G's
+        frc::ADXL345_I2C accelerometer{I2C::Port::kMXP, Accelerometer::Range::kRange_8G};
 
 ADXL345_SPI
 ^^^^^^^^^^^
@@ -104,17 +101,17 @@ The :code:`ADXL345_SPI` class (`Java <https://first.wpi.edu/FRC/roborio/release/
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Creates an ADXL345 accelerometer object on the MXP SPI port
-        // with a measurement range from -8 to 8 G's
-        frc::ADXL345_SPI accelerometer{SPI::Port::kMXP, Accelerometer::Range::kRange_8G};
-
     .. code-tab:: java
 
         // Creates an ADXL345 accelerometer object on the MXP SPI port
         // with a measurement range from -8 to 8 G's
         Accelerometer accelerometer = new ADXL345_SPI(SPI.Port.kMXP, Accelerometer.Range.k8G);
+
+    .. code-tab:: c++
+
+        // Creates an ADXL345 accelerometer object on the MXP SPI port
+        // with a measurement range from -8 to 8 G's
+        frc::ADXL345_SPI accelerometer{SPI::Port::kMXP, Accelerometer::Range::kRange_8G};
 
 ADXL362
 ^^^^^^^
@@ -123,17 +120,17 @@ The :code:`ADXL362` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Creates an ADXL362 accelerometer object on the MXP SPI port
-        // with a measurement range from -8 to 8 G's
-        frc::ADXL362 accelerometer{SPI::Port::kMXP, Accelerometer::Range::kRange_8G};
-
     .. code-tab:: java
 
         // Creates an ADXL362 accelerometer object on the MXP SPI port
         // with a measurement range from -8 to 8 G's
         Accelerometer accelerometer = new ADXL362(SPI.Port.kMXP, Accelerometer.Range.k8G);
+
+    .. code-tab:: c++
+
+        // Creates an ADXL362 accelerometer object on the MXP SPI port
+        // with a measurement range from -8 to 8 G's
+        frc::ADXL362 accelerometer{SPI::Port::kMXP, Accelerometer::Range::kRange_8G};
 
 BuiltInAccelerometer
 ^^^^^^^^^^^^^^^^^^^^
@@ -142,17 +139,17 @@ The :code:`BuiltInAccelerometer` class (`Java <https://first.wpi.edu/FRC/roborio
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Creates an object for the built-in accelerometer
-        // Range defaults to +- 8 G's
-        frc::BuiltInAccelerometer accelerometer{};
-
     .. code-tab:: java
 
         // Creates an object for the built-in accelerometer
         // Range defaults to +- 8 G's
         Accelerometer accelerometer = new BuiltInAccelerometer();
+
+    .. code-tab:: c++
+
+        // Creates an object for the built-in accelerometer
+        // Range defaults to +- 8 G's
+        frc::BuiltInAccelerometer accelerometer{};
 
 Third-party accelerometers
 --------------------------
@@ -169,27 +166,6 @@ It is recommended to use accelerometers in FRC for any application which needs a
 For detecting collisions, it is often more robust to measure the jerk than the acceleration.  The jerk is the derivative (or rate of change) of acceleration, and indicates how rapidly the forces on the robot are changing - the sudden impulse from a collision causes a sharp spike in the jerk.  Jerk can be determined by simply taking the difference of subsequent acceleration measurements, and dividing by the time between them:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        double prevXAccel = 0;
-        double prevYAccel = 0;
-
-        frc::BuiltInAccelerometer accelerometer{};
-
-        void Robot::RobotPeriodic() {
-            // Gets the current accelerations in the X and Y directions
-            double xAccel = accelerometer.GetX();
-            double yAccel = accelerometer.GetY();
-
-            // Calculates the jerk in the X and Y directions
-            // Divides by .02 because default loop timing is 20ms
-            double xJerk = (xAccel - prevXAccel)/.02;
-            double yJerk = (yAccel - prevYAccel)/.02;
-
-            prevXAccel = xAccel;
-            prevYAccel = yAccel;
-        }
 
     .. code-tab:: java
 
@@ -213,13 +189,30 @@ For detecting collisions, it is often more robust to measure the jerk than the a
             prevYAccel = yAccel;
         }
 
+    .. code-tab:: c++
+
+        double prevXAccel = 0;
+        double prevYAccel = 0;
+
+        frc::BuiltInAccelerometer accelerometer{};
+
+        void Robot::RobotPeriodic() {
+            // Gets the current accelerations in the X and Y directions
+            double xAccel = accelerometer.GetX();
+            double yAccel = accelerometer.GetY();
+
+            // Calculates the jerk in the X and Y directions
+            // Divides by .02 because default loop timing is 20ms
+            double xJerk = (xAccel - prevXAccel)/.02;
+            double yJerk = (yAccel - prevYAccel)/.02;
+
+            prevXAccel = xAccel;
+            prevYAccel = yAccel;
+        }
+
 Most accelerometers legal for FRC use are quite noisy, and it is often a good idea to combine them with the :code:`LinearDigitalFilter` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/filters/LinearDigitalFilter.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/filters/LinearDigitalFilter.html>`__) to reduce the noise:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        TODO: C++ example
 
     .. code-tab:: java
 
@@ -250,3 +243,7 @@ Most accelerometers legal for FRC use are quite noisy, and it is often a good id
             // Get the filtered X acceleration
             double filteredXAccel = xAccelFilter.pidGet();
         }
+
+    .. code-tab:: c++
+
+        TODO: C++ example

--- a/source/docs/software/sensors/accelerometers-software.rst
+++ b/source/docs/software/sensors/accelerometers-software.rst
@@ -79,7 +79,7 @@ The :code:`Accelerometer` interface contains getters for the acceleration along 
         accelerometer.setRange(Accelerometer.Range.k8G);
 
 ADXL345_I2C
-~~~~~~~~~~~
+^^^^^^^^^^^
 
 The :code:`ADXL345_I2C` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/ADXL345_I2C.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1ADXL345__I2C.html>`__) provides support for the ADXL345 accelerometer over the I2C communications bus.
 
@@ -98,7 +98,7 @@ The :code:`ADXL345_I2C` class (`Java <https://first.wpi.edu/FRC/roborio/release/
         Accelerometer accelerometer = new ADXL345_I2C(I2C.Port.kMXP, Accelerometer.Range.k8G);
 
 ADXL345_SPI
-~~~~~~~~~~~
+^^^^^^^^^^^
 
 The :code:`ADXL345_SPI` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/ADXL345_SPI.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1ADXL345__SPI.html>`__) provides support for the ADXL345 accelerometer over the SPI communications bus.   
 
@@ -117,7 +117,7 @@ The :code:`ADXL345_SPI` class (`Java <https://first.wpi.edu/FRC/roborio/release/
         Accelerometer accelerometer = new ADXL345_SPI(SPI.Port.kMXP, Accelerometer.Range.k8G);
 
 ADXL362
-~~~~~~~
+^^^^^^^
 
 The :code:`ADXL362` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/ADXL362.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1ADXL362.html>`__) provides support for the ADXL362 accelerometer over the SPI communications bus.
 
@@ -136,7 +136,7 @@ The :code:`ADXL362` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs
         Accelerometer accelerometer = new ADXL362(SPI.Port.kMXP, Accelerometer.Range.k8G);
 
 BuiltInAccelerometer
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^
 
 The :code:`BuiltInAccelerometer` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/BuiltInAccelerometer.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1BuiltInAccelerometer.html>`__) provides access to the RoboRIO's own built-in accelerometer:
 

--- a/source/docs/software/sensors/analog-inputs-software.rst
+++ b/source/docs/software/sensors/analog-inputs-software.rst
@@ -17,7 +17,7 @@ The AnalogInput class
 Support for reading the voltages on the FPGA analog inputs is provided through the :code:`AnalogInput` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/AnalogInput.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1AnalogInput.html>`__).
 
 Initializing an AnalogInput
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 An :code:`AnalogInput` may be initialized as follows:
 
@@ -34,16 +34,16 @@ An :code:`AnalogInput` may be initialized as follows:
         AnalogInput analog = new AnalogInput(0);
 
 Oversampling and Averaging
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 |Oversampling and Averaging|
 
 The FPGA's analog input modules supports both oversampling and averaging.  These behaviors are highly similar, but differ in a few important ways.  Both may be used at the same time.
 
 Oversampling
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
-When oversampling is enabled, the FPGA will add multiple consecutive samples together, and return the accumulated value.  Users may specify the number of *bits* of oversampling - for :math:`n` bits of oversampling, the number of samples added together is :math:`2^{n}`:
+When oversampling is enabled, the FPGA will add multiple consecutive samples together, and return the accumulated value.  Users may specify the number of *bits* of oversampling - for :math:`n` bits of oversampling, the number of samples added together is :math:`2~{n}`:
 
 .. tabs::
 
@@ -62,7 +62,7 @@ When oversampling is enabled, the FPGA will add multiple consecutive samples tog
         analog.setOversampleBits(4);
 
 Averaging
-^^^^^^^^^
+~~~~~~~~~
 
 Averaging behaves much like oversampling, except the accumulated values are divided by the number of samples so that the scaling of the returned values does not change.  This is often more-convenient, but occasionally the additional roundoff error introduced by the rounding is undesirable.
 
@@ -83,12 +83,12 @@ Averaging behaves much like oversampling, except the accumulated values are divi
 .. note:: When oversampling and averaging are used at the same time, the oversampling is applied *first,* and then the oversampled values are averaged.  Thus, 2-bit oversampling and 2-bit averaging used at the same time will increase the scale of the returned values by approximately a factor of 2, and decrease the update rate by approximately a factor of 4.
 
 Reading values from an AnalogInput
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Values can be read from an AnalogInput with one of four different methods:
 
 getValue
-^^^^^^^^
+~~~~~~~~
 
 The :code:`getValue` method returns the raw instantaneous measured value from the analog input, without applying any calibration and ignoring oversampling and averaging settings.  The returned value is an integer.
 
@@ -103,7 +103,7 @@ The :code:`getValue` method returns the raw instantaneous measured value from th
         analog.getValue();
 
 getVoltage
-^^^^^^^^^^
+~~~~~~~~~~
 
 The :code:`getVoltage` method returns the instantaneous measured voltage from the analog input.  Oversampling and averaging settings are ignored, but the value is rescaled to represent a voltage.  The returned value is a double.
 
@@ -118,7 +118,7 @@ The :code:`getVoltage` method returns the instantaneous measured voltage from th
         analog.getVoltage();
 
 getAverageValue
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 The :code:`getAverageValue` method returns the averaged value from the analog input.  The value is not rescaled, but oversampling and averaging are both applied.  The returned value is an integer.
 
@@ -133,7 +133,7 @@ The :code:`getAverageValue` method returns the averaged value from the analog in
         analog.getAverageValue();
 
 getAverageVoltage
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 The :code:`getAverageVoltage` method returns the averaged voltage from the analog input.  Rescaling, oversampling, and averaging are all applied.  The returned value is a double.
 
@@ -148,7 +148,7 @@ The :code:`getAverageVoltage` method returns the averaged voltage from the analo
         analog.getAverageVoltage();
 
 Accumulator
-~~~~~~~~~~~
+^^^^^^^^^^^
 
 .. note:: The accumulator methods do not currently support returning a value in units of volts - the returned value will always be an integer (specifically, a :code:`long`). 
 
@@ -195,7 +195,7 @@ Analog input channels 0 and 1 additionally support an accumulator, which integra
         analog.resetAccumulator();
 
 Obtaining synchronized count and value
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sometimes, it is necessarily to obtain matched measurements of the count and the value.  This can be done using the :code:`getAccumulatorOutput` method:
 

--- a/source/docs/software/sensors/analog-inputs-software.rst
+++ b/source/docs/software/sensors/analog-inputs-software.rst
@@ -1,5 +1,3 @@
-.. _analog-inputs-software:
-
 Analog Inputs
 =============
 
@@ -47,19 +45,19 @@ When oversampling is enabled, the FPGA will add multiple consecutive samples tog
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Sets the AnalogInput to 4-bit oversampling.  16 samples will be added together.
-        // Thus, the reported values will increase by about a factor of 16, and the update
-        // rate will decrease by a similar amount.
-        analog.SetOversampleBits(4);
-
     .. code-tab:: java
 
         // Sets the AnalogInput to 4-bit oversampling.  16 samples will be added together.
         // Thus, the reported values will increase by about a factor of 16, and the update
         // rate will decrease by a similar amount.
         analog.setOversampleBits(4);
+
+    .. code-tab:: c++
+
+        // Sets the AnalogInput to 4-bit oversampling.  16 samples will be added together.
+        // Thus, the reported values will increase by about a factor of 16, and the update
+        // rate will decrease by a similar amount.
+        analog.SetOversampleBits(4);
 
 Averaging
 ~~~~~~~~~
@@ -68,17 +66,17 @@ Averaging behaves much like oversampling, except the accumulated values are divi
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Sets the AnalogInput to 4-bit averaging.  16 samples will be averaged together.
-        // The update rate will decrease by a factor of 16.
-        analog.SetAverageBits(4);
-
     .. code-tab:: java
 
         // Sets the AnalogInput to 4-bit averaging.  16 samples will be averaged together.
         // The update rate will decrease by a factor of 16.
         analog.setAverageBits(4);
+
+    .. code-tab:: c++
+
+        // Sets the AnalogInput to 4-bit averaging.  16 samples will be averaged together.
+        // The update rate will decrease by a factor of 16.
+        analog.SetAverageBits(4);
 
 .. note:: When oversampling and averaging are used at the same time, the oversampling is applied *first,* and then the oversampled values are averaged.  Thus, 2-bit oversampling and 2-bit averaging used at the same time will increase the scale of the returned values by approximately a factor of 2, and decrease the update rate by approximately a factor of 4.
 
@@ -94,13 +92,13 @@ The :code:`getValue` method returns the raw instantaneous measured value from th
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        analog.GetValue();
-
     .. code-tab:: java
 
         analog.getValue();
+
+    .. code-tab:: c++
+
+        analog.GetValue();
 
 getVoltage
 ~~~~~~~~~~
@@ -109,13 +107,13 @@ The :code:`getVoltage` method returns the instantaneous measured voltage from th
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        analog.GetVoltage();
-
     .. code-tab:: java
 
         analog.getVoltage();
+
+    .. code-tab:: c++
+
+        analog.GetVoltage();
 
 getAverageValue
 ~~~~~~~~~~~~~~~
@@ -124,13 +122,13 @@ The :code:`getAverageValue` method returns the averaged value from the analog in
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        analog.GetAverageValue();
-
     .. code-tab:: java
 
         analog.getAverageValue();
+
+    .. code-tab:: c++
+
+        analog.GetAverageValue();
 
 getAverageVoltage
 ~~~~~~~~~~~~~~~~~
@@ -139,13 +137,13 @@ The :code:`getAverageVoltage` method returns the averaged voltage from the analo
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        analog.GetAverageVoltage();
-
     .. code-tab:: java
 
         analog.getAverageVoltage();
+
+    .. code-tab:: c++
+
+        analog.GetAverageVoltage();
 
 Accumulator
 ^^^^^^^^^^^
@@ -155,25 +153,6 @@ Accumulator
 Analog input channels 0 and 1 additionally support an accumulator, which integrates (adds up) the signal indefinitely, so that the returned value is the sum of all past measured values.  Oversampling and averaging are applied prior to accumulation.
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Sets the initial value of the accumulator to 0
-        // This is the "starting point" from which the value will change over time
-        analog.SetAccumulatorInitialValue(0);
-
-        // Sets the "center" of the accumulator to 0.  This value is subtracted from
-        // all measured values prior to accumulation.
-        analog.SetAccumulatorCenter(0);
-
-        // Returns the number of accumulated samples since the accumulator was last started/reset
-        analog.GetAccumulatorCount();
-
-        // Returns the value of the accumulator.  Return type is long.
-        analog.GetAccumulatorValue();
-
-        // Resets the accumulator to the initial value
-        analog.ResetAccumulator();
 
     .. code-tab:: java
 
@@ -194,21 +173,31 @@ Analog input channels 0 and 1 additionally support an accumulator, which integra
         // Resets the accumulator to the initial value
         analog.resetAccumulator();
 
+    .. code-tab:: c++
+
+        // Sets the initial value of the accumulator to 0
+        // This is the "starting point" from which the value will change over time
+        analog.SetAccumulatorInitialValue(0);
+
+        // Sets the "center" of the accumulator to 0.  This value is subtracted from
+        // all measured values prior to accumulation.
+        analog.SetAccumulatorCenter(0);
+
+        // Returns the number of accumulated samples since the accumulator was last started/reset
+        analog.GetAccumulatorCount();
+
+        // Returns the value of the accumulator.  Return type is long.
+        analog.GetAccumulatorValue();
+
+        // Resets the accumulator to the initial value
+        analog.ResetAccumulator();
+
 Obtaining synchronized count and value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sometimes, it is necessarily to obtain matched measurements of the count and the value.  This can be done using the :code:`getAccumulatorOutput` method:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // The count and value variables to fill
-        int_64t count;
-        int_64t value;
-
-        // Fill the count and value variables with the matched measurements
-        analog.GetAccumulatorOutput(count, value);
 
     .. code-tab:: java
 
@@ -221,6 +210,15 @@ Sometimes, it is necessarily to obtain matched measurements of the count and the
         // Read the values from the AccumulatorResult
         long count = result.count;
         long value = result.value;
+
+    .. code-tab:: c++
+
+        // The count and value variables to fill
+        int_64t count;
+        int_64t value;
+
+        // Fill the count and value variables with the matched measurements
+        analog.GetAccumulatorOutput(count, value);
 
 Using analog inputs in code
 ---------------------------

--- a/source/docs/software/sensors/analog-potentiometers-software.rst
+++ b/source/docs/software/sensors/analog-potentiometers-software.rst
@@ -18,14 +18,6 @@ An AnalogPotentiometer can be initialized as follows:
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Initializes an AnalogPotentiometer on analog port 0
-        // The full range of motion (in meaningful external units) is 0-180 (this could be degrees, for instance)
-        // The "starting point" of the motion, i.e. where the mechanism is located when the potentiometer reads 0v, is 30.
-
-        frc::AnalogPotentiometer pot{0, 180, 30};
-
     .. code-tab:: java
 
         // Initializes an AnalogPotentiometer on analog port 0
@@ -33,6 +25,14 @@ An AnalogPotentiometer can be initialized as follows:
         // The "starting point" of the motion, i.e. where the mechanism is located when the potentiometer reads 0v, is 30.
 
         AnalogPotentiometer pot = new AnalogPotentiometer(0, 180, 30);
+
+    .. code-tab:: c++
+
+        // Initializes an AnalogPotentiometer on analog port 0
+        // The full range of motion (in meaningful external units) is 0-180 (this could be degrees, for instance)
+        // The "starting point" of the motion, i.e. where the mechanism is located when the potentiometer reads 0v, is 30.
+
+        frc::AnalogPotentiometer pot{0, 180, 30};
 
 Customizing the underlying AnalogInput
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,18 +42,6 @@ Customizing the underlying AnalogInput
 If the user would like to apply custom settings to the underlying :code:`AnalogInput` used by the :code:`AnalogPotentiometer`, an alternative constructor may be used in which the :code:`AnalogInput` is injected:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Initializes an AnalogInput on port 0, and enables 2-bit averaging
-        frc::AnalogInput input{0};
-        input.SetAverageBits(2);
-
-        // Initializes an AnalogPotentiometer with the given AnalogInput
-        // The full range of motion (in meaningful external units) is 0-180 (this could be degrees, for instance)
-        // The "starting point" of the motion, i.e. where the mechanism is located when the potentiometer reads 0v, is 30.
-
-        frc::AnalogPotentiometer pot{input, 180, 30};
 
     .. code-tab:: java
 
@@ -67,6 +55,18 @@ If the user would like to apply custom settings to the underlying :code:`AnalogI
 
         AnalogPotentiometer pot = new AnalogPotentiometer(input, 180, 30);
 
+    .. code-tab:: c++
+
+        // Initializes an AnalogInput on port 0, and enables 2-bit averaging
+        frc::AnalogInput input{0};
+        input.SetAverageBits(2);
+
+        // Initializes an AnalogPotentiometer with the given AnalogInput
+        // The full range of motion (in meaningful external units) is 0-180 (this could be degrees, for instance)
+        // The "starting point" of the motion, i.e. where the mechanism is located when the potentiometer reads 0v, is 30.
+
+        frc::AnalogPotentiometer pot{input, 180, 30};
+
 Reading values from the AnalogPotentiometer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -74,17 +74,17 @@ The scaled value can be read by simply calling the :code:`get` method:
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        pot.Get();
-
     .. code-tab:: java
 
         pot.get();
 
+    .. code-tab:: c++
+
+        pot.Get();
+
 Using AnalogPotentiometers in code
 ----------------------------------
 
-Analog sensors can be used in code much in the way other sensors that measure the same thing can be.  If the analog sensor is a potentiometer measuring an arm angle, it can be used similarly to an :doc:`encoder <encoders-software>`.  If it is an ultrasonic sensor, it can be used similarly to other :doc:`ultrasonics <ultrasonics-software>`.
+Analog sensors can be used in code much in the way other sensors that measure the same thing can be.  If the analog sensor is a potentiometer measuring an arm angle, it can be used similarly to an :doc:`encoder <docs/software/sensors/encoders-software:Encoders - Software>`.  If it is an ultrasonic sensor, it can be used similarly to other :doc:`ultrasonics <docs/software/sensors/ultrasonics-software:Ultrasonics - Software>`.
 
 It is very important to keep in mind that actual, physical potentiometers generally have a limited range of motion.  Safeguards should be present in both the physical mechanism and the code to ensure that the mechanism does not break the sensor by traveling past its maximum throw.

--- a/source/docs/software/sensors/analog-potentiometers-software.rst
+++ b/source/docs/software/sensors/analog-potentiometers-software.rst
@@ -35,7 +35,7 @@ An AnalogPotentiometer can be initialized as follows:
         AnalogPotentiometer pot = new AnalogPotentiometer(0, 180, 30);
 
 Customizing the underlying AnalogInput
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note:: If the user changes the scaling of the :code:`AnalogInput` with oversampling, this must be reflected in the scale setting passed to the :code:`AnalogPotentiometer`.
 
@@ -68,7 +68,7 @@ If the user would like to apply custom settings to the underlying :code:`AnalogI
         AnalogPotentiometer pot = new AnalogPotentiometer(input, 180, 30);
 
 Reading values from the AnalogPotentiometer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The scaled value can be read by simply calling the :code:`get` method:
 

--- a/source/docs/software/sensors/counters.rst
+++ b/source/docs/software/sensors/counters.rst
@@ -13,7 +13,7 @@ Configuring a counter
 The :code:`Counter` class can be configured in a number of ways to provide differing functionalities.
 
 Counter Modes
-~~~~~~~~~~~~~
+^^^^^^^^^^^^^
 
 The :code:`Counter` object may be configured to operate in one of four different modes:
 
@@ -25,7 +25,7 @@ The :code:`Counter` object may be configured to operate in one of four different
 .. note:: In all modes except semi-period mode, the counter can be configured to increment either once per edge (2X decoding), or once per pulse (1X decoding).  By default, ??? will be used (TODO: figure this out).
 
 Two-pulse mode
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 In two-pulse mode, the :code:`Counter` will count up for every edge/pulse on the specified "up channel," and down for every edge/pulse on the specified "down channel."  A counter can be initialized in two-pulse with the following code:
 
@@ -64,7 +64,7 @@ In two-pulse mode, the :code:`Counter` will count up for every edge/pulse on the
 .. _semi-period-mode:
 
 Semi-period mode
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 In semi-period mode, the :code:`Counter` will count the duration of the pulses on a channel, either from a rising edge to the next falling edge, or from a falling edge to the next rising edge.  A counter can be initialized in semi-period mode with the following code:
 
@@ -111,7 +111,7 @@ To get the pulse width, call the :code:`getPeriod()` method:
         counter.GetPeriod();
 
 Pulse-length mode
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 In pulse-length mode, the counter will count either up or down depending on the length of the pulse (TODO: determine whether it counts up or down when the pulse is above the threshold; not documented...).  This is useful for some gear tooth sensors which encode direction in this manner.  A counter can be initialized in this mode as follows:
 
@@ -150,7 +150,7 @@ In pulse-length mode, the counter will count either up or down depending on the 
         }
 
 External direction mode
-^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~
 
 In external direction mode, the counter counts either up or down depending on the level on the second channel (TODO: does it count up if the pin is high or low?  not documented...).  A counter can be initialized in this mode as follows:
 
@@ -187,7 +187,7 @@ In external direction mode, the counter counts either up or down depending on th
 .. _configuring-counter-parameters:
 
 Configuring counter parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note:: The :code:`Counter` class does not make any assumptions about units of distance; it will return values in whatever units were used to calculate the distance-per-pulse value.  Users thus have complete control over the distance units used.  However, units of time are *always* in seconds.
 
@@ -241,7 +241,7 @@ Reading information from counters
 Regardless of mode, there is some information that the :code:`Counter` class always exposes to users:
 
 Count
-~~~~~
+^^^^^
 
 Users can obtain the current count with the :code:`get()` method:
 
@@ -258,7 +258,7 @@ Users can obtain the current count with the :code:`get()` method:
         counter.get();
 
 Distance
-~~~~~~~~
+^^^^^^^^
 
 .. note:: Counters measure *relative* distance, not absolute; the distance value returned will depend on the position of the encoder when the robot was turned on or the encoder value was last :ref:`reset <resetting-a-counter>`.
 
@@ -277,7 +277,7 @@ If the :ref:`distance per pulse <configuring-counter-parameters>` has been confi
         counter.getDistance();
 
 Rate
-^^^^
+~~~~
 
 .. note:: Units of time for the :code:`Counter` class are *always* in seconds.
 
@@ -296,7 +296,7 @@ Users can obtain the current rate of change of the counter with the :code:`getRa
         counter.getRate();
 
 Stopped
-~~~~~~~
+^^^^^^^
 
 Users can obtain whether the counter is stationary with the :code:`getStopped()` method:
 
@@ -313,7 +313,7 @@ Users can obtain whether the counter is stationary with the :code:`getStopped()`
         counter.getStopped();
 
 Direction
-^^^^^^^^^
+~~~~~~~~~
 
 Users can obtain the direction in which the counter last moved with the :code:`getDirection()` method:
 
@@ -330,7 +330,7 @@ Users can obtain the direction in which the counter last moved with the :code:`g
         counter.getDirection();
 
 Period
-~~~~~~
+^^^^^^
 
 .. note:: In :ref:`semi-period mode <semi-period-mode>`, this method returns the duration of the pulse, not of the period.
 

--- a/source/docs/software/sensors/counters.rst
+++ b/source/docs/software/sensors/counters.rst
@@ -3,7 +3,7 @@ Counters
 
 |Counters|
 
-The :code:`Counter` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/Counter.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1Counter.html>`__) is a versatile class that allows the counting of pulse edges on a digital input.  :code:`Counter` is used as a component in several more-complicated WPILib classes (such as :ref:`Encoder <encoders-software>` and :ref:`Ultrasonic <ultrasonics-software>`), but is also quite useful on its own.
+The :code:`Counter` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/Counter.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1Counter.html>`__) is a versatile class that allows the counting of pulse edges on a digital input.  :code:`Counter` is used as a component in several more-complicated WPILib classes (such as :ref:`Encoder <docs/software/sensors/encoders-software:Encoders - Software>` and :ref:`Ultrasonic <docs/software/sensors/ultrasonics-software:Ultrasonics - Software>`), but is also quite useful on its own.
 
 .. note:: There are a total of 8 counter units in the RoboRIO FPGA, meaning no more than 8 :code:`Counter` objects may be instantiated at any one time, including those contained as resources in other WPILib objects.  For detailed information on when a :code:`Counter` may be used by another object, refer to the official API documentation.
 
@@ -31,20 +31,6 @@ In two-pulse mode, the :code:`Counter` will count up for every edge/pulse on the
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Create a new Counter object in two-pulse mode
-        frc::Counter counter{frc::Counter::Mode::k2Pulse};
-
-        void Robot::RobotInit() {
-            // Set up the input channels for the counter
-            counter.SetUpSource(1);
-            counter.SetDownSource(2);
-
-            // Set the decoding type to 2X
-            counter.SetUpSourceEdge(true, true);
-            counter.SetDownSourceEdge(true, true);
-
     .. code-tab:: java
 
         // Create a new Counter object in two-pulse mode
@@ -61,7 +47,19 @@ In two-pulse mode, the :code:`Counter` will count up for every edge/pulse on the
             counter.setDownSourceEdge(true, true);
         }
 
-.. _semi-period-mode:
+    .. code-tab:: c++
+
+        // Create a new Counter object in two-pulse mode
+        frc::Counter counter{frc::Counter::Mode::k2Pulse};
+
+        void Robot::RobotInit() {
+            // Set up the input channels for the counter
+            counter.SetUpSource(1);
+            counter.SetDownSource(2);
+
+            // Set the decoding type to 2X
+            counter.SetUpSourceEdge(true, true);
+            counter.SetDownSourceEdge(true, true);
 
 Semi-period mode
 ~~~~~~~~~~~~~~~~
@@ -69,18 +67,6 @@ Semi-period mode
 In semi-period mode, the :code:`Counter` will count the duration of the pulses on a channel, either from a rising edge to the next falling edge, or from a falling edge to the next rising edge.  A counter can be initialized in semi-period mode with the following code:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Create a new Counter object in two-pulse mode
-        frc::Counter counter{frc::Counter::Mode::kSemiperiod};
-
-        void Robott() {
-            // Set up the input channel for the counter
-            counter.SetUpSource(1);
-
-            // Set the encoder to count pulse duration from rising edge to falling edge
-            counter.SetSemiPeriodMode(true);
 
     .. code-tab:: java
 
@@ -96,19 +82,31 @@ In semi-period mode, the :code:`Counter` will count the duration of the pulses o
             counter.setSemiPeriodMode(true);
         }
 
+    .. code-tab:: c++
+
+        // Create a new Counter object in two-pulse mode
+        frc::Counter counter{frc::Counter::Mode::kSemiperiod};
+
+        void Robott() {
+            // Set up the input channel for the counter
+            counter.SetUpSource(1);
+
+            // Set the encoder to count pulse duration from rising edge to falling edge
+            counter.SetSemiPeriodMode(true);
+
 To get the pulse width, call the :code:`getPeriod()` method:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Return the measured pulse width in seconds
-        counter.getPeriod();
 
     .. code-tab:: java
 
         // Return the measured pulse width in seconds
         counter.GetPeriod();
+
+    .. code-tab:: c++
+
+        // Return the measured pulse width in seconds
+        counter.getPeriod();
 
 Pulse-length mode
 ~~~~~~~~~~~~~~~~~
@@ -116,21 +114,6 @@ Pulse-length mode
 In pulse-length mode, the counter will count either up or down depending on the length of the pulse (TODO: determine whether it counts up or down when the pulse is above the threshold; not documented...).  This is useful for some gear tooth sensors which encode direction in this manner.  A counter can be initialized in this mode as follows:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Create a new Counter object in two-pulse mode
-        frc::Counter counter{frc::Counter::Mode::kPulseLength};
-
-        void Robot::RobotInit() {
-            // Set up the input channel for the counter
-            counter.SetUpSource(1);
-
-            // Set the decoding type to 2X
-            counter.SetUpSourceEdge(true, true);
-
-            // Set the counter to count down if the pulses are longer than .05 seconds
-            counter.setPulseLengthMode(.05)
 
     .. code-tab:: java
 
@@ -149,25 +132,27 @@ In pulse-length mode, the counter will count either up or down depending on the 
             counter.SetPulseLengthMode(.05)
         }
 
+    .. code-tab:: c++
+
+        // Create a new Counter object in two-pulse mode
+        frc::Counter counter{frc::Counter::Mode::kPulseLength};
+
+        void Robot::RobotInit() {
+            // Set up the input channel for the counter
+            counter.SetUpSource(1);
+
+            // Set the decoding type to 2X
+            counter.SetUpSourceEdge(true, true);
+
+            // Set the counter to count down if the pulses are longer than .05 seconds
+            counter.setPulseLengthMode(.05)
+
 External direction mode
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 In external direction mode, the counter counts either up or down depending on the level on the second channel (TODO: does it count up if the pin is high or low?  not documented...).  A counter can be initialized in this mode as follows:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Create a new Counter object in two-pulse mode
-        frc::Counter counter{frc::Counter::Mode::kExternalDirection};
-
-        void RobototInit() {
-            // Set up the input channels for the counter
-            counter.SetUpSource(1);
-            counter.SetDownSource(2);
-
-            // Set the decoding type to 2X
-            counter.SetUpSourceEdge(true, true);
 
     .. code-tab:: java
 
@@ -184,7 +169,18 @@ In external direction mode, the counter counts either up or down depending on th
             counter.setUpSourceEdge(true, true);
         }
 
-.. _configuring-counter-parameters:
+    .. code-tab:: c++
+
+        // Create a new Counter object in two-pulse mode
+        frc::Counter counter{frc::Counter::Mode::kExternalDirection};
+
+        void RobototInit() {
+            // Set up the input channels for the counter
+            counter.SetUpSource(1);
+            counter.SetDownSource(2);
+
+            // Set the decoding type to 2X
+            counter.SetUpSourceEdge(true, true);
 
 Configuring counter parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -196,25 +192,6 @@ Configuring counter parameters
 Apart from the mode-specific configurations, the :code:`Counter` class offers a number of additional configuration methods:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Configures the counter to return a distance of 4 for every 256 pulses
-        // Also changes the units of getRate
-        counter.SetDistancePerPulse(4./256.);
-
-        // Configures the counter to consider itself stopped after .1 seconds
-        counter.SetMaxPeriod(.1);
-
-        // Configures the counter to consider itself stopped when its rate is below 10
-        counter.SetMinRate(10);
-
-        // Reverses the direction of the counter
-        counter.SetReverseDirection(true);
-
-        // Configures an counter to average its period measurement over 5 samples
-        // Can be between 1 and 127 samples
-        counter.SetSamplesToAverage(5);
 
     .. code-tab:: java
 
@@ -235,6 +212,25 @@ Apart from the mode-specific configurations, the :code:`Counter` class offers a 
         // Can be between 1 and 127 samples
         counter.setSamplesToAverage(5);
 
+    .. code-tab:: c++
+
+        // Configures the counter to return a distance of 4 for every 256 pulses
+        // Also changes the units of getRate
+        counter.SetDistancePerPulse(4./256.);
+
+        // Configures the counter to consider itself stopped after .1 seconds
+        counter.SetMaxPeriod(.1);
+
+        // Configures the counter to consider itself stopped when its rate is below 10
+        counter.SetMinRate(10);
+
+        // Reverses the direction of the counter
+        counter.SetReverseDirection(true);
+
+        // Configures an counter to average its period measurement over 5 samples
+        // Can be between 1 and 127 samples
+        counter.SetSamplesToAverage(5);
+
 Reading information from counters
 ---------------------------------
 
@@ -247,15 +243,15 @@ Users can obtain the current count with the :code:`get()` method:
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // returns the current count
-        counter.Get();
-
     .. code-tab:: java
 
         // returns the current count
         counter.get();
+
+    .. code-tab:: c++
+
+        // returns the current count
+        counter.Get();
 
 Distance
 ^^^^^^^^
@@ -266,15 +262,15 @@ If the :ref:`distance per pulse <configuring-counter-parameters>` has been confi
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // returns the current distance
-        counter.GetDistance();
-
     .. code-tab:: java
 
         // returns the current distance
         counter.getDistance();
+
+    .. code-tab:: c++
+
+        // returns the current distance
+        counter.GetDistance();
 
 Rate
 ~~~~
@@ -285,15 +281,15 @@ Users can obtain the current rate of change of the counter with the :code:`getRa
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Gets the current rate of the counter
-        counter.GetRate();
-
     .. code-tab:: java
 
         // Gets the current rate of the counter
         counter.getRate();
+
+    .. code-tab:: c++
+
+        // Gets the current rate of the counter
+        counter.GetRate();
 
 Stopped
 ^^^^^^^
@@ -302,15 +298,15 @@ Users can obtain whether the counter is stationary with the :code:`getStopped()`
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Gets whether the counter is stopped
-        counter.GetStopped();
-
     .. code-tab:: java
 
         // Gets whether the counter is stopped
         counter.getStopped();
+
+    .. code-tab:: c++
+
+        // Gets whether the counter is stopped
+        counter.GetStopped();
 
 Direction
 ~~~~~~~~~
@@ -319,15 +315,15 @@ Users can obtain the direction in which the counter last moved with the :code:`g
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Gets the last direction in which the counter moved
-        counter.GetDirection();
-
     .. code-tab:: java
 
         // Gets the last direction in which the counter moved
         counter.getDirection();
+
+    .. code-tab:: c++
+
+        // Gets the last direction in which the counter moved
+        counter.GetDirection();
 
 Period
 ^^^^^^
@@ -338,17 +334,15 @@ Users can obtain the duration (in seconds) of the most-recent period with the :c
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // returns the current period in seconds
-        counter.GetPeriod();
-
     .. code-tab:: java
 
         // returns the current period in seconds
         counter.getPeriod();
 
-.. _resetting-a-counter:
+    .. code-tab:: c++
+
+        // returns the current period in seconds
+        counter.GetPeriod();
 
 Resetting a counter
 -------------------
@@ -357,21 +351,19 @@ To reset a counter to a distance reading of zero, call the :code:`reset()` metho
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Resets the encoder to read a distance of zero
-        counter.Reset();
-
     .. code-tab:: java
 
         // Resets the encoder to read a distance of zero
         counter.reset();
 
+    .. code-tab:: c++
+
+        // Resets the encoder to read a distance of zero
+        counter.Reset();
+
 Using counters in code
 ----------------------
 
-Counters are useful for a wide variety of robot applications - but since the :code:`Counter` class is so varied, it is difficult to provide a good summary of them here.  Many of these applications overlap with the :code:`Encoder` class - a simple counter is often a cheaper alternative to a quadrature encoder.  For a summary of potential uses for encoders in code, see :ref:`encoders-software`.
-
-
+Counters are useful for a wide variety of robot applications - but since the :code:`Counter` class is so varied, it is difficult to provide a good summary of them here.  Many of these applications overlap with the :code:`Encoder` class - a simple counter is often a cheaper alternative to a quadrature encoder.  For a summary of potential uses for encoders in code, see :ref:`docs/software/sensors/encoders-software:Encoders - Software`.
 
 .. |Counters| image:: images/counters/counters.png

--- a/source/docs/software/sensors/digital-inputs-software.rst
+++ b/source/docs/software/sensors/digital-inputs-software.rst
@@ -27,7 +27,7 @@ A :code:`DigitalInput` can be initialized as follows:
         DigitalInput input = new DigitalInput(0);
 
 Reading the value of the DigitalInput
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The state of the :code:`DigitalInput` can be polled with the :code:`get` method:
 
@@ -79,7 +79,7 @@ An :code:`AnalogTrigger` may be initialized as follows.  As with :code:`AnalogPo
         AnalogTrigger trigger1 = new AnalogTrigger(input);
 
 Setting the trigger points
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note:: For details on the scaling of "raw" :code:`AnalogInput` values, see :doc:`analog-inputs-software`.
 
@@ -109,7 +109,7 @@ Using DigitalInputs in code
 As almost all switches on the robot will be used through a :code:`DigitalInput`, this class is extremely important for effective robot control.
 
 Limiting the motion of a mechanism
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Nearly all motorized mechanisms (such as arms and elevators) in FRC should be given some form of "limit switch" to prevent them from damaging themselves at the end of their range of motions.  A short example is given below:
 
@@ -149,6 +149,6 @@ Nearly all motorized mechanisms (such as arms and elevators) in FRC should be gi
         }
 
 Homing an encodered mechanism
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Limit switches are very important for being able to "home" an encodered mechanism.  For an example of this, see :ref:`homing-an-encodered-mechanism`.

--- a/source/docs/software/sensors/digital-inputs-software.rst
+++ b/source/docs/software/sensors/digital-inputs-software.rst
@@ -1,5 +1,3 @@
-.. _digital-inputs-software:
-
 Digital Inputs - Software
 =========================
 
@@ -16,15 +14,15 @@ A :code:`DigitalInput` can be initialized as follows:
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Initializes a DigitalInput on DIO 0
-        frc::DigitalInput input{0};
-
     .. code-tab:: java
 
         // Initializes a DigitalInput on DIO 0
         DigitalInput input = new DigitalInput(0);
+
+    .. code-tab:: c++
+
+        // Initializes a DigitalInput on DIO 0
+        frc::DigitalInput input{0};
 
 Reading the value of the DigitalInput
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,15 +31,15 @@ The state of the :code:`DigitalInput` can be polled with the :code:`get` method:
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Gets the value of the digital input.  Returns true if the circuit is open.
-        input.Get();
-
     .. code-tab:: java
 
         // Gets the value of the digital input.  Returns true if the circuit is open.
         input.get();
+
+    .. code-tab:: c++
+
+        // Gets the value of the digital input.  Returns true if the circuit is open.
+        input.Get();
 
 Creating a DigitalInput from an AnalogInput
 -------------------------------------------
@@ -53,18 +51,6 @@ Sometimes, it is desirable to use an analog input as a digital input.  This can 
 An :code:`AnalogTrigger` may be initialized as follows.  As with :code:`AnalogPotentiometer`, an :code:`AnalogInput` may be passed explicitly if the user wishes to customize the sampling settings:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Initializes an AnalogTrigger on port 0
-        frc::AnalogTrigger trigger0{0};
-
-        // Initializes an AnalogInput on port 1 and enables 2-bit oversampling
-        frc::AnalogInput input{1};
-        input.SetAverageBits(2);
-
-        // Initializes an AnalogTrigger using the above input
-        frc::AnalogTrigger trigger1{input};
 
     .. code-tab:: java
 
@@ -78,6 +64,18 @@ An :code:`AnalogTrigger` may be initialized as follows.  As with :code:`AnalogPo
         // Initializes an AnalogTrigger using the above input
         AnalogTrigger trigger1 = new AnalogTrigger(input);
 
+    .. code-tab:: c++
+
+        // Initializes an AnalogTrigger on port 0
+        frc::AnalogTrigger trigger0{0};
+
+        // Initializes an AnalogInput on port 1 and enables 2-bit oversampling
+        frc::AnalogInput input{1};
+        input.SetAverageBits(2);
+
+        // Initializes an AnalogTrigger using the above input
+        frc::AnalogTrigger trigger1{input};
+
 Setting the trigger points
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -87,14 +85,6 @@ To convert the analog signal to a digital one, it is necessary to specify at wha
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Sets the trigger to enable at a raw value of 3500, and disable at a value of 1000
-        trigger.SetLimitsRaw(1000, 3500);
-
-        // Sets the trigger to enable at a voltage of 4 volts, and disable at a value of 1.5 volts
-        trigger.SetLimitsVoltage(1.5, 4);
-
     .. code-tab:: java
 
         // Sets the trigger to enable at a raw value of 3500, and disable at a value of 1000
@@ -102,6 +92,14 @@ To convert the analog signal to a digital one, it is necessary to specify at wha
 
         // Sets the trigger to enable at a voltage of 4 volts, and disable at a value of 1.5 volts
         trigger.setLimitsVoltage(1.5, 4);
+
+    .. code-tab:: c++
+
+        // Sets the trigger to enable at a raw value of 3500, and disable at a value of 1000
+        trigger.SetLimitsRaw(1000, 3500);
+
+        // Sets the trigger to enable at a voltage of 4 volts, and disable at a value of 1.5 volts
+        trigger.SetLimitsVoltage(1.5, 4);
 
 Using DigitalInputs in code
 ---------------------------
@@ -114,6 +112,22 @@ Limiting the motion of a mechanism
 Nearly all motorized mechanisms (such as arms and elevators) in FRC should be given some form of "limit switch" to prevent them from damaging themselves at the end of their range of motions.  A short example is given below:
 
 .. tabs::
+
+    .. code-tab:: java
+
+        Spark spark = new Spark(0);
+
+        // Limit switch on DIO 2
+        DigitalInput limit = new DigitalInput(2);
+
+        public void autonomousPeriodic() {
+            // Runs the motor forwards at half speed, unless the limit is pressed
+            if(!limit.get()) {
+                spark.set(.5);
+            } else {
+                spark.set(0);
+            }
+        }
 
     .. code-tab:: c++
 
@@ -132,23 +146,7 @@ Nearly all motorized mechanisms (such as arms and elevators) in FRC should be gi
             }
         }
 
-    .. code-tab:: java
-
-        Spark spark = new Spark(0);
-
-        // Limit switch on DIO 2
-        DigitalInput limit = new DigitalInput(2);
-
-        public void autonomousPeriodic() {
-            // Runs the motor forwards at half speed, unless the limit is pressed
-            if(!limit.get()) {
-                spark.set(.5);
-            } else {
-                spark.set(0);
-            }
-        }
-
 Homing an encodered mechanism
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Limit switches are very important for being able to "home" an encodered mechanism.  For an example of this, see :ref:`homing-an-encodered-mechanism`.
+Limit switches are very important for being able to "home" an encodered mechanism.  For an example of this, see :ref:`docs/software/sensors/encoders-software:Homing an encodered mechanism`.

--- a/source/docs/software/sensors/encoders-software.rst
+++ b/source/docs/software/sensors/encoders-software.rst
@@ -19,7 +19,7 @@ The Encoder class
 WPILib provides support for encoders through the :code:`Encoder` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/Encoder.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1Encoder.html>`__).  This class provides a simple API for configuring and reading data from encoders.
 
 Initializing an encoder
-~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^
 
 An encoder can be instantiated as follows:
 
@@ -40,7 +40,7 @@ An encoder can be instantiated as follows:
 .. _decoding-type:
 
 Decoding type
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 The WPILib :code:`Encoder` class can decode encoder signals in three different modes:
 
@@ -65,7 +65,7 @@ The WPILib :code:`Encoder` class can decode encoder signals in three different m
         Encoder encoder = new Encoder(0, 1, false, Encoder.EncodingType.k2X);
 
 Configuring encoder parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note:: The :code:`Encoder` class does not make any assumptions about units of distance; it will return values in whatever units were used to calculate the distance-per-pulse value.  Users thus have complete control over the distance units used.  However, units of time are *always* in seconds.
 
@@ -114,12 +114,12 @@ The :code:`Encoder` class offers a number of configuration methods:
         encoder.setSamplesToAverage(5);
 
 Reading information from encoders
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :code:`Encoder` class provides a wealth of information to the user about the motion of the encoder.
 
 Distance
-^^^^^^^^
+~~~~~~~~
 
 .. note:: Quadrature encoders measure *relative* distance, not absolute; the distance value returned will depend on the position of the encoder when the robot was turned on or the encoder value was last :ref:`reset <resetting-an-encoder>`.
 
@@ -138,7 +138,7 @@ Users can obtain the total distance traveled by the encoder with the :code:`getD
         encoder.setDistancePerPulse(4./256.);
 
 Rate
-^^^^
+~~~~
 
 .. note:: Units of time for the :code:`Encoder` class are *always* in seconds.
 
@@ -157,7 +157,7 @@ Users can obtain the current rate of change of the encoder with the :code:`getRa
         encoder.getRate();
 
 Stopped
-^^^^^^^
+~~~~~~~
 
 Users can obtain whether the encoder is stationary with the :code:`getStopped()` method:
 
@@ -174,7 +174,7 @@ Users can obtain whether the encoder is stationary with the :code:`getStopped()`
         encoder.getStopped();
 
 Direction
-^^^^^^^^^
+~~~~~~~~~
 
 Users can obtain the direction in which the encoder last moved with the :code:`getDirection()` method:
 
@@ -191,7 +191,7 @@ Users can obtain the direction in which the encoder last moved with the :code:`g
         encoder.getDirection();
 
 Period
-^^^^^^
+~~~~~~
 
 Users can obtain the period of the encoder pulses (in seconds) with the :code:`getPeriod()` method:
 
@@ -210,7 +210,7 @@ Users can obtain the period of the encoder pulses (in seconds) with the :code:`g
 .. _resetting-an-encoder:
 
 Resetting an encoder
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^
 
 To reset an encoder to a distance reading of zero, call the :code:`reset()` method.  This is useful for ensuring that the measured distance corresponds to the actual desired physical measurement, and is often called during a :ref:`homing <homing-an-encodered-mechanism>` routine:
 
@@ -232,7 +232,7 @@ Using encoders in code
 Encoders are some of the most useful sensors in FRC; they are very nearly a requirement to make a robot capable of nontrivially-automated actuations and movement.  The potential applications of encoders in robot code are too numerous to summarize fully here, but a few basic examples are provided below:
 
 Driving to a distance
-~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^
 
 Encoders can be used on a robot drive to create a simple "drive to distance" routine.  This is very useful for robot autonomy:
 
@@ -306,7 +306,7 @@ Encoders can be used on a robot drive to create a simple "drive to distance" rou
         }
         
 Stabilizing heading
-~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^
 
 .. warning:: Like with all control loops, users should be careful to ensure that the sensor direction and the turning direction are consistent.  If they are not, the loop will be unstable and the robot will turn wildly.
 
@@ -393,14 +393,14 @@ Encoders can be used to ensure that a robot drives straight in a manner quite si
 More-advanced implementations can use more-complicated control loops.  Closing a control loop on the encoder difference is roughly analogous to closing it on the heading error, and so PD loops are particularly effective.
 
 PID Control
-~~~~~~~~~~~
+^^^^^^^^^^^
 
 Encoders are particularly useful as inputs to PID controllers (the heading stabilization example above is a simple P loop).  For more information on PID control, see ref:`docs/software/advanced-programming/common-control-algorithms:Common Control Algorithms`.
 
 .. _homing-an-encodered-mechanism:
 
 Homing an encodered mechanism
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since encoders measure *relative* distance, it is often important to ensure that their "zero-point" is in the right place.  A typical way to do this is a "homing routine," in which a mechanism is moved until it hits a known position (usually accomplished with a limit switch), or "home," and then the encoder is reset.  The following code provides a basic example:
 

--- a/source/docs/software/sensors/encoders-software.rst
+++ b/source/docs/software/sensors/encoders-software.rst
@@ -1,9 +1,7 @@
-.. _encoders-software:
-
 Encoders - Software
 ===================
 
-.. note:: This section covers encoders in software.  For a hardware guide to encoders, see :ref:`encoders-hardware`.
+.. note:: This section covers encoders in software.  For a hardware guide to encoders, see :ref:`docs/hardware/sensors/encoders-hardware:Encoders - Hardware`.
 
 |Encoding Direction|
 
@@ -11,7 +9,7 @@ Encoders are devices used to measure motion (usually, the rotation of a shaft). 
 
 |Encoder Modules|
 
-The FPGA handles encoders either through a counter module or an encoder module, depending on the :ref:`decoding type <decoding-type>` - the choice is handled automatically by WPILib.  The FPGA contains 8 encoder modules.
+The FPGA handles encoders either through a counter module or an encoder module, depending on the :ref:`decoding type <docs/software/sensors/encoders-software:Decoding type>` - the choice is handled automatically by WPILib.  The FPGA contains 8 encoder modules.
 
 The Encoder class
 -----------------
@@ -25,19 +23,17 @@ An encoder can be instantiated as follows:
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Initializes an encoder on DIO pins 0 and 1
-        // Defaults to 4X decoding and non-inverted
-        frc::Encoder encoder{0, 1};
-
     .. code-tab:: java
 
         // Initializes an encoder on DIO pins 0 and 1
         // Defaults to 4X decoding and non-inverted
         Encoder encoder = new Encoder(0, 1);
 
-.. _decoding-type:
+    .. code-tab:: c++
+
+        // Initializes an encoder on DIO pins 0 and 1
+        // Defaults to 4X decoding and non-inverted
+        frc::Encoder encoder{0, 1};
 
 Decoding type
 ~~~~~~~~~~~~~
@@ -52,47 +48,28 @@ The WPILib :code:`Encoder` class can decode encoder signals in three different m
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Initializes an encoder on DIO pins 0 and 1
-        // 2X encoding and non-inverted
-        frc::Encoder encoder{0, 1, false, frc::Encoder::EncodingType::k2X};
-
     .. code-tab:: java
 
         // Initializes an encoder on DIO pins 0 and 1
         // 2X encoding and non-inverted
         Encoder encoder = new Encoder(0, 1, false, Encoder.EncodingType.k2X);
 
+    .. code-tab:: c++
+
+        // Initializes an encoder on DIO pins 0 and 1
+        // 2X encoding and non-inverted
+        frc::Encoder encoder{0, 1, false, frc::Encoder::EncodingType::k2X};
+
 Configuring encoder parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note:: The :code:`Encoder` class does not make any assumptions about units of distance; it will return values in whatever units were used to calculate the distance-per-pulse value.  Users thus have complete control over the distance units used.  However, units of time are *always* in seconds.
 
-.. note:: The number of pulses used in the distance-per-pulse calculation does *not* depend on the :ref:`decoding type <decoding-type>` - each "pulse" should always be considered to be a full cycle (four edges).
+.. note:: The number of pulses used in the distance-per-pulse calculation does *not* depend on the :ref:`decoding type <docs/software/sensors/encoders-software:Decoding type>` - each "pulse" should always be considered to be a full cycle (four edges).
 
 The :code:`Encoder` class offers a number of configuration methods:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Configures the encoder to return a distance of 4 for every 256 pulses
-        // Also changes the units of getRate
-        encoder.SetDistancePerPulse(4./256.);
-
-        // Configures the encoder to consider itself stopped after .1 seconds
-        encoder.SetMaxPeriod(.1);
-
-        // Configures the encoder to consider itself stopped when its rate is below 10
-        encoder.SetMinRate(10);
-
-        // Reverses the direction of the encoder
-        encoder.SetReverseDirection(true);
-
-        // Configures an encoder to average its period measurement over 5 samples
-        // Can be between 1 and 127 samples
-        encoder.SetSamplesToAverage(5);
 
     .. code-tab:: java
 
@@ -113,6 +90,25 @@ The :code:`Encoder` class offers a number of configuration methods:
         // Can be between 1 and 127 samples
         encoder.setSamplesToAverage(5);
 
+    .. code-tab:: c++
+
+        // Configures the encoder to return a distance of 4 for every 256 pulses
+        // Also changes the units of getRate
+        encoder.SetDistancePerPulse(4./256.);
+
+        // Configures the encoder to consider itself stopped after .1 seconds
+        encoder.SetMaxPeriod(.1);
+
+        // Configures the encoder to consider itself stopped when its rate is below 10
+        encoder.SetMinRate(10);
+
+        // Reverses the direction of the encoder
+        encoder.SetReverseDirection(true);
+
+        // Configures an encoder to average its period measurement over 5 samples
+        // Can be between 1 and 127 samples
+        encoder.SetSamplesToAverage(5);
+
 Reading information from encoders
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -121,21 +117,21 @@ The :code:`Encoder` class provides a wealth of information to the user about the
 Distance
 ~~~~~~~~
 
-.. note:: Quadrature encoders measure *relative* distance, not absolute; the distance value returned will depend on the position of the encoder when the robot was turned on or the encoder value was last :ref:`reset <resetting-an-encoder>`.
+.. note:: Quadrature encoders measure *relative* distance, not absolute; the distance value returned will depend on the position of the encoder when the robot was turned on or the encoder value was last :ref:`reset <docs/software/sensors/encoders-software:Resetting an encoder>`.
 
 Users can obtain the total distance traveled by the encoder with the :code:`getDistance()` method:
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Configures an encoder to return a distance of 4 for every 256 pulses
-        encoder.SetDistancePerPulse(4./256.);
-
     .. code-tab:: java
 
         // Configures an encoder to return a distance of 4 for every 256 pulses
         encoder.setDistancePerPulse(4./256.);
+
+    .. code-tab:: c++
+
+        // Configures an encoder to return a distance of 4 for every 256 pulses
+        encoder.SetDistancePerPulse(4./256.);
 
 Rate
 ~~~~
@@ -146,15 +142,15 @@ Users can obtain the current rate of change of the encoder with the :code:`getRa
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Gets the current rate of the encoder
-        encoder.GetRate();
-
     .. code-tab:: java
 
         // Gets the current rate of the encoder
         encoder.getRate();
+
+    .. code-tab:: c++
+
+        // Gets the current rate of the encoder
+        encoder.GetRate();
 
 Stopped
 ~~~~~~~
@@ -163,15 +159,15 @@ Users can obtain whether the encoder is stationary with the :code:`getStopped()`
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Gets whether the encoder is stopped
-        encoder.GetStopped();
-
     .. code-tab:: java
 
         // Gets whether the encoder is stopped
         encoder.getStopped();
+
+    .. code-tab:: c++
+
+        // Gets whether the encoder is stopped
+        encoder.GetStopped();
 
 Direction
 ~~~~~~~~~
@@ -180,15 +176,15 @@ Users can obtain the direction in which the encoder last moved with the :code:`g
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Gets the last direction in which the encoder moved
-        encoder.GetDirection();
-
     .. code-tab:: java
 
         // Gets the last direction in which the encoder moved
         encoder.getDirection();
+
+    .. code-tab:: c++
+
+        // Gets the last direction in which the encoder moved
+        encoder.GetDirection();
 
 Period
 ~~~~~~
@@ -197,34 +193,32 @@ Users can obtain the period of the encoder pulses (in seconds) with the :code:`g
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Gets the current period of the encoder
-        encoder.GetPeriod();
-
     .. code-tab:: java
 
         // Gets the current period of the encoder
         encoder.getPeriod();
 
-.. _resetting-an-encoder:
+    .. code-tab:: c++
+
+        // Gets the current period of the encoder
+        encoder.GetPeriod();
 
 Resetting an encoder
 ^^^^^^^^^^^^^^^^^^^^
 
-To reset an encoder to a distance reading of zero, call the :code:`reset()` method.  This is useful for ensuring that the measured distance corresponds to the actual desired physical measurement, and is often called during a :ref:`homing <homing-an-encodered-mechanism>` routine:
+To reset an encoder to a distance reading of zero, call the :code:`reset()` method.  This is useful for ensuring that the measured distance corresponds to the actual desired physical measurement, and is often called during a :ref:`homing <docs/software/sensors/encoders-software:Homing an encodered mechanism>` routine:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Resets the encoder to read a distance of zero
-        encoder.Reset();
 
     .. code-tab:: java
 
         // Resets the encoder to read a distance of zero
         encoder.reset();
+
+    .. code-tab:: c++
+
+        // Resets the encoder to read a distance of zero
+        encoder.Reset();
 
 Using encoders in code
 ----------------------
@@ -237,38 +231,6 @@ Driving to a distance
 Encoders can be used on a robot drive to create a simple "drive to distance" routine.  This is very useful for robot autonomy:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Creates an encoder on DIO ports 0 and 1.
-        frc::Encoder encoder{0, 1};
-
-        // Initialize motor controllers and drive
-        frc::Spark left1{0};
-        frc::Spark left2{1};
-        frc::Spark right1{2};
-        frc::Spark right2{3};
-
-        frc::SpeedControllerGroup leftMotors{left1, left2};
-        frc::SpeedControllerGroup rightMotors{right1, right2};
-
-        frc::DifferentialDrive drive{leftMotors, rightMotors};
-
-        void Robot::RobotInit() {
-            // Configures the encoder's distance-per-pulse
-            // The robot moves forward 1 foot per encoder rotation
-            // There are 256 pulses per encoder rotation
-            encoder.SetDistancePerPulse(1./256.);
-        }
-
-        void Robot:AutonomousPeriodic() {
-            // Drives forward at half speed until the robot has moved 5 feet, then stops:
-            if(encoder.GetDistance < 5) {
-                drive.TankDrive(.5, .5);
-            } else {
-                drive.TankDrive(0, 0);
-            }
-        }
       
     .. code-tab:: java
 
@@ -304,24 +266,11 @@ Encoders can be used on a robot drive to create a simple "drive to distance" rou
                 drive.tankDrive(0, 0);
             }
         }
-        
-Stabilizing heading
-^^^^^^^^^^^^^^^^^^^
-
-.. warning:: Like with all control loops, users should be careful to ensure that the sensor direction and the turning direction are consistent.  If they are not, the loop will be unstable and the robot will turn wildly.
-
-Encoders can be used to ensure that a robot drives straight in a manner quite similar to :ref:`how it is done with a gyroscope <stabilizing-heading-while-driving>`.  A simple implementation with a P loop is given below:
-
-.. tabs::
 
     .. code-tab:: c++
 
-        // The encoders for the drive
-        frc::Encoder leftEncoder{0,1};
-        frc::Encoder rightEncoder{2,3};
-
-        // The gain for a simple P loop
-        double kP = 1;
+        // Creates an encoder on DIO ports 0 and 1.
+        frc::Encoder encoder{0, 1};
 
         // Initialize motor controllers and drive
         frc::Spark left1{0};
@@ -334,22 +283,30 @@ Encoders can be used to ensure that a robot drives straight in a manner quite si
 
         frc::DifferentialDrive drive{leftMotors, rightMotors};
 
-        void Robot::AutonomousInit() {
-            // Configures the encoders' distance-per-pulse
+        void Robot::RobotInit() {
+            // Configures the encoder's distance-per-pulse
             // The robot moves forward 1 foot per encoder rotation
             // There are 256 pulses per encoder rotation
-            leftEncoder.SetDistancePerPulse(1./256.);
-            rightEncoder.SetDistancePerPulse(1./256.);
+            encoder.SetDistancePerPulse(1./256.);
         }
 
-        void Robot::AutonomousPeriodic() {
-            // Assuming no wheel slip, the difference in encoder distances is proportional to the heading error
-            double error = leftEncoder.GetDistance() - rightEncoder.GetDistance();
-
-            // Drives forward continuously at half speed, using the encoders to stabilize the heading
-            drive.TankDrive(.5 + kP * error, .5 - kP * error);
+        void Robot:AutonomousPeriodic() {
+            // Drives forward at half speed until the robot has moved 5 feet, then stops:
+            if(encoder.GetDistance < 5) {
+                drive.TankDrive(.5, .5);
+            } else {
+                drive.TankDrive(0, 0);
+            }
         }
-    
+        
+Stabilizing heading
+^^^^^^^^^^^^^^^^^^^
+
+.. warning:: Like with all control loops, users should be careful to ensure that the sensor direction and the turning direction are consistent.  If they are not, the loop will be unstable and the robot will turn wildly.
+
+Encoders can be used to ensure that a robot drives straight in a manner quite similar to :ref:`how it is done with a gyroscope <docs/software/sensors/gyros-software:Stabilizing heading while driving>`.  A simple implementation with a P loop is given below:
+
+.. tabs::
         
     .. code-tab:: java
 
@@ -390,6 +347,42 @@ Encoders can be used to ensure that a robot drives straight in a manner quite si
             drive.tankDrive(.5 + kP * error, .5 - kP * error);
         }
 
+    .. code-tab:: c++
+
+        // The encoders for the drive
+        frc::Encoder leftEncoder{0,1};
+        frc::Encoder rightEncoder{2,3};
+
+        // The gain for a simple P loop
+        double kP = 1;
+
+        // Initialize motor controllers and drive
+        frc::Spark left1{0};
+        frc::Spark left2{1};
+        frc::Spark right1{2};
+        frc::Spark right2{3};
+
+        frc::SpeedControllerGroup leftMotors{left1, left2};
+        frc::SpeedControllerGroup rightMotors{right1, right2};
+
+        frc::DifferentialDrive drive{leftMotors, rightMotors};
+
+        void Robot::AutonomousInit() {
+            // Configures the encoders' distance-per-pulse
+            // The robot moves forward 1 foot per encoder rotation
+            // There are 256 pulses per encoder rotation
+            leftEncoder.SetDistancePerPulse(1./256.);
+            rightEncoder.SetDistancePerPulse(1./256.);
+        }
+
+        void Robot::AutonomousPeriodic() {
+            // Assuming no wheel slip, the difference in encoder distances is proportional to the heading error
+            double error = leftEncoder.GetDistance() - rightEncoder.GetDistance();
+
+            // Drives forward continuously at half speed, using the encoders to stabilize the heading
+            drive.TankDrive(.5 + kP * error, .5 - kP * error);
+        }
+
 More-advanced implementations can use more-complicated control loops.  Closing a control loop on the encoder difference is roughly analogous to closing it on the heading error, and so PD loops are particularly effective.
 
 PID Control
@@ -397,34 +390,12 @@ PID Control
 
 Encoders are particularly useful as inputs to PID controllers (the heading stabilization example above is a simple P loop).  For more information on PID control, see ref:`docs/software/advanced-programming/common-control-algorithms:Common Control Algorithms`.
 
-.. _homing-an-encodered-mechanism:
-
 Homing an encodered mechanism
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since encoders measure *relative* distance, it is often important to ensure that their "zero-point" is in the right place.  A typical way to do this is a "homing routine," in which a mechanism is moved until it hits a known position (usually accomplished with a limit switch), or "home," and then the encoder is reset.  The following code provides a basic example:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        frc::Encoder encoder{0,1};
-
-        frc::Spark spark{0};
-
-        // Limit switch on DIO 2
-        frc::DigitalInput limit{2};
-
-        void AutonomousPeriodic() {
-            // Runs the motor backwards at half speed until the limit switch is pressed
-            // then turn off the motor and reset the encoder
-            if(!limit.Get()) {
-                spark.Set(-.5);
-            } else {
-                spark.Set(0);
-                encoder.Reset();
-            }
-        }
 
     .. code-tab:: java
 
@@ -443,6 +414,26 @@ Since encoders measure *relative* distance, it is often important to ensure that
             } else {
                 spark.set(0);
                 encoder.reset();
+            }
+        }
+
+    .. code-tab:: c++
+
+        frc::Encoder encoder{0,1};
+
+        frc::Spark spark{0};
+
+        // Limit switch on DIO 2
+        frc::DigitalInput limit{2};
+
+        void AutonomousPeriodic() {
+            // Runs the motor backwards at half speed until the limit switch is pressed
+            // then turn off the motor and reset the encoder
+            if(!limit.Get()) {
+                spark.Set(-.5);
+            } else {
+                spark.Set(0);
+                encoder.Reset();
             }
         }
 

--- a/source/docs/software/sensors/gyros-software.rst
+++ b/source/docs/software/sensors/gyros-software.rst
@@ -15,7 +15,7 @@ All natively-supported gyro objects in WPILib implement the :code:`Gyro` interfa
 .. note:: It is crucial that the robot remain stationary while calibrating a gyro.
 
 ADXRS450_Gyro
-~~~~~~~~~~~~~
+^^^^^^^^^^^^^
 
 The :code:`ADXRS450_Gyro` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1ADXRS450__Gyro.html>`__) provides support for the Analog Devices ADXRS450 gyro available in the kit of parts, which connects over the SPI bus.
 
@@ -32,7 +32,7 @@ The :code:`ADXRS450_Gyro` class (`Java <https://first.wpi.edu/FRC/roborio/releas
         Gyro gyro = new ADXRS450_Gyro(SPI.Port.kMXP);
 
 AnalogGyro
-~~~~~~~~~~
+^^^^^^^^^^
 
 The :code:`AnalogGyro` class (`Java <https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/AnalogGyro.html>`__, `C++ <https://first.wpi.edu/FRC/roborio/release/docs/cpp/classfrc_1_1AnalogGyro.html>`__) provides support for any single-axis gyro with an analog output.
 
@@ -63,7 +63,7 @@ Using gyros in code
 Gyros are extremely useful in FRC for both measuring and controlling robot heading.  Since FRC matches are generally short, total gyro drift over the course of an FRC match tends to be manageably small (on the order of a couple of degrees for a good-quality gyro).  Morever, not all useful gyro applications require the absolute heading measurement to remain accurate over the course of the entire match.
 
 Displaying the robot heading on the dashboard
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :ref:`Shuffleboard <tour-of-shuffleboard>` includes a widget for displaying heading data from a :code:`Gyro` in the form of a compass.  This can be helpful for viewing the robot heading when sight lines to the robot are obscured:
 
@@ -91,7 +91,7 @@ Displaying the robot heading on the dashboard
 .. _stabilizing-heading-while-driving:
 
 Stabilizing heading while driving
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A very common use for a gyro is to stabilize robot heading while driving, so that the robot drives straight.  This is especially important for holonomic drives such as mecanum and swerve, but is extremely useful for tank drives as well.
 
@@ -100,7 +100,7 @@ This is typically achieved by closing a PID controller on either the turn rate o
 .. warning:: Like with all control loops, users should be careful to ensure that the sensor direction and the turning direction are consistent.  If they are not, the loop will be unstable and the robot will turn wildly.
 
 Example: Tank drive stabilization using turn rate
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example shows how to stabilize heading using a simple P loop closed on the turn rate.  Since a robot that is not turning should have a turn rate of zero, the setpoint for the loop is implicitly zero, making this method very simple.
 
@@ -164,7 +164,7 @@ The following example shows how to stabilize heading using a simple P loop close
 More-advanced implementations can use a more-complicated control loop.  When closing the loop on the turn rate for heading stabilization, PI loops are particularly effective.
 
 Example: Tank drive stabilization using heading
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example shows how to stabilize heading using a simple P loop closed on the heading.  Unlike in the turn rate example, we will need to set the setpoint to the current heading before starting motion, making this method slightly more-complicated.
 
@@ -243,7 +243,7 @@ The following example shows how to stabilize heading using a simple P loop close
 More-advanced implementations can use a more-complicated control loop.  When closing the loop on the heading for heading stabilization, PD loops are particularly effective.
 
 Turning to a set heading
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Another common and highly-useful application for a gyro is turning a robot to face a specified direction.  This can be a component of an autonomous driving routine, or can be used during teleoperated control to help align a robot with field elements.
 

--- a/source/docs/software/sensors/gyros-software.rst
+++ b/source/docs/software/sensors/gyros-software.rst
@@ -1,9 +1,7 @@
-.. _gyros-software:
-
 Gyroscopes - Software
 =====================
 
-.. note:: This section covers gyros in software.  For a hardware guide to gyros, see :ref:`gyros-hardware`.
+.. note:: This section covers gyros in software.  For a hardware guide to gyros, see :ref:`docs/hardware/sensors/gyros-hardware:Gyros - Hardware`.
 
 A gyroscope, or "gyro," is an angular rate sensor typically used in robotics to measure and/or stabilize robot headings.  WPILib natively provides specific support for the ADXRS450 gyro available in the kit of parts, as well as more general support for a wider variety of analog gyros through the `AnalogGyro`_ class.
 
@@ -21,15 +19,15 @@ The :code:`ADXRS450_Gyro` class (`Java <https://first.wpi.edu/FRC/roborio/releas
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Creates an ADXRS450_Gyro object on the MXP SPI port
-        ADXRS450_Gyro gyro{SPI::Port::kMXP};
-
     .. code-tab:: java
 
         // Creates an ADXRS450_Gyro object on the MXP SPI port
         Gyro gyro = new ADXRS450_Gyro(SPI.Port.kMXP);
+
+    .. code-tab:: c++
+
+        // Creates an ADXRS450_Gyro object on the MXP SPI port
+        ADXRS450_Gyro gyro{SPI::Port::kMXP};
 
 AnalogGyro
 ^^^^^^^^^^
@@ -40,15 +38,15 @@ The :code:`AnalogGyro` class (`Java <https://first.wpi.edu/FRC/roborio/release/d
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Creates an AnalogGyro object on port 0
-        AnalogGyro gyro{0};
-
     .. code-tab:: java
 
         // Creates an AnalogGyro object on port 0
         Gyro gyro = new AnalogGyro(0);
+
+    .. code-tab:: c++
+
+        // Creates an AnalogGyro object on port 0
+        AnalogGyro gyro{0};
 
 Third-party gyros
 -----------------
@@ -65,18 +63,9 @@ Gyros are extremely useful in FRC for both measuring and controlling robot headi
 Displaying the robot heading on the dashboard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:ref:`Shuffleboard <tour-of-shuffleboard>` includes a widget for displaying heading data from a :code:`Gyro` in the form of a compass.  This can be helpful for viewing the robot heading when sight lines to the robot are obscured:
+:ref:`Shuffleboard <docs/software/wpilib-tools/shuffleboard/getting-started/shuffleboard-tour:Tour of Shuffleboard>` includes a widget for displaying heading data from a :code:`Gyro` in the form of a compass.  This can be helpful for viewing the robot heading when sight lines to the robot are obscured:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        frc::ADXRS450_Gyro gyro{frc::SPI::Port::kMXP};
-
-        void Robot::RobotInit() {
-            // Places a compass indicator for the gyro heading on the dashboard
-            frc::Shuffleboard.GetTab("Example tab").Add(gyro);
-        }
 
     .. code-tab:: java
 
@@ -88,7 +77,14 @@ Displaying the robot heading on the dashboard
             Shuffleboard.getTab("Example tab").add((Sendable) gyro);
         }
 
-.. _stabilizing-heading-while-driving:
+    .. code-tab:: c++
+
+        frc::ADXRS450_Gyro gyro{frc::SPI::Port::kMXP};
+
+        void Robot::RobotInit() {
+            // Places a compass indicator for the gyro heading on the dashboard
+            frc::Shuffleboard.GetTab("Example tab").Add(gyro);
+        }
 
 Stabilizing heading while driving
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,33 +101,6 @@ Example: Tank drive stabilization using turn rate
 The following example shows how to stabilize heading using a simple P loop closed on the turn rate.  Since a robot that is not turning should have a turn rate of zero, the setpoint for the loop is implicitly zero, making this method very simple.
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        frc::ADXRS450_Gyro gyro{frc::SPI::Port::kMXP};
-
-        // The gain for a simple P loop
-        double kP = 1;
-
-        // Initialize motor controllers and drive
-        frc::Spark left1{0};
-        frc::Spark left2{1};
-        frc::Spark right1{2};
-        frc::Spark right2{3};
-
-        frc::SpeedControllerGroup leftMotors{left1, left2};
-        frc::SpeedControllerGroup rightMotors{right1, right2};
-
-        frc::DifferentialDrive drive{leftMotors, rightMotors};
-
-        void Robot::AutonomousPeriodic() {
-            // Setpoint is implicitly 0, since we don't want the heading to change
-            double error = -gyro.GetRate();
-
-            // Drives forward continuously at half speed, using the gyro to stabilize the heading
-            drive.TankDrive(.5 + kP * error, .5 - kP * error);
-        }
-    
         
     .. code-tab:: java
 
@@ -161,24 +130,12 @@ The following example shows how to stabilize heading using a simple P loop close
             drive.tankDrive(.5 + kP * error, .5 - kP * error);
         }
 
-More-advanced implementations can use a more-complicated control loop.  When closing the loop on the turn rate for heading stabilization, PI loops are particularly effective.
-
-Example: Tank drive stabilization using heading
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The following example shows how to stabilize heading using a simple P loop closed on the heading.  Unlike in the turn rate example, we will need to set the setpoint to the current heading before starting motion, making this method slightly more-complicated.
-
-.. tabs::
-
     .. code-tab:: c++
 
         frc::ADXRS450_Gyro gyro{frc::SPI::Port::kMXP};
 
         // The gain for a simple P loop
         double kP = 1;
-
-        // The heading of the robot when starting the motion
-        double heading;
 
         // Initialize motor controllers and drive
         frc::Spark left1{0};
@@ -191,19 +148,23 @@ The following example shows how to stabilize heading using a simple P loop close
 
         frc::DifferentialDrive drive{leftMotors, rightMotors};
 
-        void Robot::AutonomousInit() {
-            // Set setpoint to current heading at start of auto
-            heading = gyro.GetAngle();
-        }
-
         void Robot::AutonomousPeriodic() {
-            double error = heading - gyro.GetAngle();
+            // Setpoint is implicitly 0, since we don't want the heading to change
+            double error = -gyro.GetRate();
 
             // Drives forward continuously at half speed, using the gyro to stabilize the heading
             drive.TankDrive(.5 + kP * error, .5 - kP * error);
         }
-    
-        
+
+More-advanced implementations can use a more-complicated control loop.  When closing the loop on the turn rate for heading stabilization, PI loops are particularly effective.
+
+Example: Tank drive stabilization using heading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example shows how to stabilize heading using a simple P loop closed on the heading.  Unlike in the turn rate example, we will need to set the setpoint to the current heading before starting motion, making this method slightly more-complicated.
+
+.. tabs::
+      
     .. code-tab:: java
 
         Gyro gyro = new ADXRS450_Gyro(SPI.Port.kMXP);
@@ -240,23 +201,15 @@ The following example shows how to stabilize heading using a simple P loop close
             drive.tankDrive(.5 + kP * error, .5 - kP * error);
         }
 
-More-advanced implementations can use a more-complicated control loop.  When closing the loop on the heading for heading stabilization, PD loops are particularly effective.
-
-Turning to a set heading
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Another common and highly-useful application for a gyro is turning a robot to face a specified direction.  This can be a component of an autonomous driving routine, or can be used during teleoperated control to help align a robot with field elements.
-
-Much like with heading stabilization, this is often accomplished with a PID loop - unlike with stabilization, however, the loop can only be closed on the heading.  The following example code will turn the robot to face 90 degrees with a simple P loop:
-
-.. tabs::
-
     .. code-tab:: c++
 
         frc::ADXRS450_Gyro gyro{frc::SPI::Port::kMXP};
 
         // The gain for a simple P loop
         double kP = 1;
+
+        // The heading of the robot when starting the motion
+        double heading;
 
         // Initialize motor controllers and drive
         frc::Spark left1{0};
@@ -269,15 +222,29 @@ Much like with heading stabilization, this is often accomplished with a PID loop
 
         frc::DifferentialDrive drive{leftMotors, rightMotors};
 
-        void Robot::AutonomousPeriodic() {
-            // Find the heading error; setpoint is 90
-            double error = 90 - gyro.GetAngle();
-
-            // Turns the robot to face the desired direction
-            drive.TankDrive(kP * error, kP * error);
+        void Robot::AutonomousInit() {
+            // Set setpoint to current heading at start of auto
+            heading = gyro.GetAngle();
         }
-    
-        
+
+        void Robot::AutonomousPeriodic() {
+            double error = heading - gyro.GetAngle();
+
+            // Drives forward continuously at half speed, using the gyro to stabilize the heading
+            drive.TankDrive(.5 + kP * error, .5 - kP * error);
+        }
+
+More-advanced implementations can use a more-complicated control loop.  When closing the loop on the heading for heading stabilization, PD loops are particularly effective.
+
+Turning to a set heading
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Another common and highly-useful application for a gyro is turning a robot to face a specified direction.  This can be a component of an autonomous driving routine, or can be used during teleoperated control to help align a robot with field elements.
+
+Much like with heading stabilization, this is often accomplished with a PID loop - unlike with stabilization, however, the loop can only be closed on the heading.  The following example code will turn the robot to face 90 degrees with a simple P loop:
+
+.. tabs::
+      
     .. code-tab:: java
 
         Gyro gyro = new ADXRS450_Gyro(SPI.Port.kMXP);
@@ -304,6 +271,32 @@ Much like with heading stabilization, this is often accomplished with a PID loop
 
             // Turns the robot to face the desired direction
             drive.tankDrive(kP * error, kP * error);
+        }
+
+    .. code-tab:: c++
+
+        frc::ADXRS450_Gyro gyro{frc::SPI::Port::kMXP};
+
+        // The gain for a simple P loop
+        double kP = 1;
+
+        // Initialize motor controllers and drive
+        frc::Spark left1{0};
+        frc::Spark left2{1};
+        frc::Spark right1{2};
+        frc::Spark right2{3};
+
+        frc::SpeedControllerGroup leftMotors{left1, left2};
+        frc::SpeedControllerGroup rightMotors{right1, right2};
+
+        frc::DifferentialDrive drive{leftMotors, rightMotors};
+
+        void Robot::AutonomousPeriodic() {
+            // Find the heading error; setpoint is 90
+            double error = 90 - gyro.GetAngle();
+
+            // Turns the robot to face the desired direction
+            drive.TankDrive(kP * error, kP * error);
         }
 
 As before, more-advanced implementations can use more-complicated control loops.

--- a/source/docs/software/sensors/sensor-overview-software.rst
+++ b/source/docs/software/sensors/sensor-overview-software.rst
@@ -1,9 +1,7 @@
-.. _sensor-overview-software:
-
 Sensor Overview - Software
 ==========================
 
-.. note:: This section covers using sensors in software.  For a guide to sensor hardware, see :ref:`sensor-overview-hardware`.
+.. note:: This section covers using sensors in software.  For a guide to sensor hardware, see :ref:`docs/hardware/sensors/sensor-overview-hardware:Sensor Overview - Hardware`.
 
 .. note:: While cameras may definitely be considered "sensors", vision processing is a sufficiently-complicated subject that it is covered in :ref:`its own section <strategies-for-vision-programming>`, rather than here.
 
@@ -15,18 +13,18 @@ What sensors does WPILIB support?
 The RoboRIO includes a `FPGA <https://en.wikipedia.org/wiki/Field-programmable_gate_array>`__ which allows accurate real-time measuring of a variety of sensor input.  WPILib, in turn, provides a number of classes for accessing this functionality.
 
 TODO: Fix this graphic.  Vision should be removed, counters are omitted but should be included, in general this needs to be made sensible/consistent
+
 |Types of Sensors|
 
 WPILib provides native support for (TODO: make each of these links):
 
-- Accelerometers
-- Gyroscopes
-- Magnetometers (compasses)
-- Ultrasonic rangefinders
-- Potentiometers
-- Counters
-- Quadrature encoders
-- Limit switches
+- :ref:`Accelerometers <docs/software/sensors/accelerometers-software:Accelerometers - Software>`
+- :ref:`Gyroscopes <docs/software/sensors/gyros-software:Gyroscopes - Software>`
+- :ref:`Ultrasonic rangefinders <docs/software/sensors/ultrasonics-software:Ultrasonics - Software>`
+- :ref:`Potentiometers <docs/software/sensors/analog-potentiometers-software:Analog Potentiometers - Software>`
+- :ref:`Counters <docs/software/sensors/counters:Counters>`
+- :ref:`Quadrature encoders <docs/software/sensors/encoders-software:Encoders - Software>`
+- :ref:`Limit switches <docs/software/sensors/digital-inputs-software:Digital Inputs - Software>`
 
 Additionally, WPILib includes lower-level classes for interfacing directly with the FPGA's digital and analog inputs and outputs.
 

--- a/source/docs/software/sensors/ultrasonics-software.rst
+++ b/source/docs/software/sensors/ultrasonics-software.rst
@@ -1,9 +1,7 @@
-.. _ultrasonics-software:
-
 Ultrasonics - Software
 ======================
 
-.. note:: This section covers ultrasonics in software.  For a hardware guide to ultrasonics, see :ref:`ultrasonics-hardware`.
+.. note:: This section covers ultrasonics in software.  For a hardware guide to ultrasonics, see :ref:`docs/hardware/sensors/ultrasonics-hardware:Ultrasonics - Hardware`.
 
 An ultrasonic sensor is commonly used to measure distance to an object using high-frequency sound.  Generally, ultrasonics measure the distance to the closest object within their "field of view."
 
@@ -19,31 +17,29 @@ The :code:`Ultrasonic` class (`Java <https://first.wpi.edu/FRC/roborio/release/d
 
 .. tabs::
 
-    .. code-tab:: c++
-
-        // Creates a ping-response Ultrasonic object on DIO 1 and 2.
-        frc::Ultrasonic ultrasonic{1, 2};
-
-
     .. code-tab:: java
 
         // Creates a ping-response Ultrasonic object on DIO 1 and 2.
         Ultrasonic ultrasonic = new Ultrasonic(1, 2);
 
+    .. code-tab:: c++
+
+        // Creates a ping-response Ultrasonic object on DIO 1 and 2.
+        frc::Ultrasonic ultrasonic{1, 2};
+
 It is highly recommended to use ping-response ultrasonics in "automatic mode," as this will allow WPILib to ensure that multiple sensors do not interfere with each other:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Starts the ultrasonic sensor running in automatic mode
-        ultrasonic.SetAutomaticMode(true);
-
 
     .. code-tab:: java
 
         // Starts the ultrasonic sensor running in automatic mode
         ultrasonic.setAutomaticMode(true);
+
+    .. code-tab:: c++
+
+        // Starts the ultrasonic sensor running in automatic mode
+        ultrasonic.SetAutomaticMode(true);
 
 Analog ultrasonics
 ------------------
@@ -61,37 +57,6 @@ Using ultrasonics in code
 Ultrasonic sensors are very useful for determining spacing during autonomous routines.  For example, the following code will drive the robot forward until the ultrasonic measures a distance of 12 inches to the nearest object, and then stop:
 
 .. tabs::
-
-    .. code-tab:: c++
-
-        // Creates a ping-response Ultrasonic object on DIO 1 and 2.
-        frc::Ultrasonic ultrasonic{1, 2};
-
-        // Initialize motor controllers and drive
-        frc::Spark left1{0};
-        frc::Spark left2{1};
-        frc::Spark right1{2};
-        frc::Spark right2{3};
-
-        frc::SpeedControllerGroup leftMotors{left1, left2};
-        frc::SpeedControllerGroup rightMotors{right1, right2};
-
-        frc::DifferentialDrive drive{leftMotors, rightMotors};
-
-        void Robot::RobotInit() {
-            // Start the ultrasonic in automatic mode
-            ultrasonic.SetAutomaticMode(true);
-        }
-
-        void Robot:AutonomousPeriodic() {
-            if(ultrasonic.GetRangeInches() > 12) {
-                drive.TankDrive(.5, .5);
-            }
-            else {
-                drive.TankDrive(0, 0);
-            }
-        }
-
 
     .. code-tab:: java
 
@@ -126,19 +91,39 @@ Ultrasonic sensors are very useful for determining spacing during autonomous rou
             }
         }
 
-Additionally, ping-response ultrasonics can be sent to :ref:`Shuffleboard <tour-of-shuffleboard>`, where they will be displayed with their own widgets:
-
-.. tabs::
-
     .. code-tab:: c++
 
         // Creates a ping-response Ultrasonic object on DIO 1 and 2.
         frc::Ultrasonic ultrasonic{1, 2};
 
+        // Initialize motor controllers and drive
+        frc::Spark left1{0};
+        frc::Spark left2{1};
+        frc::Spark right1{2};
+        frc::Spark right2{3};
+
+        frc::SpeedControllerGroup leftMotors{left1, left2};
+        frc::SpeedControllerGroup rightMotors{right1, right2};
+
+        frc::DifferentialDrive drive{leftMotors, rightMotors};
+
         void Robot::RobotInit() {
-            // Places the ultrasonic on the dashboard
-            frc::Shuffleboard.GetTab("Example tab").Add(ultrasonic);
+            // Start the ultrasonic in automatic mode
+            ultrasonic.SetAutomaticMode(true);
         }
+
+        void Robot:AutonomousPeriodic() {
+            if(ultrasonic.GetRangeInches() > 12) {
+                drive.TankDrive(.5, .5);
+            }
+            else {
+                drive.TankDrive(0, 0);
+            }
+        }
+
+Additionally, ping-response ultrasonics can be sent to :ref:`Shuffleboard <docs/software/wpilib-tools/shuffleboard/getting-started/shuffleboard-tour:Tour of Shuffleboard>`, where they will be displayed with their own widgets:
+
+.. tabs::
 
     .. code-tab:: java
 
@@ -148,4 +133,14 @@ Additionally, ping-response ultrasonics can be sent to :ref:`Shuffleboard <tour-
         public void robotInit() {
             // Places a the ultrasonic on the dashboard
             Shuffleboard.getTab("Example tab").add(ultrasonic);
+        }
+
+    .. code-tab:: c++
+
+        // Creates a ping-response Ultrasonic object on DIO 1 and 2.
+        frc::Ultrasonic ultrasonic{1, 2};
+
+        void Robot::RobotInit() {
+            // Places the ultrasonic on the dashboard
+            frc::Shuffleboard.GetTab("Example tab").Add(ultrasonic);
         }

--- a/source/docs/software/wpilib-tools/shuffleboard/getting-started/shuffleboard-tour.rst
+++ b/source/docs/software/wpilib-tools/shuffleboard/getting-started/shuffleboard-tour.rst
@@ -1,5 +1,3 @@
-.. _tour-of-shuffleboard:
-
 Tour of Shuffleboard
 ====================
 
@@ -42,7 +40,7 @@ The easiest way to get data displayed on the dashboard is simply to use methods 
    .. code-tab:: java
    
         SmartDashboard.putNumber("Joystick X value", joystick1.getX());
-		
+
 to see a field displayed with the label "Joystick X value" and a value of the X value of the joystick. Each time this line of code is executed, a new joystick value will be sent to Shuffleboard. Remember: you must write the joystick value whenever you want to see an updated value. Executing this line once at the start of the program will only display the value once at the time the line of code was executed.
 
 .. figure:: images/joystick-value.png


### PR DESCRIPTION
Changes tab order to have java first, changes links to use auto-generated link format, removes custom link anchors.