### PR TITLE
Issue #203 Add hardware section - added link &tc

### DIFF
--- a/source/docs/hardware/getting-started/wiring-pneumatics.rst
+++ b/source/docs/hardware/getting-started/wiring-pneumatics.rst
@@ -13,7 +13,7 @@ For complicated robot designs requiring more channels or multiple solenoid volta
 PCM Power and Control Wiring
 ----------------------------
 
-The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see :ref:`How To Wire A Robot <docs/hardware/getting-started/how-to-wire-a-robot:Pneumatics Control Module Power (Optional)>`
+The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see :ref:`docs/hardware/getting-started/how-to-wire-a-robot:Pneumatics Control Module Power (Optional)`
 
 Additional PCMs can be wired to a standard WAGO connector on the side of the PDP and protected with a 20A or smaller circuit breaker. Additional PCMs should also be placed anywhere in the middle of the CAN chain.
 

--- a/source/docs/hardware/getting-started/wiring-pneumatics.rst
+++ b/source/docs/hardware/getting-started/wiring-pneumatics.rst
@@ -13,7 +13,7 @@ For complicated robot designs requiring more channels or multiple solenoid volta
 PCM Power and Control Wiring
 ----------------------------
 
-The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see `How To Wire A Robot <https://docs.wpilib.org/en/latest/docs/hardware/getting-started/how-to-wire-a-robot.html>`__ 
+The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see `How To Wire A Robot <https://docs.wpilib.org/en/latest/docs/hardware/getting-started/how-to-wire-a-robot.html>`__
 
 Additional PCMs can be wired to a standard WAGO connector on the side of the PDP and protected with a 20A or smaller circuit breaker. Additional PCMs should also be placed anywhere in the middle of the CAN chain.
 

--- a/source/docs/hardware/getting-started/wiring-pneumatics.rst
+++ b/source/docs/hardware/getting-started/wiring-pneumatics.rst
@@ -13,7 +13,7 @@ For complicated robot designs requiring more channels or multiple solenoid volta
 PCM Power and Control Wiring
 ----------------------------
 
-The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see `How To Wire A Robot <https://docs.wpilib.org/en/latest/docs/hardware/getting-started/how-to-wire-a-robot.html>`__
+The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see :ref:`How To Wire A Robot <docs/hardware/getting-started/how-to-wire-a-robot:Pneumatics Control Module Power (Optional)>`
 
 Additional PCMs can be wired to a standard WAGO connector on the side of the PDP and protected with a 20A or smaller circuit breaker. Additional PCMs should also be placed anywhere in the middle of the CAN chain.
 

--- a/source/docs/hardware/getting-started/wiring-pneumatics.rst
+++ b/source/docs/hardware/getting-started/wiring-pneumatics.rst
@@ -13,7 +13,7 @@ For complicated robot designs requiring more channels or multiple solenoid volta
 PCM Power and Control Wiring
 ----------------------------
 
-The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM see Wiring the 2015 FRC Control System.
+The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see `How To Wire A Robot.<https://docs.wpilib.org/en/latest/docs/hardware/getting-started/how-to-wire-a-robot.html>`__ 
 
 Additional PCMs can be wired to a standard WAGO connector on the side of the PDP and protected with a 20A or smaller circuit breaker. Additional PCMs should also be placed anywhere in the middle of the CAN chain.
 

--- a/source/docs/hardware/getting-started/wiring-pneumatics.rst
+++ b/source/docs/hardware/getting-started/wiring-pneumatics.rst
@@ -13,7 +13,7 @@ For complicated robot designs requiring more channels or multiple solenoid volta
 PCM Power and Control Wiring
 ----------------------------
 
-The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM see Wiring the 2015 FRC Control System. 
+The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM see Wiring the 2015 FRC Control System.
 
 Additional PCMs can be wired to a standard WAGO connector on the side of the PDP and protected with a 20A or smaller circuit breaker. Additional PCMs should also be placed anywhere in the middle of the CAN chain.
 

