### PR TITLE
Disable linkcheck

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,6 @@ steps:
 - script: make lint
   displayName: 'Lint Check'
 
-- script: make linkcheck
-  displayName: 'Link Check'
-
 - script: sudo apt-get update
   displayName: 'Update System Packages'
 


### PR DESCRIPTION
Build keeps failing due to azure timing out/exceeding maximum number of retries. Linkcheck can just be done manually every now and again. 