### PR TITLE
Ubuntu install info for robot characterization

### DIFF
--- a/source/docs/software/wpilib-tools/robot-characterization/introduction.rst
+++ b/source/docs/software/wpilib-tools/robot-characterization/introduction.rst
@@ -98,6 +98,8 @@ To install the Robot Characterization Toolsuite, open a console and enter the fo
 
 The toolsuite, and all of its dependencies, should be automatically downloaded and installed. If you are using a Windows machine and the command pip is not recognized, ensure that your python scripts folder `has been added to the PATH <https://datatofish.com/add-python-to-windows-path/>`__.
 
+If you are on Ubuntu, you will have to manually install tkinter with ``sudo apt-get install python3-tk``. You will also have to use the ``pip3`` command instead of ``pip`` as ``pip`` refers to Python 2 on Ubuntu distributions.
+
 If you already have the toolsuite installed, be sure to update it regularly to benefit from bugfixes and new features additions:
 
 .. code-block:: console

--- a/source/docs/software/wpilib-tools/robot-characterization/introduction.rst
+++ b/source/docs/software/wpilib-tools/robot-characterization/introduction.rst
@@ -98,7 +98,7 @@ To install the Robot Characterization Toolsuite, open a console and enter the fo
 
 The toolsuite, and all of its dependencies, should be automatically downloaded and installed. If you are using a Windows machine and the command pip is not recognized, ensure that your python scripts folder `has been added to the PATH <https://datatofish.com/add-python-to-windows-path/>`__.
 
-If you are on Ubuntu, you will have to manually install tkinter with ``sudo apt-get install python3-tk``. You will also have to use the ``pip3`` command instead of ``pip`` as ``pip`` refers to Python 2 on Ubuntu distributions.
+.. note:: If you are on Ubuntu, you will have to manually install tkinter with ``sudo apt-get install python3-tk``. You will also have to use the ``pip3`` command instead of ``pip`` as ``pip`` refers to Python 2 on Ubuntu distributions.
 
 If you already have the toolsuite installed, be sure to update it regularly to benefit from bugfixes and new features additions:
 


### PR DESCRIPTION
When installing the robot characterization with `pip3 install frc-characterization` on Ubuntu, you also have to install the `python3-tk` package. This PR adds clarification that you have to use the `pip3` command on Ubuntu distributions and that you will also have to manually install `python3-tk`.