### PR TITLE
Fix Battery and Trajectory Links

### DIFF
--- a/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
@@ -196,7 +196,7 @@ Robot Battery
 .. image:: images/control-system-hardware/robot-battery.png
   :width: 500
 
-The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__.
+The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the datasheet for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__.
 
 .. note:: Other battery part numbers may be legal, consult the `FRC Manual <https://www.firstinspires.org/resource-library/frc/competition-manual-qa-system>`__ for a complete list.
 

--- a/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
@@ -196,7 +196,7 @@ Robot Battery
 .. image:: images/control-system-hardware/robot-battery.png
   :width: 500
 
-The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__ and `Enersys NP18-12 <https://www.enersys.com/WorkArea/DownloadAsset.aspx?id=488>`__.
+The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__ and `Enersys NP18-12 <http://www.farnell.com/datasheets/1821790.pdf>`__.
 
 .. note:: Other battery part numbers may be legal, consult the `FRC Manual <https://www.firstinspires.org/resource-library/frc/competition-manual-qa-system>`__ for a complete list.
 

--- a/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
@@ -196,7 +196,7 @@ Robot Battery
 .. image:: images/control-system-hardware/robot-battery.png
   :width: 500
 
-The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__ and `Enersys NP18-12 <https://www.mkbattery.com/application/files/7015/7375/4449/ES17-12.pdf>`__.
+The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__ and `Enersys NP18-12 <http://www.farnell.com/datasheets/1821790.pdf>`__.
 
 .. note:: Other battery part numbers may be legal, consult the `FRC Manual <https://www.firstinspires.org/resource-library/frc/competition-manual-qa-system>`__ for a complete list.
 

--- a/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
@@ -196,7 +196,7 @@ Robot Battery
 .. image:: images/control-system-hardware/robot-battery.png
   :width: 500
 
-The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__ and `Enersys NP18-12 <http://www.farnell.com/datasheets/1821790.pdf>`__.
+The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__.
 
 .. note:: Other battery part numbers may be legal, consult the `FRC Manual <https://www.firstinspires.org/resource-library/frc/competition-manual-qa-system>`__ for a complete list.
 

--- a/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/control-system-hardware.rst
@@ -196,7 +196,7 @@ Robot Battery
 .. image:: images/control-system-hardware/robot-battery.png
   :width: 500
 
-The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__ and `Enersys NP18-12 <http://www.farnell.com/datasheets/1821790.pdf>`__.
+The power supply for an FRC robot is a single 12V 18Ah battery. The batteries used for FRC are sealed lead acid batteries capable of meeting the high current demands of an FRC robot. For more information, see the Datasheets for the `MK ES17-12 <https://www.mkbattery.com/application/files/2515/3308/8109/ES17-12.pdf>`__ and `Enersys NP18-12 <https://www.mkbattery.com/application/files/7015/7375/4449/ES17-12.pdf>`__.
 
 .. note:: Other battery part numbers may be legal, consult the `FRC Manual <https://www.firstinspires.org/resource-library/frc/competition-manual-qa-system>`__ for a complete list.
 

--- a/source/docs/software/advanced-controls/trajectories/constraints.rst
+++ b/source/docs/software/advanced-controls/trajectories/constraints.rst
@@ -55,4 +55,4 @@ Users can create their own constraint by implementing the ``TrajectoryConstraint
 
 The ``MaxVelocity`` method should return the maximum allowed velocity for the given pose, curvature, and original velocity of the trajectory without any constraints. The ``MinMaxAcceleration`` method should return the minimum and maximum allowed acceleration for the given pose, curvature, and constrained velocity.
 
-See the source code (`Java <https://github.com/wpilibsuite/allwpilib/tree/master/wpilibj/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint>`_, `C++ <https://github.com/wpilibsuite/allwpilib/tree/master/wpilibc/src/main/native/cpp/trajectory/constraint>`_) for the WPILib-provided constraints for more examples on how to write your own custom trajectory constraints.
+See the source code (`Java <https://github.com/wpilibsuite/allwpilib/tree/master/wpimath/src/main/java/edu/wpi/first/wpilibj/trajectory/constraint>`_, `C++ <https://github.com/wpilibsuite/allwpilib/tree/master/wpimath/src/main/native/cpp/trajectory/constraint>`_) for the WPILib-provided constraints for more examples on how to write your own custom trajectory constraints.


### PR DESCRIPTION
https://github.com/wpilibsuite/allwpilib/pull/2629 broke some links

Additionally, looks like the battery PDF host was taken down.