### PR TITLE
Exclude Units Docs Temporarily

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -80,7 +80,11 @@ todo_include_todos = False
 linkcheck_anchors = False
 
 # Linkcheck Exclusions
-linkcheck_ignore = [r'.*kauailabs.com.*', r'.*frcvision.local.*', r'.*andymark.com.*']
+# Units excluded, tracking https://github.com/wpilibsuite/frc-docs/issues/834
+linkcheck_ignore = [r'.*kauailabs.com.*',
+                    r'.*frcvision.local.*',
+                    r'.*andymark.com.*',
+                    r'.*http://nholthaus.github.io/units/.*']
 
 # Sets linkcheck timeout in seconds
 linkcheck_timeout = 30


### PR DESCRIPTION
Chosen to exclude Units instead of replacing the URL as no suitable replacements are available, I'd prefer a broken link with a tracking issue over replacing the URL with an outdated or unofficial source.

Tracking: https://github.com/wpilibsuite/frc-docs/issues/834