### PR TITLE
Use consistent file extension formatting

### DIFF
--- a/source/docs/contributing/frc-docs/style-guide.rst
+++ b/source/docs/contributing/frc-docs/style-guide.rst
@@ -191,6 +191,23 @@ For the specifics of saving a diagram as a ``.svg`` with metadata, take a look a
 
 .. warning:: Make sure you don't modify any file that is in a ``diagrams`` folder, or ends in ``.drawio.svg`` in any program other than draw.io, otherwise you might risk breaking the metadata of the file, making it uneditable.
 
+File Extensions
+---------------
+
+File extensions should use code formatting. For example, use:
+
+.. code-block:: text
+
+   ``.png``
+
+instead of:
+
+.. code-block:: text
+
+   .png
+   ".png"
+   "``.png``"
+
 Table of Contents (TOC)
 -----------------------
 

--- a/source/docs/getting-started/getting-started-frc-control-system/control-system-software.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/control-system-software.rst
@@ -29,7 +29,7 @@ Visual Studio Code
 
 .. image:: images/control-system-software/visual-studio-code.png
 
-Visual Studio Code is the supported development environment for C++ and Java, two of the three supported languages used for programming an FRC robot. Both are object-oriented text based programming languages. A program in C++ (for FRC) consists of a number of header (.h) and implementation (.cpp) files where as a program in Java consists of .java files contained in one or more packages. A guide to getting started with C++ for FRC, including the installation and configuration of Visual Studio Code can be found :doc:`here <offline-installation-preparations>`.
+Visual Studio Code is the supported development environment for C++ and Java, two of the three supported languages used for programming an FRC robot. Both are object-oriented text based programming languages. A program in C++ (for FRC) consists of a number of header (.h) and implementation (.cpp) files where as a program in Java consists of ``.java`` files contained in one or more packages. A guide to getting started with C++ for FRC, including the installation and configuration of Visual Studio Code can be found :doc:`here <offline-installation-preparations>`.
 
 FRC Driver Station Powered by NI LabVIEW (Windows Only)
 -------------------------------------------------------

--- a/source/docs/getting-started/getting-started-frc-control-system/wpilib-setup.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/wpilib-setup.rst
@@ -90,8 +90,8 @@ WPILib Installation Guide
           :alt:
 
       Unzip and untar the file by looking at the file in the explorer and
-      double-clicking on it, once or twice to unzip (remove the .gz extension)
-      and again to untar it (remove the .tar extension). When finished it
+      double-clicking on it, once or twice to unzip (remove the ``.gz`` extension)
+      and again to untar it (remove the ``.tar`` extension). When finished it
       should look like the folder shown below.
 
       .. figure:: images/mac/UntarredRelease.png
@@ -206,9 +206,9 @@ WPILib Installation Guide
 
     **Installing Visual Studio Code**
 
-      1. Download the Linux .deb file from `code.visualstudio.com <https://code.visualstudio.com/>`__. For 2020, the recommended version is 1.41.1 which can be directly downloaded here:  `https://update.code.visualstudio.com/1.41.1/linux-deb-x64/stable <https://update.code.visualstudio.com/1.41.1/linux-deb-x64/stable>`__
+      1. Download the Linux ``.deb`` file from `code.visualstudio.com <https://code.visualstudio.com/>`__. For 2020, the recommended version is 1.41.1 which can be directly downloaded here:  `https://update.code.visualstudio.com/1.41.1/linux-deb-x64/stable <https://update.code.visualstudio.com/1.41.1/linux-deb-x64/stable>`__
 
-      2. Double-click on the .deb file in the file explorer
+      2. Double-click on the ``.deb`` file in the file explorer
       3. Click the "Install" button to install VS Code
 
       .. figure:: images/linux/install-vscode.png

--- a/source/docs/software/basic-programming/git-getting-started.rst
+++ b/source/docs/software/basic-programming/git-getting-started.rst
@@ -226,9 +226,9 @@ Updating a Fork
 Gitignore
 ---------
 
-.. important:: It is extremely important that teams **do not** modify the .gitignore file that is included with their robot project. This can lead to offline deployment not working.
+.. important:: It is extremely important that teams **do not** modify the ``.gitignore`` file that is included with their robot project. This can lead to offline deployment not working.
 
