### PR TITLE
Fix SlewRateLimiter C++ example

### DIFF
--- a/source/docs/software/advanced-control/filters/slew-rate-limiter.rst
+++ b/source/docs/software/advanced-control/filters/slew-rate-limiter.rst
@@ -26,7 +26,7 @@ Creating a SlewRateLimiter is simple:
   .. code-tab:: c++
 
     // Creates a SlewRateLimiter that limits the rate of change of the signal to 0.5 volts per second
-    frc::SlewRateLimiter<units::volts> filter = new SlewRateLimiter(0.5_v / 1_s);
+    frc::SlewRateLimiter<units::volts> filter{0.5_v / 1_s};
 
 Using a SlewRateLimiter
 -----------------------


### PR DESCRIPTION
The example allocates a pointer and attempts to assign it to a value,
which doesn't compile. This patch uses a value type instead because it's
more modern style.