### PR TITLE
Internet Explorer is no longer recommended

### DIFF
--- a/source/docs/networking/networking-introduction/networking-basics.rst
+++ b/source/docs/networking/networking-introduction/networking-basics.rst
@@ -153,7 +153,7 @@ To work properly mDNS must be allowed to pass through your firewall. Because the
 mDNS - Browser support
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Most web-browsers should be able to utilize the mDNS address to access the roboRIO web server as long as an mDNS provider is installed. To access the webdashboard, the browser must also support Microsoft Silverlight. Internet Explorer is recommended.
+Most web-browsers should be able to utilize the mDNS address to access the roboRIO web server as long as an mDNS provider is installed. These browsers include Microsoft Edge, Firefox, and Google Chrome.
 
 USB
 ---


### PR DESCRIPTION
As of 2019, the RoboRio no longer uses Microsoft Silverlight and thus does not require Internet Explorer. Edge, Firefox, and Chrome should be recommended alternatives instead.