### PR TITLE
Add Discord Embed Color

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -50,6 +50,7 @@ ogp_image = "https://raw.githubusercontent.com/wpilibsuite/branding/master/png/w
 # Enables ChiefDelphi support
 ogp_custom_meta_tags = [
     '<meta property="og:ignore_canonical" content="true" />',
+    '<meta name="theme-color" content="#AC2B37" />',
 ]
 
 # Enable hover content on glossary term


### PR DESCRIPTION
Sets the color of the vertical bar that appears to the left of links embedded in Discord.

Current color: #AC2B37 -> The red of the wpilib logo