### PR TITLE
Specify only one linkcheck worker

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -54,6 +54,7 @@ linkcheck_ignore = [r'.*kauailabs.com.*', r'.*frcvision.local.*']
 # Sets linkcheck timeout in seconds
 linkcheck_timeout = 30
 linkcheck_retries = 3
+linkcheck_workers = 1
 
 # Autosection labels prefix document path and filename
 autosectionlabel_prefix_document = True

--- a/source/docs/contributing/top-contributors.rst
+++ b/source/docs/contributing/top-contributors.rst
@@ -2,4 +2,4 @@ Top Contributors
 ================
 
 .. ghcontributors:: wpilibsuite/frc-docs
-   :limit: 10
+   :limit: 100

--- a/source/docs/contributing/top-contributors.rst
+++ b/source/docs/contributing/top-contributors.rst
@@ -2,4 +2,4 @@ Top Contributors
 ================
 
 .. ghcontributors:: wpilibsuite/frc-docs
-   :limit: 100
+   :limit: 10


### PR DESCRIPTION
Looks like having five threads had us over GitHub's request/second quota.