### PR TITLE
Fix code tab in Command-Based convenience features

### DIFF
--- a/source/docs/software/commandbased/convenience-features.rst
+++ b/source/docs/software/commandbased/convenience-features.rst
@@ -388,7 +388,7 @@ whenFinished
 
 The ``whenFinished()`` decorator (`Java <https://first.wpi.edu/FRC/roborio/development/docs/java/edu/wpi/first/wpilibj2/command/Command.html#whenFinished(java.lang.Runnable)>`__, `C++ <https://first.wpi.edu/FRC/roborio/development/docs/cpp/classfrc2_1_1Command.html#a935487276747ed668967259856b90165>`__) adds a method to be executed after the command ends:
 
-..tabs::
+.. tabs::
 
   .. code-tab:: java
 


### PR DESCRIPTION
Fix a problem with the code tab of the whenFinished section in commandbased/convenience-features.rst.
![image](https://user-images.githubusercontent.com/32647745/66327902-e7015300-e92b-11e9-9950-5cec1d7f85d8.png)
