### PR TITLE
Add Copperforge and Kauai Labs to CAN manufactor table

### DIFF
--- a/source/docs/hardware/getting-started/can-addressing.rst
+++ b/source/docs/hardware/getting-started/can-addressing.rst
@@ -58,7 +58,7 @@ REV Robotics    5
 Grapple         6
 MindSensors     7
 Team Use        8
-Reserved        9
+Kauai Labs      9
 Copperforge     10
 Reserved        11-255
 =============== =====

--- a/source/docs/hardware/getting-started/can-addressing.rst
+++ b/source/docs/hardware/getting-started/can-addressing.rst
@@ -58,7 +58,9 @@ REV Robotics    5
 Grapple         6
 MindSensors     7
 Team Use        8
-Reserved        9-255
+Reserved        9
+Copperforge     10
+Reserved        11-255
 =============== =====
 
 API/Message Identifier


### PR DESCRIPTION
As per our email with @Kevin-OConnor, Copperforge has been assigned CAN Manufacturer Code 10. Updating the public copy of the document seems to have slipped through the cracks, since this happened during competition season back in April.

Email as per @Daltz333's request:
![image](https://user-images.githubusercontent.com/4739008/59058957-b325fc00-886b-11e9-8e22-64fa0e844ae0.png)
