### PR TITLE
Various configuration tweaks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
 - script: sudo apt-get update
   displayName: 'Update System Packages'
 
-- script: sudo apt-get install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-fonts-extra dvipng
+- script: sudo apt-get install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra dvipng
   displayName: 'Install LateX'
 
 - script: sudo apt-get install -qy --force-yes graphviz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,13 +42,33 @@ steps:
   displayName: 'Compile EPUB'
 
 - task: ArchiveFiles@2
+  displayName: 'Archive HTML'
   inputs:
-    rootFolderOrFile: build/ 
+    rootFolderOrFile: build/html/
     includeRootFolder: false
     archiveType: 'zip'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/docs.zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/docs-html.zip'
+    replaceExistingArchive: true 
+
+- task: ArchiveFiles@2
+  displayName: 'Archive PDF'
+  inputs:
+    rootFolderOrFile: build/latex/firstroboticscompetition.pdf
+    includeRootFolder: false
+    archiveType: 'zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/docs-pdf.zip'
+    replaceExistingArchive: true 
+
+- task: ArchiveFiles@2
+  displayName: 'Archive EPUB'
+  inputs:
+    rootFolderOrFile: build/epub/FIRSTRobiticsCompetition.epub 
+    includeRootFolder: false
+    archiveType: 'zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/docs-epub.zip'
     replaceExistingArchive: true 
 
 - task: PublishBuildArtifacts@1
+  displayName: Publish Artifacts
   inputs:
     artifactName: 'Docs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,13 +18,16 @@ steps:
     architecture: 'x64'
     
 - script: python -m pip install --upgrade pip setuptools wheel
-  displayName: 'Install and upgrade pip'
+  displayName: 'Install and Upgrade Pip'
 
 - script: pip install -r source/requirements.txt
   displayName: 'Install Python Requirements'
 
-- script: sudo apt-get update && sudo apt-get install -qy --force-yes texlive-fonts-extra texlive-latex-extra-doc texlive-pictures-doc texlive-publishers-doc texlive-lang-english texlive-full
-  displayName: 'Install LaTeX'
+- script: sudo apt-get update
+  displayName: 'Update System Packages'
+
+- script: sudo apt-get install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra texlive-math-extra dvipng
+  displayName: 'Install LateX'
 
 - script: sudo apt-get install -qy --force-yes graphviz
   displayName: 'Install GraphViz'
@@ -36,7 +39,7 @@ steps:
   displayName: 'Compile PDF'
 
 - script: make epub
-  displayName: 'Compile EPUB'
+  displayName: 'Compile epub'
 
 - task: ArchiveFiles@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,12 @@ steps:
 - script: make html
   displayName: 'Compile Docs'
 
+- script: make latexpdf
+  displayName: 'Compile PDF'
+
+- script: make epub
+  displayName: 'Compile epub'
+
 - task: ArchiveFiles@2
   inputs:
     rootFolderOrFile: build/ 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ steps:
   displayName: 'Compile PDF'
 
 - script: make epub
-  displayName: 'Compile epub'
+  displayName: 'Compile EPUB'
 
 - task: ArchiveFiles@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ steps:
   displayName: 'Install GraphViz'
   
 - script: make html
-  displayName: 'Compile Docs'
+  displayName: 'Compile HTML'
 
 - script: make latexpdf
   displayName: 'Compile PDF'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
 - script: pip install -r source/requirements.txt
   displayName: 'Install Python Requirements'
 
-- script: sudo apt-get update && sudo apt-get install -qy --force-yes texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latexmk dvipng
+- script: sudo apt-get update && sudo apt-get install -qy --force-yes texlive-fonts-extra texlive-latex-extra-doc texlive-pictures-doc texlive-publishers-doc texlive-lang-english texlive-full
   displayName: 'Install LaTeX'
 
 - script: sudo apt-get install -qy --force-yes graphviz
@@ -36,7 +36,7 @@ steps:
   displayName: 'Compile PDF'
 
 - script: make epub
-  displayName: 'Compile epub'
+  displayName: 'Compile EPUB'
 
 - task: ArchiveFiles@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,6 @@ steps:
     replaceExistingArchive: true 
 
 - task: PublishBuildArtifacts@1
-  displayName: Publish Artifacts
+  displayName: 'Publish Artifacts'
   inputs:
     artifactName: 'Docs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
 - script: sudo apt-get update
   displayName: 'Update System Packages'
 
-- script: sudo apt-get install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra texlive-math-extra dvipng
+- script: sudo apt-get install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-fonts-extra dvipng
   displayName: 'Install LateX'
 
 - script: sudo apt-get install -qy --force-yes graphviz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ steps:
 - task: ArchiveFiles@2
   displayName: 'Archive EPUB'
   inputs:
