### PR TITLE
Fail BuildBot on Linux and Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
Added the following options to the Makefile

-W (fail on warning)
--keep-going (show all of the warnings)