### PR TITLE
add warning about phase lag from filtered velocity

### DIFF
--- a/source/docs/software/wpilib-tools/robot-characterization/analyzing-feedback.rst
+++ b/source/docs/software/wpilib-tools/robot-characterization/analyzing-feedback.rst
@@ -1,14 +1,16 @@
 Feedback Analysis
 =================
 
+.. important:: These gains are, in effect, "educated guesses" - they are not guaranteed to be perfect, and should be viewed as a "starting point" for further tuning.
+
+.. warning:: The feedback gain calculation assumes that there is no mechanical backlash, sensor noise, or phase lag in the sensor measurement.  While these are reasonable assumptions in many situations, none of them are strictly true in practice.  In particular, many "smart motor controllers" (such as the ``Talon SRX``, ``Talon FX``, and ``SparkMax``) have default settings that apply substantial :ref:`low-pass filtering <docs/software/advanced-control/filters/introduction:Introduction to Filters>` to their encoder velocity measurements, which introduces a significant amount of phase lag.  This can cause the calculated gains for velocity loops to be unstable.  To rectify this, either decrease the amount of filtering through the controller's API, or reduce the magnitude of the PID gains - it has been found that shrinking gains by about a factor of 10 works well for most default filtering settings.
+
 Once the feedforward coefficients have been computed, the controls on the ``Feedback Analysis`` pane become available.
 
 .. image:: images/feedbackanalysis.png
    :alt: Picture of the feedback analysis pane
 
 These can be used to calculate optimal feedback gains for a PD or P controller for your mechanism (via `LQR <https://en.wikipedia.org/wiki/Linear%E2%80%93quadratic_regulator>`__).
-
-.. important:: These gains are, in effect, "educated guesses" - they are not guaranteed to be perfect, and should be viewed as a "starting point" for further tuning.
 
 Set Units
 ---------


### PR DESCRIPTION
LQR gains have been reported to be too large for velocity loops on smart controllers for ages; after some head-scratching and documentation-searching, this seems to be the likely culprit.