### PR TITLE
Fix FIRST branding in docs

### DIFF
--- a/source/docs/beta/beta-getting-started/accessing-the-beta-project.rst
+++ b/source/docs/beta/beta-getting-started/accessing-the-beta-project.rst
@@ -1,9 +1,11 @@
+.. include:: <isonum.txt>
+
 Accessing the Beta Project
 ==========================
 
 .. note:: Only accepted Beta Test teams will have access to the Beta project.
 
-The members identified by your team to communicate with FIRST technical staff will have access to the Beta Test project on the `<https://usfirst.collab.net>`__ site.
+The members identified by your team to communicate with *FIRST*\ |reg| technical staff will have access to the Beta Test project on the `<https://usfirst.collab.net>`__ site.
 
 Signing In
 ----------
@@ -27,9 +29,9 @@ The Project Homepage
 
 .. image:: images/accessing-the-beta-project/project-home.png
 
-The project homepage contains some statistics and Project News. Throughout the beta, the Project News section may be updated with the latest information from the FIRST technical staff. The top ribbon contains tabs allowing you to navigate to the different sections of the project:
+The project homepage contains some statistics and Project News. Throughout the beta, the Project News section may be updated with the latest information from the *FIRST* technical staff. The top ribbon contains tabs allowing you to navigate to the different sections of the project:
 
 1. Trackers - The Trackers tab is where the bug tracker for the project is located.
 2. File Releases - The File Releases tab will host any files you will need to download as part of the Beta test process such as NI Update files.
-3. Documents - the Documents tab will contain any documents to be distributed to Beta teams. Much of the documentation for the Beta test will be located on the FRC Docs site but there may still be documents posted here as well.
+3. Documents - the Documents tab will contain any documents to be distributed to Beta teams. Much of the documentation for the Beta test will be located on the FRC\ |reg| Docs site but there may still be documents posted here as well.
 4. Discussions - The Discussions tab contains a forum which will allow teams to post questions or discussions about the Beta test, software or documentation. Task reports will also be posted here.

--- a/source/docs/beta/beta-getting-started/welcome.rst
+++ b/source/docs/beta/beta-getting-started/welcome.rst
@@ -1,7 +1,9 @@
+.. include:: <isonum.txt>
+
 Beta Test Welcome
 =================
 
-Thank you for participating in the FRC Control System Beta Testing program.
+Thank you for participating in the FRC\ |reg| Control System Beta Testing program.
 
 Before getting started with the :ref:`docs/beta/tasks/index:Beta Tasks` please review the following articles:
 
@@ -11,4 +13,4 @@ Before getting started with the :ref:`docs/beta/tasks/index:Beta Tasks` please r
 - :ref:`docs/beta/beta-getting-started/monitoring-via-email-notifications:Monitoring Via Email Notifications`
 - :ref:`docs/beta/tasks/beta-task-overview:Beta Task Overview`
 
-Please use the TeamForge project as your primary means of communication. Members of the control system development team at CTRE, FIRST, NI, and WPI are all monitoring the project and will strive to provide timely feedback and updates.
+Please use the TeamForge project as your primary means of communication. Members of the control system development team at CTRE, *FIRST*\ |reg|, NI, and WPI are all monitoring the project and will strive to provide timely feedback and updates.

--- a/source/docs/contributing/contribution-guidelines.rst
+++ b/source/docs/contributing/contribution-guidelines.rst
@@ -1,25 +1,27 @@
+.. include:: <isonum.txt>
+
 Contribution Guidelines
 =======================
 
 Welcome to the contribution guidelines for the frc-docs project. If you are unfamiliar to writing in the reStructuredText format, please read up on it `here <https://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html>`__.
 
-.. important:: Currently we are in the process of migrating documentation from the official screensteps. Please pardon the constant housekeeping. FIRST retains all rights to documentation and images provided. Credit for article will be in the `Github commit history. <https://github.com/wpilibsuite/frc-docs/graphs/commit-activity>`_
+.. important:: Currently we are in the process of migrating documentation from the official screensteps. Please pardon the constant housekeeping. *FIRST*\ |reg| retains all rights to documentation and images provided. Credit for articles/updates will be in the `Github commit history. <https://github.com/wpilibsuite/frc-docs/graphs/commit-activity>`_
 
 Mission Statement
 -----------------
 
