### PR TITLE
Fix links in sensors

### DIFF
--- a/source/docs/hardware/sensors/sensor-overview-hardware.rst
+++ b/source/docs/hardware/sensors/sensor-overview-hardware.rst
@@ -1,6 +1,4 @@
-.. _sensor-overview-hardware:
-
 Sensor Overview - Hardware
 ==========================
 
-.. note:: This section covers sensor hardware, not the use of sensors in code. For a software sensor guide, see :ref:`sensor-overview-software`.
+.. note:: This section covers sensor hardware, not the use of sensors in code. For a software sensor guide, see :ref:`docs/software/sensors/sensor-overview-software:Sensor Overview - Software`.

--- a/source/docs/software/sensors/analog-potentiometers-software.rst
+++ b/source/docs/software/sensors/analog-potentiometers-software.rst
@@ -85,6 +85,6 @@ The scaled value can be read by simply calling the :code:`get` method:
 Using AnalogPotentiometers in code
 ----------------------------------
 
-Analog sensors can be used in code much in the way other sensors that measure the same thing can be.  If the analog sensor is a potentiometer measuring an arm angle, it can be used similarly to an :doc:`encoder <docs/software/sensors/encoders-software:Encoders - Software>`.  If it is an ultrasonic sensor, it can be used similarly to other :doc:`ultrasonics <docs/software/sensors/ultrasonics-software:Ultrasonics - Software>`.
+Analog sensors can be used in code much in the way other sensors that measure the same thing can be.  If the analog sensor is a potentiometer measuring an arm angle, it can be used similarly to an :ref:`encoder <docs/software/sensors/encoders-software:Encoders - Software>`.  If it is an ultrasonic sensor, it can be used similarly to other :ref:`ultrasonics <docs/software/sensors/ultrasonics-software:Ultrasonics - Software>`.
 
 It is very important to keep in mind that actual, physical potentiometers generally have a limited range of motion.  Safeguards should be present in both the physical mechanism and the code to ensure that the mechanism does not break the sensor by traveling past its maximum throw.

--- a/source/docs/software/sensors/counters.rst
+++ b/source/docs/software/sensors/counters.rst
@@ -256,9 +256,9 @@ Users can obtain the current count with the :code:`get()` method:
 Distance
 ^^^^^^^^
 
-.. note:: Counters measure *relative* distance, not absolute; the distance value returned will depend on the position of the encoder when the robot was turned on or the encoder value was last :ref:`reset <resetting-a-counter>`.
+.. note:: Counters measure *relative* distance, not absolute; the distance value returned will depend on the position of the encoder when the robot was turned on or the encoder value was last :ref:`reset <docs/software/sensors/counters:Resetting a Counter>`.
 
-If the :ref:`distance per pulse <configuring-counter-parameters>` has been configured, users can obtain the total distance traveled by the counted sensor with the :code:`getDistance()` method:
+If the :ref:`distance per pulse <docs/software/sensors/counters:Configuring counter parameters>` has been configured, users can obtain the total distance traveled by the counted sensor with the :code:`getDistance()` method:
 
 .. tabs::
 
@@ -328,7 +328,7 @@ Users can obtain the direction in which the counter last moved with the :code:`g
 Period
 ^^^^^^
 
-.. note:: In :ref:`semi-period mode <semi-period-mode>`, this method returns the duration of the pulse, not of the period.
+.. note:: In :ref:`semi-period mode <docs/software/sensors/counters:Semi-period mode>`, this method returns the duration of the pulse, not of the period.
 
 Users can obtain the duration (in seconds) of the most-recent period with the :code:`getPeriod()` method:
 


### PR DESCRIPTION
Various links were incorrectly referenced using `doc` when they should've used `ref`. 