### PR TITLE
Use forward slash in beta docs

### DIFF
--- a/source/docs/beta/tasks/task-4-new-features.rst
+++ b/source/docs/beta/tasks/task-4-new-features.rst
@@ -10,10 +10,10 @@ The purpose of this task is to test any newly developed or heavily modified feat
 
 **LabVIEW**
 
-**C++\Java**
+**C++/Java**
 
 - New Command Based framework
-- C++\Java Simulator UI
+- C++/Java Simulator UI
 - Synchronous PID Controller
 - Kinematics classes
 - C++ Units feature


### PR DESCRIPTION
Backslash is used as a delimiter and is invisible on docs.