### PR TITLE
Add 24px margin-bottom to images in tabs

### DIFF
--- a/source/_static/css/frc-rtd.css
+++ b/source/_static/css/frc-rtd.css
@@ -120,3 +120,10 @@
 	    white-space: normal !important;
 	}
 }
+
+/* ===================================== */
+/* ====== START SPHINX TABS CSS ======== */
+
+.sphinx-tab img {
+	margin-bottom: 24px;
+}


### PR DESCRIPTION
Before 
![image](https://user-images.githubusercontent.com/10674555/95416046-c9304a80-08ff-11eb-868e-2f275253af32.png)

After

![image](https://user-images.githubusercontent.com/10674555/95416085-e6651900-08ff-11eb-804f-a9d9d8dbe161.png)


Tracking Issue: https://github.com/executablebooks/sphinx-tabs/issues/93