-A .gitignore file is commonly used as a list of files to not automatically commit with ``git add``. Any files or directory listed in this file will **not** be committed. They will also not show up with `git status <https://git-scm.com/docs/git-status>`_.
+A ``.gitignore`` file is commonly used as a list of files to not automatically commit with ``git add``. Any files or directory listed in this file will **not** be committed. They will also not show up with `git status <https://git-scm.com/docs/git-status>`_.
 
 Additional Information can be found `here <https://www.atlassian.com/git/tutorials/saving-changes/gitignore>`__
 

--- a/source/docs/software/driverstation/imaging-your-classmate.rst
+++ b/source/docs/software/driverstation/imaging-your-classmate.rst
@@ -86,7 +86,7 @@ Copy Files Dialog
 
 .. image:: images/imaging-your-classmate/copy-files-dialog.png
 
-Choose “No” and select your .7z image
+Choose “No” and select your ``.7z`` image
 
 Prepare Drive
 ^^^^^^^^^^^^^

--- a/source/docs/software/examples-tutorials/machine-learning/how-it-works.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/how-it-works.rst
@@ -18,7 +18,7 @@ Data
 
 Images should be labeled in Supervisely. They should be downloaded as ``jpeg + json``, in a tar file. When the user calls ``estimator.fit("s3://bucket")``, SageMaker automatically downloads the content of that folder/bucket to ``/opt/ml/input/data/training`` inside of the training instance.
 
-The tar is converted to the 2 records and ``.pbtxt`` used by the retraining script by the ``tar_to_record.sh`` script. It automatically finds the ONLY tar in the specified folder and extracts it. It then uses ``json_to_csv.py`` to convert the jsons to 2 large csv files. ``generate_tfrecord.py`` converts the csv files into .record files. Finally, the ``meta.json`` file is parsed by ``parse_meta.py`` to create the ``.pbtxt`` file, which is a label map.
+The tar is converted to the 2 records and ``.pbtxt`` used by the retraining script by the ``tar_to_record.sh`` script. It automatically finds the ONLY tar in the specified folder and extracts it. It then uses ``json_to_csv.py`` to convert the jsons to 2 large csv files. ``generate_tfrecord.py`` converts the csv files into ``.record`` files. Finally, the ``meta.json`` file is parsed by ``parse_meta.py`` to create the ``.pbtxt`` file, which is a label map.
 
 Hyperparameters
 ---------------

--- a/source/docs/software/vision-processing/frcvision/the-raspberry-pi-frc-console.rst
+++ b/source/docs/software/vision-processing/frcvision/the-raspberry-pi-frc-console.rst
@@ -118,7 +118,7 @@ The running application can be changed by selecting one of the choices in the dr
 -   Custom application which doesn't upload anything to the rPi and assumes that the developer wants to have a custom program
     and script.
 -   Java, C++ or Python pre-installed sample programs that can be edited into your own application.
--   Java, C++, or Python uploaded program. Java programs require a .jar file with the compiled program and C++ programs require
+-   Java, C++, or Python uploaded program. Java programs require a ``.jar`` file with the compiled program and C++ programs require
     an rPi executable to be uploaded to the rPI.
 
 .. figure:: images/the-raspberry-pi-frc-console/application-2.png

--- a/source/docs/software/wpilib-tools/robotbuilder/advanced/robotbuilder-custom-components.rst
+++ b/source/docs/software/wpilib-tools/robotbuilder/advanced/robotbuilder-custom-components.rst
@@ -158,6 +158,6 @@ The sections of the palette (these are case sensitive):
 icon.png
 --------
 
-The icon that shows up in the palette and the help page. This should be a 64x64 .png file.
+The icon that shows up in the palette and the help page. This should be a 64x64 ``.png`` file.
 
-It should use the color scheme and general style of the section it's in to avoid visual clutter, but this is entirely optional. Photoshop .psd files of the icons and backgrounds are in `src/main/icons/icons <https://github.com/wpilibsuite/RobotBuilder/tree/master/src/main/icons/icons>`_ and png files of the icons and backgrounds are in `src/main/resources/icons <https://github.com/wpilibsuite/RobotBuilder/tree/master/src/main/resources/icons>`_.
+It should use the color scheme and general style of the section it's in to avoid visual clutter, but this is entirely optional. Photoshop ``.psd`` files of the icons and backgrounds are in `src/main/icons/icons <https://github.com/wpilibsuite/RobotBuilder/tree/master/src/main/icons/icons>`_ and png files of the icons and backgrounds are in `src/main/resources/icons <https://github.com/wpilibsuite/RobotBuilder/tree/master/src/main/resources/icons>`_.

