### PR TITLE
Add scrollbar to the sidebar

### DIFF
--- a/source/_static/css/frc-rtd.css
+++ b/source/_static/css/frc-rtd.css
@@ -84,4 +84,12 @@
 	.header-bar {
 		display: none;
 	}
+
+	.wy-nav-content-wrap {
+		margin-left: 0px;
+	}
+
+	.wy-nav-side {
+		width: 300px;
+	}
 }

--- a/source/_static/css/frc-rtd.css
+++ b/source/_static/css/frc-rtd.css
@@ -1,68 +1,87 @@
 #link-bar a:visited {
-color:#FFF;
+	color: #FFF;
 }
 
 #link-bar li {
-float:left;
-padding:15px;
+	float: left;
+	padding: 15px;
 }
 
 .color-strip {
-height:10px;
-margin:0;
-padding:0;
-position:relative;
-width:100%;
-z-index:999;
+	height: 10px;
+	margin :0;
+	padding: 0;
+	position: relative;
+	width: 100%;
+	z-index: 999;
 }
 
 .color-strip .fblue {
-background:#009cd7;
+	background: #009cd7;
 }
 
 .color-strip .fgreen {
-background:#00a651;
+	background: #00a651;
 }
 
 .color-strip .forange {
-background:#f57e25;
+	background: #f57e25;
 }
 
 .color-strip .fred {
-background:#ed1c24;
+	background: #ed1c24;
 }
 
 .color-strip div {
-display:block;
-float:left;
-height:100%;
-width:25%;
+	display: block;
+	float: left;
+	height: 100%;
+	width: 25%;
 }
 
 .header-bar {
-background:#003974;
-min-height:60px;
+	background: #003974;
+	min-height: 60px;
 }
 
 .link-bar-container {
-margin-left:300px;
+	margin-left: 320px;
 }
 
 .wy-nav-content {
-background:#fcfcfc;
+	background: #fcfcfc;
 }
 
-.wy-nav-content-wrap
-{
-  filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#003974',endColorstr='#003974',GradientType=1);background:#003974;background:-moz-linear-gradient(left,#003974,#6cc2c9,#003974);background:-webkit-gradient(linear,left top,right top,color-stop(0%,#003974),color-stop(50%,#6cc2c9),color-stop(100%,#003974));background:-webkit-linear-gradient(left,#003974,#6cc2c9,#003974);background:-o-linear-gradient(left,#003974,#6cc2c9,#003974);background:-ms-linear-gradient(left,#003974,#6cc2c9,#003974);background:linear-gradient(to right,#003974,#6cc2c9,#003974)
+/* Tweaks to make sidebar scroll look pretty */
+.wy-side-scroll {
+	width: auto;
+	overflow-y: auto;
+	margin-top: 10px;
+}
+
+.wy-nav-side {
+	width: 320px;
+}
+
+.wy-nav-content {
+	max-width: 820px;
+}
+
+.wy-nav-content-wrap {
+	margin-left: 320px;
+}
+
+.wy-nav-content-wrap{
+	filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#003974',endColorstr='#003974',GradientType=1);background:#003974;background:-moz-linear-gradient(left,#003974,#6cc2c9,#003974);background:-webkit-gradient(linear,left top,right top,color-stop(0%,#003974),color-stop(50%,#6cc2c9),color-stop(100%,#003974));background:-webkit-linear-gradient(left,#003974,#6cc2c9,#003974);background:-o-linear-gradient(left,#003974,#6cc2c9,#003974);background:-ms-linear-gradient(left,#003974,#6cc2c9,#003974);background:linear-gradient(to right,#003974,#6cc2c9,#003974)
 }
 
 .wy-nav-side,.wy-side-nav-search,.wy-nav-top {
-background:#003974;
+	background: #003974;
 }
 
+/* Hide color bar on mobile */
 @media screen and (max-width: 768px) {
-.header-bar {
-display:none;
-}
+	.header-bar {
+		display: none;
+	}
 }


### PR DESCRIPTION
Closes #292 
- Refactors the CSS source
- Increases sidebar width by 20px to accommodate the scrollbar (and margins of appropriate elements to adjust for this)
- Adds a small 10px margin above the top of the navigation to account for the colored top bar

![image](https://user-images.githubusercontent.com/10674555/67544620-32ee1f00-f6c4-11e9-8bff-d636bbba01ff.png)
