### PR TITLE
Always use "macOS" when referring to Apple's OS

### DIFF
--- a/source/docs/contributing/style-guide.rst
+++ b/source/docs/contributing/style-guide.rst
@@ -35,6 +35,7 @@ Use the following case for these terms:
 - roboRIO (not RoboRIO, roboRio, or RoboRio)
 - LabVIEW (not labview or LabView)
 - Visual Studio Code (VS Code) (not vscode, VScode, vs code, etc)
+- macOS (not Mac OS, Mac OSX, Mac OS X, Mac, Mac OS, etc.)
 
 Use the ASCII character set for English text. For special characters (e.g. Greek symbols) use the `standard character entity sets <http://docutils.sourceforge.net/docs/ref/rst/definitions.html#character-entity-sets>`_.
 

--- a/source/docs/getting-started/getting-started-frc-control-system/control-system-software.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/control-system-software.rst
@@ -8,7 +8,7 @@ Operating System Compatibility
 
 The primary supported OS for FRC components is Windows. All required FRC software components have been tested on Windows 7, 8, and 10. Windows XP is not supported.
 
-Having said that, many of the tools for C++/Java programming are also supported and tested on Mac and Linux. Teams programming in C++/Java should be able to develop using these systems, using a Windows system for the Windows-only operations such as Driver Station, radio programming, and roboRIO imaging.
+Having said that, many of the tools for C++/Java programming are also supported and tested on macOS and Linux. Teams programming in C++/Java should be able to develop using these systems, using a Windows system for the Windows-only operations such as Driver Station, radio programming, and roboRIO imaging.
 
 Components supported on all OS’s have been marked with an \* below. All other items are Windows only, unless noted.
 

--- a/source/docs/getting-started/getting-started-frc-control-system/offline-installation-preparations.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/offline-installation-preparations.rst
@@ -29,7 +29,7 @@ C++/Java Teams
 ^^^^^^^^^^^^^^
 
 -  `C++/Java WPILib Installer <https://github.com/wpilibsuite/allwpilib/releases>`__
--  VS Code (if using Windows, run the installer and use it to download the appropriate VS Code file. If using Mac/Linux, download Visual Studio Code from `here <https://code.visualstudio.com/download>`__)
+-  VS Code (if using Windows, run the installer and use it to download the appropriate VS Code file. If using macOS/Linux, download Visual Studio Code from `here <https://code.visualstudio.com/download>`__)
 
 3rd Party Libraries/Software
 ----------------------------

--- a/source/docs/getting-started/getting-started-frc-control-system/wpilib-setup.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/wpilib-setup.rst
@@ -61,7 +61,7 @@ WPILib Installation Guide
 
       Both of these reference the specific year as the WPIlib C++ tools will now support side-by-side installs of multiple environments from different seasons.
 
-  .. tab :: Mac OSX
+  .. tab :: macOS
 
     **Getting Visual Studio Code**
 
@@ -81,7 +81,7 @@ WPILib Installation Guide
 
       Download the software release by navigating to this page:
       https://github.com/wpilibsuite/allwpilib/releases and downloading the
-      Mac release.
+      macOS release.
 
       .. figure:: images/mac/MacReleasePage.png
           :alt:

--- a/source/docs/getting-started/running-a-benchtop/creating-benchtop-test-program-cpp-java.rst
+++ b/source/docs/getting-started/running-a-benchtop/creating-benchtop-test-program-cpp-java.rst
@@ -39,7 +39,7 @@ Once all the above have been configured, click "Generate Project" and the robot 
 Opening The New Project
 -----------------------
 
-After successfully creating your project, VS Code will give the option of opening the project as shown below. We can choose to do that now or later by typing Ctrl-O (Command+O on mac) and select the folder where We saved our project.
+After successfully creating your project, VS Code will give the option of opening the project as shown below. We can choose to do that now or later by typing Ctrl-O (Command+O on macOS) and select the folder where We saved our project.
 
 Once opened we will see the project hierarchy on the left. Double clicking on the file will open that file in the editor.
 

--- a/source/docs/software/basic-programming/git-getting-started.rst
+++ b/source/docs/software/basic-programming/git-getting-started.rst
@@ -18,7 +18,7 @@ Prerequisites
 You have to download and install Git from the following links:
 
 - `Windows <https://git-scm.com/download/win>`_
-- `Mac OS X <https://git-scm.com/download/mac>`_
+- `macOS <https://git-scm.com/download/mac>`_
 - `Linux <https://git-scm.com/download/linux>`_
 
 .. note:: You may need to add Git to your `path <https://www.google.com/search?q=adding+git+to+path>`__