--- a/source/docs/software/wpilib-tools/robotbuilder/introduction/starting-robotbuilder.rst
+++ b/source/docs/software/wpilib-tools/robotbuilder/introduction/starting-robotbuilder.rst
@@ -22,4 +22,4 @@ Option 2 - Running from the Script
 
 The install process installs the tools to ``~/wpilib/YYYY/tools`` (where YYYY is the year and ~ is ``C:\Users\Public`` on Windows).
 
-Inside this folder you will find .vbs (Windows) and .py (macOS/Linux) files that you can use to launch each tool. These scripts help launch the tools using the correct JDK and are what you should use to launch the tools.
+Inside this folder you will find ``.vbs`` (Windows) and ``.py`` (macOS/Linux) files that you can use to launch each tool. These scripts help launch the tools using the correct JDK and are what you should use to launch the tools.

--- a/source/docs/software/wpilib-tools/shuffleboard/custom-widgets/creating-plugins.rst
+++ b/source/docs/software/wpilib-tools/shuffleboard/custom-widgets/creating-plugins.rst
@@ -92,7 +92,7 @@ By running ``gradle deployPlugin`` from the command line, the jar file will auto
 Manually Adding Plugin
 ----------------------
 The other way to add a plugin to Shuffleboard is to compile it to a jar file and add it from Shuffleboard.
-First, compile your plugin into a .jar file using Maven or Gradle. Then, open Shuffleboard, click on the file tab in the top left, and choose Plugins from the drop down menu.
+First, compile your plugin into a ``.jar`` file using Maven or Gradle. Then, open Shuffleboard, click on the file tab in the top left, and choose Plugins from the drop down menu.
 
 .. image:: images/loading-plugin.png
 

--- a/source/docs/software/wpilib-tools/shuffleboard/getting-started/shuffleboard-tour.rst
+++ b/source/docs/software/wpilib-tools/shuffleboard/getting-started/shuffleboard-tour.rst
@@ -28,10 +28,10 @@ You can start Shuffleboard in one of four ways:
 
 1. You can automatically start it when the Driver Station starts by setting the "Dashboard Type" to Shuffleboard in the settings tab as shown in the picture above.
 2. You can run it by double-clicking the Shuffleboard icon on the Windows Desktop.
-3. You can run it by double-clicking on the shuffleboard.XXX file (where XXX is vbs on Windows and .py on Linux or macOS) in ``~/WPILib/YYYY/tools/`` (where YYYY is the year and ~ is ``C:\Users\Public`` on Windows). This is useful on a development system that does not have the Driver Station installed such as a macOS or Linux system.
+3. You can run it by double-clicking on the shuffleboard.XXX file (where XXX is ``.vbs`` on Windows and ``.py`` on Linux or macOS) in ``~/WPILib/YYYY/tools/`` (where YYYY is the year and ~ is ``C:\Users\Public`` on Windows). This is useful on a development system that does not have the Driver Station installed such as a macOS or Linux system.
 4. You can start it from the command line by typing the command: ``shuffleboard`` on Windows or ``python shuffleboard.py`` on macOS or Linux from ``~/WPILib/YYYY/tools`` directory (where YYYY is the year and ~ is ``C:\Users\Public`` on Windows). This is often easiest on a a development system that doesn't have the Driver Station installed.
 
-.. note:: The .vbs (Windows) and .py (macOS/Linux) scripts help launch the tools using the correct JDK.
+.. note:: The ``.vbs`` (Windows) and ``.py`` (macOS/Linux) scripts help launch the tools using the correct JDK.
 
 Getting robot data onto the dashboard
 -------------------------------------


### PR DESCRIPTION
Closes #848

I ran `grep -Ern '(^|\s+|")\.[a-zA-Z0-9]+(\s+|$|")' --include=\*.rst *` to find all matches (ignoring some false-positives) that didn't comply to the agreed-upon standard and fixed them.