### PR TITLE
Update Rediraffe to 0.2.3

### DIFF
--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -11,4 +11,4 @@ sphinx-hoverxref==0.5b1
 sphinxext-opengraph==0.3.0
 sphinxext-toptranslators==0.1.1
 sphinxext-linkcheckdiff==0.1.0
-sphinxext-rediraffe==0.2.1
+sphinxext-rediraffe==0.2.3


### PR DESCRIPTION
Prevents local rebuilds from failing due to conflicting redirects