--- a/source/docs/software/networktables/client-side-program.rst
+++ b/source/docs/software/networktables/client-side-program.rst
@@ -55,4 +55,4 @@ https://first.wpi.edu/FRC/roborio/maven/release/edu/wpi/first/ntcore/ntcore-jni/
 
 https://first.wpi.edu/FRC/roborio/maven/release/edu/wpi/first/wpiutil/wpiutil-java/2019.4.1/ (wpiutil java files)
 
-.. note:: The desktop platform jar is for Windows, Mac, and Linux.
+.. note:: The desktop platform jar is for Windows, macOS, and Linux.

--- a/source/docs/software/wpilib-overview/creating-robot-program.rst
+++ b/source/docs/software/wpilib-overview/creating-robot-program.rst
@@ -160,7 +160,7 @@ Once all the above have been configured, click "Generate Project" and the robot 
 Opening The New Project
 -----------------------
 
-After successfully creating your project, VS Code will give the option of opening the project as shown below. We can choose to do that now or later by typing Ctrl-O (Command+O on mac) and select the folder where We saved our project.
+After successfully creating your project, VS Code will give the option of opening the project as shown below. We can choose to do that now or later by typing Ctrl-O (Command+O on macOS) and select the folder where We saved our project.
 
 Once opened we will see the project hierarchy on the left. Double clicking on the file will open that file in the editor.
 

--- a/source/docs/software/wpilib-overview/importing-eclipse-project.rst
+++ b/source/docs/software/wpilib-overview/importing-eclipse-project.rst
@@ -23,7 +23,7 @@ You'll be presented with the WPILib Eclipse Project Upgrade window. This is simi
 
 Click "Upgrade Project" to begin the upgrade.
 
-The eclipse project will be upgraded and copied into the new project directory. You can then either open the new project immediately (the pop-up shown below should appear in the bottom right) or open it later using the Ctrl-O (or Command-O for Mac) shortcut.
+The eclipse project will be upgraded and copied into the new project directory. You can then either open the new project immediately (the pop-up shown below should appear in the bottom right) or open it later using the Ctrl-O (or Command-O for macOS) shortcut.
 
 |Opening Project|
 

--- a/source/docs/software/wpilib-overview/vscode-basics.rst
+++ b/source/docs/software/wpilib-overview/vscode-basics.rst
@@ -22,7 +22,7 @@ The most important link to take a look at is probably the basic User Interface d
 Command Palette
 ---------------
 
-The Command Palette can be used to access or run almost any function or feature in Visual Studio Code (including those from the WPILib extension). The Command Palette can be accessed from the View menu or by pressing Ctrl+Shift+P (Cmd+Shift+P on Mac). Typing text into the window will dynamically narrow the search to relevant commands and show them in the dropdown.
+The Command Palette can be used to access or run almost any function or feature in Visual Studio Code (including those from the WPILib extension). The Command Palette can be accessed from the View menu or by pressing Ctrl+Shift+P (Cmd+Shift+P on macOS). Typing text into the window will dynamically narrow the search to relevant commands and show them in the dropdown.
 
 In the following example "wpilib" is typed into the search box after activating the Command Palette, and it narrows the list to functions containing WPILib.
 

--- a/source/docs/software/wpilib-tools/path-planning/pathfinder/adding-field-images.rst
+++ b/source/docs/software/wpilib-tools/path-planning/pathfinder/adding-field-images.rst
@@ -4,7 +4,7 @@ Adding field images to PathWeaver
 =================================
 The initial release of PathWeaver contained the field image for the *FRC*\ |reg| 2018 Game. The next update will include *FIRST*\ |reg| Destination Deep Space. Here are instructions for adding the 2019 game now or adding your own field image for some other application.
 
-Games are loaded from the ``~/PathWeaver/Games`` on Linux and Mac or ``%USERPROFILE%/PathWeaver/Games`` directory on Windows. The files can be in either a game-specific subdirectory, or in a zip file in the Games directory. The ZIP file must follow the same layout as a game directory; the JSON file must be in the root of the ZIP file (cannot be in a subdirectory).
+Games are loaded from the ``~/PathWeaver/Games`` on Linux and macOS or ``%USERPROFILE%/PathWeaver/Games`` directory on Windows. The files can be in either a game-specific subdirectory, or in a zip file in the Games directory. The ZIP file must follow the same layout as a game directory; the JSON file must be in the root of the ZIP file (cannot be in a subdirectory).
 
 Download the ready-to-use *FIRST* Destination Deep Space field definition :download:`here <files/DeepSpace.zip>`. Other field definitions are available in the `PathWeaver GitHub repository <https://github.com/wpilibsuite/PathWeaver/tree/master/src/main/resources/edu/wpi/first/pathweaver>`__.
 

