### PR TITLE
Allow text wrapping in tables

### DIFF
--- a/source/_static/css/frc-rtd.css
+++ b/source/_static/css/frc-rtd.css
@@ -115,6 +115,8 @@
   }
 }
 /* Fix table padding https://github.com/readthedocs/sphinx_rtd_theme/issues/117 */
-.wy-table-responsive table td, .wy-table-responsive table th {
-    white-space: normal !important;
+@media screen and (min-width: 768px) {
+	.wy-table-responsive table td, .wy-table-responsive table th {
+	    white-space: normal !important;
+	}
 }

--- a/source/_static/css/frc-rtd.css
+++ b/source/_static/css/frc-rtd.css
@@ -114,7 +114,7 @@
     left: 320px;
   }
 }
-
-.wy-table-responsive table td,.wy-table-responsive table th {
+/* Fix table padding https://github.com/readthedocs/sphinx_rtd_theme/issues/117 */
+.wy-table-responsive table td, .wy-table-responsive table th {
     white-space: normal !important;
 }

--- a/source/_static/css/frc-rtd.css
+++ b/source/_static/css/frc-rtd.css
@@ -114,3 +114,7 @@
     left: 320px;
   }
 }
+
+.wy-table-responsive table td,.wy-table-responsive table th {
+    white-space: normal !important;
+}


### PR DESCRIPTION
I re-discovered [this sphynx/RTD issue](https://github.com/readthedocs/sphinx_rtd_theme/issues/117) where text in tables is set to `white-space: nowrap` and leads to tables that create horizontal scroll bars. Thus, I added `white-space: normal` to enable all table text to wrap. I also looked through all tables currently in the docs and this change does not seem to affect them, but will make tables added in #200 look better.