-The WPILib Mission is to enable FIRST Robotics teams to focus on writing game-specific software rather than focusing on hardware details - "raise the floor, don't lower the ceiling". We work to enable teams with limited programming knowledge and/or mentor experience to be as successful as possible, while not hampering the abilities of teams with more advanced programming capabilities. We support Kit of Parts control system components directly in the library. We also strive to keep parity between major features of each language (Java, C++, and NI's LabVIEW), so that teams aren't at a disadvantage for choosing a specific programming language.
+The WPILib Mission is to enable *FIRST* Robotics teams to focus on writing game-specific software rather than focusing on hardware details - "raise the floor, don't lower the ceiling". We work to enable teams with limited programming knowledge and/or mentor experience to be as successful as possible, while not hampering the abilities of teams with more advanced programming capabilities. We support Kit of Parts control system components directly in the library. We also strive to keep parity between major features of each language (Java, C++, and NI's LabVIEW), so that teams aren't at a disadvantage for choosing a specific programming language.
 
-These docs serve to provide a learning ground for all FIRST Robotics Competition teams. Contributions to the project must follow these core principles.
+These docs serve to provide a learning ground for all *FIRST* Robotics Competition teams. Contributions to the project must follow these core principles.
 
 - Community-led documentation. Documentation sources are hosted publicly and the community are able to make contributions
 - Structured, well-formatted, clean documentation. Documentation should be clean and easy to read, from both a source and release standpoint
-- Relevant. Documentation should be focused on the FIRST Robotics Competition.
+- Relevant. Documentation should be focused on the *FIRST* Robotics Competition.
 
 Please see the :ref:`docs/contributing/style-guide:Style Guide` for information on styling your documentation.
 
 Note on New Articles
 --------------------
-All new articles will undergo a review process before being merged into the repository. This review process will be done by members of the WPILib team. New Articles must be on official FIRST supported Software and Hardware. Documentation on unofficial libraries or sensors *will not* be accepted. This process may take some time to review, please be patient.
+All new articles will undergo a review process before being merged into the repository. This review process will be done by members of the WPILib team. New Articles must be on official *FIRST* supported Software and Hardware. Documentation on unofficial libraries or sensors *will not* be accepted. This process may take some time to review, please be patient.
 
 Minor revisions and rewrites will be accepted at a more generous rate.

--- a/source/docs/contributing/style-guide.rst
+++ b/source/docs/contributing/style-guide.rst
@@ -1,3 +1,5 @@
+.. include:: <isonum.txt>
+
 Style Guide
 ===========
 
@@ -39,6 +41,8 @@ Use the ASCII character set for English text. For special characters (e.g. Greek
 Use ``.. math::`` for standalone equations and ``:math:`` for inline equations.  A useful LaTeX equation cheat sheet can be found `here <https://www.reed.edu/academic_support/pdfs/qskills/latexcheatsheet.pdf>`_.
 
 Use literals for filenames, function, and variable names.
+
+Use of the registered trademarks *FIRST*\ |reg| and FRC\ |reg| should follow the Policy from `this page <https://www.firstinspires.org/brand>`__. Specifically, where possible (i.e. not nested inside other markup or in a document title), the first use of the trademarks should have the |reg| symbol and all instances of *FIRST* should be italicized. The |reg| symbol can be added by using ``..include:: <isonum.txt>`` at the top of the document and then using ``*FIRST*\ |reg|`` or ``FRC\ |reg|``.
 
 Whitespace
 ----------

--- a/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
@@ -1,7 +1,9 @@
+.. include:: <isonum.txt>
+
 FRC Control System Hardware Overview
 ====================================
 
-The goal of this document is to provide a brief overview of the hardware components that make up the FRC Control System. Each component will contain a brief description of the component function, a brief listing of critical connections, and a link to more documentation if available.
+The goal of this document is to provide a brief overview of the hardware components that make up the FRC\ |reg| Control System. Each component will contain a brief description of the component function, a brief listing of critical connections, and a link to more documentation if available.
 
 .. note:: For complete wiring instructions/diagrams, please see the :doc:`Wiring the FRC Control System <how-to-wire-a-robot>` document.
 
@@ -177,4 +179,4 @@ The power supply for an FRC robot is a single 12V 18Ah battery. The batteries us
 Image Credits
 -------------
 
-Image of roboRIO courtesy of National Instruments. Image of DMC-60 courtesy of Digilent. Image of SD540 courtesy of Mindsensors. Images of Jaguar Motor Controller, Talon SRX, Victor 888, Victor SP, Victor SPX, and Spike H-Bridge Relay courtesy of VEX Robotics, Inc. Image of SPARK MAX courtesy of REV Robotics. Lifecam, PDP, PCM, SPARK, and VRM photoscourtesy of FIRST. All other photos courtesy of AndyMark Inc.
+Image of roboRIO courtesy of National Instruments. Image of DMC-60 courtesy of Digilent. Image of SD540 courtesy of Mindsensors. Images of Jaguar Motor Controller, Talon SRX, Victor 888, Victor SP, Victor SPX, and Spike H-Bridge Relay courtesy of VEX Robotics, Inc. Image of SPARK MAX courtesy of REV Robotics. Lifecam, PDP, PCM, SPARK, and VRM photos courtesy of *FIRST*\ |reg|. All other photos courtesy of AndyMark Inc.

--- a/source/docs/getting-started/getting-started-frc-control-system/intro.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/intro.rst
@@ -1,7 +1,9 @@
+.. include:: <isonum.txt>
+
 Introduction
 ============
 
-Welcome to the official documentation home for the *FIRST* Robotics Competition Control System and WPILib software packages. This page is the primary resource documenting the use of the FRC Control System (including wiring, configuration and software) as well as the WPILib libraries and tools.
+Welcome to the official documentation home for the *FIRST*\ |reg| Robotics Competition Control System and WPILib software packages. This page is the primary resource documenting the use of the FRC\ |reg| Control System (including wiring, configuration and software) as well as the WPILib libraries and tools.
 
 New to Programming?
 -------------------

--- a/source/docs/getting-started/getting-started-frc-control-system/offline-installation-preparations.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/offline-installation-preparations.rst
@@ -1,7 +1,9 @@
+.. include:: <isonum.txt>
+
 Offline Installation Preparation
 ================================
 
-This article contains instructions/links to components you will want to gather if you need to do offline installation of the FRC Control System software.
+This article contains instructions/links to components you will want to gather if you need to do offline installation of the FRC\ |reg| Control System software.
 
 Documentation
 -------------
@@ -21,7 +23,7 @@ All Teams
 LabVIEW Teams
 ^^^^^^^^^^^^^
 
--  LabVIEW USB (from FIRST Choice) or `Download <https://www.ni.com/download/labview-for-frc-18.0/7841/en/>`__
+-  LabVIEW USB (from *FIRST*\ |reg| Choice) or `Download <https://www.ni.com/download/labview-for-frc-18.0/7841/en/>`__
 
 C++/Java Teams
 ^^^^^^^^^^^^^^

--- a/source/docs/hardware/hardware-basics/preemptive-troubleshooting.rst
+++ b/source/docs/hardware/hardware-basics/preemptive-troubleshooting.rst
@@ -1,9 +1,11 @@
+.. include:: <isonum.txt>
+
 Robot Preemptive Troubleshooting
-====================================
+================================
 
 .. note::
 
-    In FIRST Robotics Competition, robots take a lot of stress while driving around the field. It is important to make sure that connections are tight, parts are bolted securely in place and that everything is mounted so that a robot bouncing around the field does not break.
+    In *FIRST*\ |reg| Robotics Competition, robots take a lot of stress while driving around the field. It is important to make sure that connections are tight, parts are bolted securely in place and that everything is mounted so that a robot bouncing around the field does not break.
 
 Check battery connections
 ------------------------------
@@ -117,4 +119,4 @@ Handy tools
 
 There never seems to be enough light inside robots, at least not enough to scrutinize the critical connection points, so consider using a handheld LED flashlight to inspect the connections on your robot. They're available from home depot or any hardware/automotive store.
 
-WAGO tool is nice to for redoing weidmuller connections with stranded wires.  Often I’ll do one to show the team, and then have them do the rest using the WAGO tool to press down the white-plunger while they insert the stranded wire.  The angle of the WAGO tool makes this particularly helpful.
+A WAGO tool is nice tool for redoing Weidmuller connections with stranded wires.  Often I’ll do one to show the team, and then have them do the rest using the WAGO tool to press down the white-plunger while they insert the stranded wire.  The angle of the WAGO tool makes this particularly helpful.

--- a/source/docs/software/support/support-resources.rst
+++ b/source/docs/software/support/support-resources.rst
@@ -1,7 +1,9 @@
+.. include:: <isonum.txt>
+
 Support Resources
 =================
 
-In addition to the documentation here, there are a variety of other resources available to FRC teams to help understand the Control System and software.
+In addition to the documentation here, there are a variety of other resources available to FRC\ |reg| teams to help understand the Control System and software.
 
 Other Documentation
 -------------------

--- a/source/docs/software/vision-processing/introduction/identifying-and-processing-the-targets.rst
+++ b/source/docs/software/vision-processing/introduction/identifying-and-processing-the-targets.rst
@@ -17,7 +17,7 @@ This document walks through the approach used by the example code provided in La
 Original Image
 --------------
 
-The image shown below is the starting image for the example described here. The image was taken using the green ring light available in FIRST Choice combined with an additional ring light of a different size. Additional sample images are provided with the vision code examples.
+The image shown below is the starting image for the example described here. The image was taken using the green ring light available in *FIRST*\ |reg| Choice combined with an additional ring light of a different size. Additional sample images are provided with the vision code examples.
 
 .. image:: images/identifying-and-processing-the-targets/original-image.png
 

--- a/source/docs/software/wpilib-tools/path-planning/pathfinder/adding-field-images.rst
+++ b/source/docs/software/wpilib-tools/path-planning/pathfinder/adding-field-images.rst
@@ -1,10 +1,12 @@
+.. include:: <isonum.txt>
+
 Adding field images to PathWeaver
 =================================
-The initial release of PathWeaver contained the field image for the FRC 2018 Game. The next update will include FIRST Destination Deep Space. Here are instructions for adding the 2019 game now or adding your own field image for some other application.
+The initial release of PathWeaver contained the field image for the *FRC*\ |reg| 2018 Game. The next update will include *FIRST*\ |reg| Destination Deep Space. Here are instructions for adding the 2019 game now or adding your own field image for some other application.
 
 Games are loaded from the ``~/PathWeaver/Games`` on Linux and Mac or ``%USERPROFILE%/PathWeaver/Games`` directory on Windows. The files can be in either a game-specific subdirectory, or in a zip file in the Games directory. The ZIP file must follow the same layout as a game directory; the JSON file must be in the root of the ZIP file (cannot be in a subdirectory).
 
-Download the ready-to-use FIRST Destination Deep Space field definition :download:`here <files/DeepSpace.zip>`. Other field definitions are available in the `PathWeaver GitHub repository <https://github.com/wpilibsuite/PathWeaver/tree/master/src/main/resources/edu/wpi/first/pathweaver>`__.
+Download the ready-to-use *FIRST* Destination Deep Space field definition :download:`here <files/DeepSpace.zip>`. Other field definitions are available in the `PathWeaver GitHub repository <https://github.com/wpilibsuite/PathWeaver/tree/master/src/main/resources/edu/wpi/first/pathweaver>`__.
 
 File Layout
 -----------
@@ -38,4 +40,4 @@ The field corners are the X and Y coordinates of the top-left and bottom-right p
 
 The field size is the width and length of the playable area of the field in the provided units.
 
-The field units are case-insensitive and can be in meters, cm, mm, inches, feet, yards, or miles. Singular, plural, and abbreviations are supported (eg"meter","meters", and"m"are all valid for specifying meters)
+The field units are case-insensitive and can be in meters, cm, mm, inches, feet, yards, or miles. Singular, plural, and abbreviations are supported (e.g. "meter","meters", and"m"are all valid for specifying meters)

--- a/source/index.rst
+++ b/source/index.rst
@@ -2,10 +2,10 @@
    sphinx-quickstart on Fri Apr  5 23:28:43 2019.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
-   
+
 .. include:: <isonum.txt>
 
-*FIRST* Robotics Competition Control System
+FIRST Robotics Competition Control System
 ===========================================
 
 Welcome to the *FIRST*\ |reg| Robotics Competition Control System Documentation! This documentation will be the Official *FIRST* Robotics Competition Control System documentation for the 2020 season and beyond.

--- a/source/index.rst
+++ b/source/index.rst
@@ -2,11 +2,13 @@
    sphinx-quickstart on Fri Apr  5 23:28:43 2019.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
+   
+.. include:: <isonum.txt>
 
-FIRST Robotics Competition Documentation
-========================================
+*FIRST* Robotics Competition Control System
+===========================================
 
-Welcome to the FIRST Robotics Competition Documentation! This documentation will be the Official FIRST® Robotics Competition documentation for the 2020 season and beyond.
+Welcome to the *FIRST*\ |reg| Robotics Competition Control System Documentation! This documentation will be the Official *FIRST* Robotics Competition Control System documentation for the 2020 season and beyond.
 
 .. note:: It's advised to continue using `ScreenSteps <https://wpilib.screenstepslive.com/s/4485>`__ until the official WPILib release for 2020.
 


### PR DESCRIPTION
Updates _FIRST_ branding to italicize all instances of _FIRST_ and add the registered mark after the first instance of _FIRST_ on the page. Also added registered mark to instances of FRC on pages being touched anyway, but did not do a complete update for FRC.