### PR TITLE
Update wpi-drive-classes to fix example indentation

### DIFF
--- a/source/docs/software/actuators/wpi-drive-classes.rst
+++ b/source/docs/software/actuators/wpi-drive-classes.rst
@@ -301,7 +301,7 @@ Joystick construction.
 
         void TeleopPeriodic() override {
             myDrive.TankDrive(leftStick.GetY(), rightStick.GetY());
-                myDrive.ArcadeDrive(driveStick.GetY(), driveStick.GetX());
+            myDrive.ArcadeDrive(driveStick.GetY(), driveStick.GetX());
             myDrive.CurvatureDrive(driveStick.GetY(), driveStick.GetX(), driveStick.GetButton(1));
         }
 


### PR DESCRIPTION
There was an extra indentation on line 304 (cpp example of arcade drive). This commit makes it in line with the rest of the example.