### PR TITLE
Update Sphinx to 3.1.2

### DIFF
--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,5 +1,5 @@
 sphinx_rtd_theme==0.5.0
-sphinx==3.1.1
+sphinx==3.1.2
 sphinx-tabs==1.1.12
 latex==0.7.0
 doc8==0.8.1


### PR DESCRIPTION
This fixes the weird bullet spacing.
