### PR TITLE
Update homepage to include 2020 notice

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -6,7 +6,9 @@
 FIRST Robotics Competition Documentation
 ========================================
 
-Welcome to the FIRST Robotics Competition Documentation! This documentation is very much a work-in-progress, so please excuse the constant house-keeping. If you'd like to contribute, check out :doc:`docs/contributing/contribution-guidelines`.
+Welcome to the FIRST Robotics Competition Documentation! This documentation will be the Official FIRST® Robotics Competition documentation for the 2020 season and beyond. It is important to recognize that while most of these documents are identical to their `ScreenSteps <https://wpilib.screenstepslive.com/s/4485>`__ predecessors, various tweaks have been made to clean up and update the articles. This includes using features that are only available in the 2020 release of WPILib. It's advised to continue using `ScreenSteps <https://wpilib.screenstepslive.com/s/4485>`__ until the official WPILib release for 2020. Teams that are in the closed beta program *should* use this website, as it contains all of the changes that will be in the beta. Information on contributing to this website can be found at the :doc:`contributing <docs/contributing/contribution-guidelines>` page.
+
+New teams may wish to familiarize themselves with the different components of the FRC :doc:`Software <docs/software/getting-started/control-system-software>` and :doc:`Hardware <docs/hardware/getting-started/control-system-hardware>`. These pages introduce the various components of the software and hardware elements that make up building a FRC robot. After reviewing these pages, information on setting up and using this software/hardware can be found in their appropriate sections in the left-hand navigation menu.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR includes a notice to only use the website for 2020 software/hardware. It directs new teams to the software and hardware overview pages, and to go to the requested section for more information on what each component it.