### PR TITLE
Correct `note` admonition in PCM docs

### DIFF
--- a/source/docs/getting-started/getting-started-frc-control-system/how-to-wire-a-robot.rst
+++ b/source/docs/getting-started/getting-started-frc-control-system/how-to-wire-a-robot.rst
@@ -209,7 +209,7 @@ Pneumatics Control Module Power (Optional)
 
 Requires: Wire stripper, small flat screwdriver (optional), 18AWG red and black wire
 
-..note: The PCM is an optional component used for controlling pneumatics on the robot.
+.. note: The PCM is an optional component used for controlling pneumatics on the robot.
 
 1. Strip ~5/16" on the end of the red and black 18AWG wire.
 2. Connect the wire to one of the two terminal pairs labeled "Vbat VRM PCM PWR" on the PDP.


### PR DESCRIPTION
the source file had `..note` instead of `.. note`, causing the admonition to not be rendered - see https://docs.wpilib.org/en/latest/docs/getting-started/getting-started-frc-control-system/how-to-wire-a-robot.html#pneumatics-control-module-power-optional