### PR TITLE
Enable linkcheck

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,9 @@ steps:
 - script: make lint
   displayName: 'Lint Check'
 
+- script: make linkcheck
+  displayName: 'Link Check'
+
 - script: sudo apt-get update
   displayName: 'Update System Packages'
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -43,6 +43,9 @@ todo_emit_warnings = False
 # TODO Directives are not shown in output
 todo_include_todos = False
 
+# Disable following anchors in URLS for linkcheck
+linkcheck_anchors = False
+
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True
 
@@ -111,4 +114,4 @@ latex_elements = {
 
 suppress_warnings = ['epub.unknown_project_files']
 
-sphinx_tabs_valid_builders = ['epub']
+sphinx_tabs_valid_builders = ['epub', 'linkcheck']


### PR DESCRIPTION
Pros: All links are tested with every pull-request to ensure validity.
Cons: Build times are increased by around 3 minutes.

Closes #150 