--- a/source/docs/software/wpilib-tools/robotbuilder/advanced/robotbuilder-custom-components.rst
+++ b/source/docs/software/wpilib-tools/robotbuilder/advanced/robotbuilder-custom-components.rst
@@ -8,7 +8,7 @@ Custom Component Structure
 
 .. image:: images/custom-components-1.png
 
-Custom components all go in ``$USER_HOME/Robotbuilder/extensions``. On Linux and Mac, ``$USER_HOME`` will be ``/Users/yourusername/``. On Windows, it will be ``C:\Users\yourusername\``
+Custom components all go in ``$USER_HOME/Robotbuilder/extensions``. On Linux and macOS , ``$USER_HOME`` will be ``/Users/yourusername/``. On Windows, it will be ``C:\Users\yourusername\``
 
 There are seven files and one folder that are needed for a custom component. The folder contains the files describing the component and how to export it. It should have the same name as the component (e.g."Kiwi Drive" for a kiwi drive controller, "Robot Drive 6" for a six-motor drive controller, etc.). The files should have the same names and extensions as the ones shown here. Other files can be in the folder along with these seven, but the seven must be present for RobotBuilder to recognize the custom component.
 

--- a/source/docs/software/wpilib-tools/robotbuilder/introduction/starting-robotbuilder.rst
+++ b/source/docs/software/wpilib-tools/robotbuilder/introduction/starting-robotbuilder.rst
@@ -1,12 +1,12 @@
 Starting RobotBuilder
 =====================
 
-.. note:: RobotBuilder is a Java program and as such should be able to run on any platform that is supported by Java. We have been running RobotBuilder on Mac OS X, Windows, and various versions of Linux successfully.
+.. note:: RobotBuilder is a Java program and as such should be able to run on any platform that is supported by Java. We have been running RobotBuilder on macOS, Windows, and various versions of Linux successfully.
 
 Getting RobotBuilder
 --------------------
 
-RobotBuilder is downloaded as part of the WPILib Offline Installer. For more information, see the :ref:`Windows/MacOS/Linux installation guides <docs/getting-started/getting-started-frc-control-system/wpilib-setup:WPILib Installation Guide>`
+RobotBuilder is downloaded as part of the WPILib Offline Installer. For more information, see the :ref:`Windows/macOS/Linux installation guides <docs/getting-started/getting-started-frc-control-system/wpilib-setup:WPILib Installation Guide>`
 
 Option 1 - Starting from Visual Studio Code
 -------------------------------------------
@@ -22,4 +22,4 @@ Option 2 - Running from the Script
 
 The install process installs the tools to ``~/wpilib/YYYY/tools`` (where YYYY is the year and ~ is ``C:\Users\Public on Windows``).
 
-Inside this folder you will find .vbs (Windows) and .py (Mac/Linux) files that you can use to launch each tool. These scripts help launch the tools using the correct JDK and are what you should use to launch the tools.
+Inside this folder you will find .vbs (Windows) and .py (macOS/Linux) files that you can use to launch each tool. These scripts help launch the tools using the correct JDK and are what you should use to launch the tools.

--- a/source/docs/software/wpilib-tools/shuffleboard/getting-started/shuffleboard-tour.rst
+++ b/source/docs/software/wpilib-tools/shuffleboard/getting-started/shuffleboard-tour.rst
@@ -27,7 +27,7 @@ Starting Shuffleboard
 You can start Shuffleboard in one of three ways:
 
 1. You can automatically start it when the Driver Station starts by setting the "Dashboard Type" to Shuffleboard in the settings tab as shown in the picture above.
-2. You can run it by double-clicking on the .jar file in /WPILib/tools/shuffleboard.jar. This is useful on a development system that does not have the Driver Station installed such as a Mac or Linux system.
+2. You can run it by double-clicking on the .jar file in /WPILib/tools/shuffleboard.jar. This is useful on a development system that does not have the Driver Station installed such as a macOS or Linux system.
 3. You can start it from the command line by typing the command: ``java -jar shuffleboard.jar`` from ``home-dir/WPILib/tools`` directory. This is often easiest on a a development system that doesn't have the Driver Station installed.
 
 Getting robot data onto the dashboard


### PR DESCRIPTION
Whenever speaking in context of Apple's computer OS, use the correct stylization and be consistent.

Mac OS, Mac OSX, Mac OS X, Mac, Mac OS, etc. => macOS

Fixes https://github.com/wpilibsuite/frc-docs/issues/274