### PR TITLE
Disable todo warnings and put the todolist somewhere 

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -36,7 +36,7 @@ extensions = [
 ]
 
 # TODO Directives omit a warning
-todo_emit_warnings = True
+todo_emit_warnings = False
 
 # TODO Directives are not shown in output
 todo_include_todos = False

--- a/source/index.rst
+++ b/source/index.rst
@@ -59,3 +59,5 @@ Welcome to the FIRST Robotics Competition Documentation! This documentation is v
    :caption: Contributing
    
    contributing
+   
+.. todolist::


### PR DESCRIPTION
This allows us to actually use the todo plugin without the build bot failing on the warnings that would be generated.