### PR TITLE
Make check-spelling formatting fit with the rest of the CI checks

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -81,7 +81,6 @@ jobs:
       run: |
         make sizecheck
   check-spelling:
-    name: Check Spelling
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Get rid of the specified name "Check Spelling" for the check-spelling check to match the other checks.