### PR TITLE
Update notfound extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Documentation Status](https://readthedocs.org/projects/frc-docs/badge/?version=latest)
-![CI](https://github.com/wpilibsuite/frc-docs/workflows/CI/badge.svg))
+![CI](https://github.com/wpilibsuite/frc-docs/workflows/CI/badge.svg)
 
 # frc-docs
 Welcome to frc-docs! This repository contains the various source articles for the frc-docs website. frc-docs is licensed under Creative Commons, with assets such as the FIRST logo under trademark and copyright of [FIRST](https://www.firstinspires.org/).

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -5,7 +5,7 @@ latex==0.7.0
 doc8==0.8.1
 sphinxcontrib-remoteliteralinclude==0.0.4
 sphinxcontrib-ghcontributors==0.2.2
-sphinx-notfound-page==0.4
+sphinx-notfound-page==0.5
 sphinxcontrib-svg2pdfconverter==1.1.0
 sphinx-hoverxref==0.5b1
 sphinxext-opengraph==0.3.0


### PR DESCRIPTION
Silences a warning that was caused from wrong import.

See https://github.com/readthedocs/sphinx-notfound-page/pull/82

Additionally, removes an extra ")" in the README