### PR TITLE
Add Copperforge LibCu listing 

### DIFF
--- a/source/docs/software/wpilib-overview/3rd-party-libraries.rst
+++ b/source/docs/software/wpilib-overview/3rd-party-libraries.rst
@@ -12,6 +12,8 @@ Libraries
 
 `Analog Devices ADIS16470 IMU <https://github.com/juchong/ADIS16470-roboRIO-Driver>`__ - Driver for ADIS16470 IMU. More info `here <https://wiki.analog.com/first/first_robotics_donation_resources#adis16470_imu_board_for_first_robotics>`__
 
+`Copperforge LibCu Software Library <https://copperforge.cc/docs/software/libcu/>`__ - Library for all Copperforge devices including the Lasershark
+
 `CTRE Phoenix Toolsuite <https://www.ctr-electronics.com/control-system/hro.html#product_tabs_technical_resources>`__ - Contains TalonSRX/Victor SPX Libraries and Phoenix Tuner program for configuring CTRE CAN devices
 
 `Digilent <https://reference.digilentinc.com/dmc-60c/getting-started>`__ - DMC-60C library


### PR DESCRIPTION
Adds LibCu documentation to the list of 3rd-party vendor libraries. Thanks to @ThadHouse for all of the help setting this up.