### PR TITLE
Exclude kauailabs from linkcheck

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -48,7 +48,7 @@ todo_include_todos = False
 linkcheck_anchors = False
 
 # Linkcheck Exclusions
-linkcheck_ignore = ['.*kauailabs.com.*']
+linkcheck_ignore = [r'.*kauailabs.com.*']
 
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,7 +48,9 @@ todo_include_todos = False
 linkcheck_anchors = False
 
 # Linkcheck Exclusions
-linkcheck_ignore = [r'/kauailabs.com/g']
+linkcheck_ignore = [
+	r'/kauailabs.com/g'
+]
 
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,7 +48,7 @@ todo_include_todos = False
 linkcheck_anchors = False
 
 # Linkcheck Exclusions
-linkcheck_ignore = [r'kauailabs.com']
+linkcheck_ignore = [r'/kauailabs.com/g']
 
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,9 +48,7 @@ todo_include_todos = False
 linkcheck_anchors = False
 
 # Linkcheck Exclusions
-linkcheck_ignore = [
-	r'kauailabs.com'
-]
+linkcheck_ignore = ['kauailabs.com']
 
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True

--- a/source/conf.py
+++ b/source/conf.py
@@ -47,6 +47,9 @@ todo_include_todos = False
 # Disable following anchors in URLS for linkcheck
 linkcheck_anchors = False
 
+# Linkcheck Exclusions
+linkcheck_ignore = ['kauailabs.com']
+
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,7 +48,7 @@ todo_include_todos = False
 linkcheck_anchors = False
 
 # Linkcheck Exclusions
-linkcheck_ignore = ['kauailabs.com']
+linkcheck_ignore = ['.*kauailabs.com.*']
 
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True

--- a/source/conf.py
+++ b/source/conf.py
@@ -49,7 +49,7 @@ linkcheck_anchors = False
 
 # Linkcheck Exclusions
 linkcheck_ignore = [
-	r'/kauailabs.com/g'
+	r'kauailabs.com'
 ]
 
 # Autosection labels prefix document path and filename

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,7 +48,7 @@ todo_include_todos = False
 linkcheck_anchors = False
 
 # Linkcheck Exclusions
-linkcheck_ignore = ['kauailabs.com']
+linkcheck_ignore = [r'kauailabs.com']
 
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True


### PR DESCRIPTION
KauaiLabs website consistently has downtime, and various website issues. This excludes all urls with their root domain from the link check. In the mean time, I have sent them an email informing them of these issues.