--- a/source/docs/hardware/getting-started/wiring-pneumatics.rst
+++ b/source/docs/hardware/getting-started/wiring-pneumatics.rst
@@ -1,59 +1,36 @@
 Wiring Pneumatics
 =================
 
-.. hint:: Wiring pneumatics has been made very simple in the 2019 Control System. A single Pneumatics Control Module is all that will be needed for many pneumatics applications, with additional PCMs supporting more complex designs including more than 8 solenoid channels or a mix of 12V and 24V solenoids.
+.. hint:: For pneumatics safety & mechanical requirements, consult this year's Robot Construction rules (Section 10 in 2019). For mechanical design guidelines, the FIRST Pneumatics Manual is located `here (last updated 2017)<https://firstfrc.blob.core.windows.net/frc2017/pneumatics-manual.pdf>`__
 
 Wiring Overview
 ---------------
 
-A single PCM will support many pneumatics applications, providing an output
-for the compressor, input for the pressure switch and outputs for up to 8
-solenoid channels (12V or 24V selectable). The module is connected to the
-roboRIO over the CAN bus and powered via 12V from the PDP.
+A single PCM will support most pneumatics applications, providing an output for the compressor, input for the pressure switch, and outputs for up to 8 solenoid channels (12V or 24V selectable). The module is connected to the roboRIO over the CAN bus and powered via 12V from the PDP.
+
+For complicated robot designs requiring more channels or multiple solenoid voltages, additional PCMs can be added to the control system.
 
 PCM Power and Control Wiring
 ----------------------------
 
-The first PCM on your robot can be wired from the PDP VRM/PCM
-connectors on the end of the PDP. The PCM is connected to the
-roboRIO via CAN and can be placed anywhere in the middle of
-the CAN chain (or on the end with a custom terminator). For
-more details on wiring a single PCM see Wiring the 2015 FRC
-Control System. Additional PCMs can be wired to a standard WAGO
-connector on the side of the PDP and protected with a 20A or
-smaller circuit breaker. Additional PCMs should also be placed
-anywhere in the middle of the CAN chain.
+The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM see Wiring the 2015 FRC Control System. 
+
+Additional PCMs can be wired to a standard WAGO connector on the side of the PDP and protected with a 20A or smaller circuit breaker. Additional PCMs should also be placed anywhere in the middle of the CAN chain.
 
 The Compressor
 ---------------
 
-The compressor can be wired directly to the Compressor Out
-connectors on the PCM. If additional length is required,
-make sure to use 18 AWG wire or larger for the extension.
+The compressor can be wired directly to the Compressor Out connectors on the PCM. If additional length is required, make sure to use 18 AWG wire or larger for the extension.
 
 The Pressure Switch
 ----------------------------
 
