### PR TITLE
Add description of linkcheck.

### DIFF
--- a/source/docs/contributing/build-instructions.rst
+++ b/source/docs/contributing/build-instructions.rst
@@ -50,9 +50,14 @@ Open up a Powershell Window or terminal and navigate to the frc-docs directory t
 Lint Check
 ^^^^^^^^^^
 
-.. note:: Lint Check is currently unavailable due to a bug with line endings. See `this issue <https://bugs.launchpad.net/doc8/+bug/1756704>`__ for more information.
+.. note:: Lint Check is currently unavailable on Windows due to a bug with line endings. See `this issue <https://bugs.launchpad.net/doc8/+bug/1756704>`__ for more information.
 
 It's encouraged to check any changes you make with the linter. This **will** fail the buildbot if it does not pass. To check, run ``.\make lint``
+
+Link Check
+^^^^^^^^^^
+
+The link checker makes sure that all links in the documentation resolve. This **will** fail the buildbot if it does not pass. To check, run ``.\make linkcheck``
 
 Building HTML
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Clarify that linter is only broken on Windows