### PR TITLE
Fix sidebar RTD version selector width

### DIFF
--- a/source/_static/css/frc-rtd.css
+++ b/source/_static/css/frc-rtd.css
@@ -39,6 +39,10 @@
 	width: 25%;
 }
 
+.rst-versions {
+	width: 320px !important;
+}
+
 .header-bar {
 	background: #003974;
 	min-height: 60px;


### PR DESCRIPTION
This
![image](https://user-images.githubusercontent.com/10674555/67891099-4536e580-fb28-11e9-9850-72902d77c01f.png)

becomes
![image](https://user-images.githubusercontent.com/10674555/67891111-4bc55d00-fb28-11e9-8b39-f739a577cf59.png)