-The pressure switch should be connected directly to
-the pressure switch input terminals on the PCM. There
-is no polarity on the input terminals or on the pressure
-switch itself, either terminal on the PCM can be connected
-to either terminal on the switch. Ring or spade terminals
-are recommended for the connection to the switch screws
-(note that the screws are slightly larger than #6, but can
-be threaded through a ring terminal with a hole for a #6
-screw such as the terminals shown in the image).
+The pressure switch should be connected directly to the pressure switch input terminals on the PCM. There is no polarity on the input terminals or on the pressure switch itself, either terminal on the PCM can be connected to either terminal on the switch. Ring or spade terminals are recommended for the connection to the switch screws (note that the screws are slightly larger than #6, but can be threaded through a ring terminal with a hole for a #6 screw such as the terminals shown in the image).
 
 Solenoids
 ---------
 
-Each solenoid channel should be wired directly to a
-numbered pair of terminals on the PCM. A single
-acting solenoid will use one numbered terminal pair.
-A double acting solenoid will use two pairs (as shown
-in the image above). If your solenoid does not come
-with color coded wiring, check the datasheet to make
-sure to wire with the proper polarity.
+Each solenoid channel should be wired directly to a numbered pair of terminals on the PCM. A single acting solenoid will use one numbered terminal pair. A double acting solenoid will use two pairs (as shown in the image above). If your solenoid does not come with color coded wiring, check the datasheet to make sure to wire with the proper polarity.
 
 Solenoid Voltage Jumper
 ------------------------
@@ -61,12 +38,4 @@ Solenoid Voltage Jumper
 .. image:: images/wiring-pneumatics/pcm01.jpg
    :width: 400
 
-The PCM is capable of powering either 12V or 24V solenoids,
-but all solenoids connected to a single PCM must be the same
-voltage. The PCM ships with the jumper in the 12V position
-as shown in the image. To use 24V solenoids move the jumper
-from the left two pins (as shown in the image) to the right
-two pins. The overlay on the PCM also indicates which
-position corresponds to which voltage. You may need to use
-a tool such as a small screwdriver, small pair of pliers, or
-a pair of tweezers to remove the jumper.
+The PCM is capable of powering either 12V or 24V solenoids, but all solenoids connected to a single PCM must be the same voltage. The PCM ships with the jumper in the 12V position as shown in the image. To use 24V solenoids move the jumper from the left two pins (as shown in the image) to the right two pins. The overlay on the PCM also indicates which position corresponds to which voltage. You may need to use a tool such as a small screwdriver, small pair of pliers, or a pair of tweezers to remove the jumper.

--- a/source/docs/hardware/getting-started/wiring-pneumatics.rst
+++ b/source/docs/hardware/getting-started/wiring-pneumatics.rst
@@ -13,7 +13,7 @@ For complicated robot designs requiring more channels or multiple solenoid volta
 PCM Power and Control Wiring
 ----------------------------
 
-The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see `How To Wire A Robot.<https://docs.wpilib.org/en/latest/docs/hardware/getting-started/how-to-wire-a-robot.html>`__ 
+The first PCM on your robot can be wired from the PDP VRM/PCM connectors on the end of the PDP. The PCM is connected to the roboRIO via CAN and can be placed anywhere in the middle of the CAN chain (or on the end with a custom terminator). For more details on wiring a single PCM, see `How To Wire A Robot <https://docs.wpilib.org/en/latest/docs/hardware/getting-started/how-to-wire-a-robot.html>`__ 
 
 Additional PCMs can be wired to a standard WAGO connector on the side of the PDP and protected with a 20A or smaller circuit breaker. Additional PCMs should also be placed anywhere in the middle of the CAN chain.
 

--- a/source/docs/hardware/getting-started/wiring-pneumatics.rst
+++ b/source/docs/hardware/getting-started/wiring-pneumatics.rst
@@ -1,7 +1,7 @@
 Wiring Pneumatics
 =================
 
-.. hint:: For pneumatics safety & mechanical requirements, consult this year's Robot Construction rules (Section 10 in 2019). For mechanical design guidelines, the FIRST Pneumatics Manual is located `here (last updated 2017)<https://firstfrc.blob.core.windows.net/frc2017/pneumatics-manual.pdf>`__
+.. hint:: For pneumatics safety & mechanical requirements, consult this year's Robot Construction rules (Section 10 in 2019). For mechanical design guidelines, the FIRST Pneumatics Manual is located `here (last updated 2017) <https://firstfrc.blob.core.windows.net/frc2017/pneumatics-manual.pdf>`__
 
 Wiring Overview
 ---------------


### PR DESCRIPTION
Proposed fix for issue #203: add a reference to "use the rules" & a link to the Pneumatics Manual. 
None of the hardware technical information should be included in this article since the focus is wiring the pneumatics. 

I followed the Style Guide, but the GitHub preview of the link is definitely broken - can a regular contributor check that before merge?

Clarified "Additional PCMs" sections as well.