### PR TITLE
added missing zero

### DIFF
--- a/source/docs/networking/networking-basics.rst
+++ b/source/docs/networking/networking-basics.rst
@@ -8,7 +8,7 @@ An IP address is a unique string of numbers, separated by periods that identifie
 
 .. image:: images/networking-basics/ip-address-parts.png
 
-As shown above, this means that each IP address is a 32-bit address meaning there are 232 addresses, or nearly 4,300,000,000 addresses possible. However, most of these are used publicly for things like web servers.
+As shown above, this means that each IP address is a 32-bit address meaning there are 2\ :sup:`32` addresses, or nearly 4,300,000,000 addresses possible. However, most of these are used publicly for things like web servers.
 
 This brings up our **first key point** of IP Addressing: Each device on the network must have a unique IP address. No two devices can have the same IP address, otherwise collisions will occur.
 


### PR DESCRIPTION
Added missing zero. Also rephrased to be slightly more accurate.  "just over" gives the impression it similar in scale to an insignificant rounding error.  2^32 is actually 4,294,967,296‬, a margin of error of over 7%.  Certainly not insignificant.