### PR TITLE
Specify the usage of anonymous and non-anonymous hyperlinks

### DIFF
--- a/source/docs/contributing/style-guide.rst
+++ b/source/docs/contributing/style-guide.rst
@@ -84,11 +84,19 @@ Follow the `WPILib style guide <https://github.com/wpilibsuite/styleguide/>`_ fo
 Links
 -----
 
-Links should be in the following format
+It is preferred to format links as an anonymous hyperlink. The important thing to note is the **two** underscores appending the text. In the situation that only one underscore is used, issues may arise when compiling the document.
 
 .. code-block:: text
 
-   Hi there, `this is a link <http://example.com>`_ and it's pretty cool!
+   Hi there, `this is a link <http://example.com>`__ and it's pretty cool!
+
+However, in some cases where the same link must be referenced multiple times, the syntax below is accepted.
+
+.. code-block:: text
+
+   Hi there, `this is a link`_ and it's pretty cool!
+
+   ..  _this is a link: http://example.com
 
 Images
 ------

--- a/source/docs/contributing/style-guide.rst
+++ b/source/docs/contributing/style-guide.rst
@@ -84,7 +84,7 @@ Follow the `WPILib style guide <https://github.com/wpilibsuite/styleguide/>`_ fo
 Links
 -----
 
-It is preferred to format links as an anonymous hyperlink. The important thing to note is the **two** underscores appending the text. In the situation that only one underscore is used, issues may arise when compiling the document.
+It is preferred to format links as anonymous hyperlinks. The important thing to note is the **two** underscores appending the text. In the situation that only one underscore is used, issues may arise when compiling the document.
 
 .. code-block:: text
 


### PR DESCRIPTION
Previously non-anonymous inline hyperlinks were recommended. This was due to a misunderstanding early in the writing of the style guide that non-anonymous inline hyperlinks were the same as anonymous hyperlinks. However, this is incorrect.

Non-anonymous inline hyperlinks **will** conflict with other non-anonymous hyperlinks in the file. For example, this will throw an error.

```
Click `here <https://example.com>`_ for an example.

Click `here <https://example.com>`_ for the same example but on a different line.
```

This pull requests specified that **anonymous** hyperlinks are **preferred**. Non-anonymous non-inline hyperlinks can also be accepted as it reduces the amount of typing necessary for links. 