-    rootFolderOrFile: build/epub/FIRSTRobiticsCompetition.epub 
+    rootFolderOrFile: build/epub/FIRSTRoboticsCompetition.epub 
     includeRootFolder: false
     archiveType: 'zip'
     archiveFile: '$(Build.ArtifactStagingDirectory)/docs-epub.zip'

--- a/source/conf.py
+++ b/source/conf.py
@@ -91,14 +91,22 @@ def setup(app):
 
 # -- Options for latex generation --------------------------------------------
 
-latex_engine = 'pdflatex'
+latex_engine = 'xelatex'
 
 latex_elements = {
-	'preamble': r'''
-	\usepackage[utf8]{inputenc}
-	\usepackage{fdsymbol}
-	\usepackage{newunicodechar}
-	\newunicodechar{⌀}{\ensuremath{\diameter}}'''
+    'fontpkg': r'''
+	\setmainfont{DejaVu Serif}
+	\setsansfont{DejaVu Sans}
+	\setmonofont{DejaVu Sans Mono}''',
+    'preamble': r'''
+	\usepackage[titles]{tocloft}
+	\cftsetpnumwidth {1.25cm}\cftsetrmarg{1.5cm}
+	\setlength{\cftchapnumwidth}{0.75cm}
+	\setlength{\cftsecindent}{\cftchapnumwidth}
+	\setlength{\cftsecnumwidth}{1.25cm}
+	''',
+    'fncychap': r'\usepackage[Bjornstrup]{fncychap}',
+    'printindex': r'\footnotesize\raggedright\printindex',
 }
 
 suppress_warnings = ['epub.unknown_project_files']

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,6 +20,7 @@
 project = 'FIRST Robotics Competition'
 copyright = '2019, FIRST'
 author = 'WPILib'
+version = '2019.4.1'
 
 
 # -- General configuration ---------------------------------------------------
@@ -86,3 +87,17 @@ user_options = [
 
 def setup(app):
   app.add_stylesheet('css/frc-rtd.css')
+
+
+# -- Options for latex generation --------------------------------------------
+
+latex_engine = 'lualatex'
+
+latex_elements = {
+	'preamble': r'''
+	\usepackage{unicode-math}'''
+}
+
+suppress_warnings = ['epub.unknown_project_files']
+
+sphinx_tabs_valid_builders = ['epub']

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,7 +20,7 @@
 project = 'FIRST Robotics Competition'
 copyright = '2019, FIRST'
 author = 'WPILib'
-version = '2019.4.1'
+version = '2019'
 
 
 # -- General configuration ---------------------------------------------------

--- a/source/conf.py
+++ b/source/conf.py
@@ -93,6 +93,11 @@ def setup(app):
 
 latex_engine = 'pdflatex'
 
+latex_elements = {
+	'preamble': r'''
+	\usepackage[utf8]{inputenc}'''
+}
+
 suppress_warnings = ['epub.unknown_project_files']
 
 sphinx_tabs_valid_builders = ['epub']

--- a/source/conf.py
+++ b/source/conf.py
@@ -95,7 +95,10 @@ latex_engine = 'pdflatex'
 
 latex_elements = {
 	'preamble': r'''
-	\usepackage[utf8]{inputenc}'''
+	\usepackage[utf8]{inputenc}
+	\usepackage{fdsymbol}
+	\usepackage{newunicodechar}
+	\newunicodechar{⌀}{\ensuremath{\diameter}}'''
 }
 
 suppress_warnings = ['epub.unknown_project_files']

--- a/source/conf.py
+++ b/source/conf.py
@@ -91,12 +91,7 @@ def setup(app):
 
 # -- Options for latex generation --------------------------------------------
 
-latex_engine = 'lualatex'
-
-latex_elements = {
-	'preamble': r'''
-	\usepackage{unicode-math}'''
-}
+latex_engine = 'pdflatex'
 
 suppress_warnings = ['epub.unknown_project_files']
 

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,4 +1,4 @@
 sphinx_rtd_theme==0.4.3
 sphinx==2.1.0
-sphinx-tabs==1.1.10
+sphinx-tabs==1.1.11
 latex==0.7.0


### PR DESCRIPTION
- Fix readthedocs build failing (sphinx_tabs was incompatible with pdf generation)
- Generate PDF and epub files on azure pipelines

Modifications
--------------
- Suppress unknown mimetype for EPUB generation. Image files generated with graphviz do not have a known mimetype and should be suppressed. Does **not** effect the final result.
- Adds epub to the list of valid builders for the sphinx_tabs plugin. This results in code output looking like the below
- This also adds extra dependencies to build PDF and EPUB for appveyor
- Also bumps Sphinx tabs version up 1.1.11 which fixes compatibility with SphinxV2

Example EPUB/PDF tab code content (unfortunately, I do not believe this is configurable):

Java
C++

```
java content here
```

```
cpp content here
```