### PR TITLE
Remove Redundancy in root TOC

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -22,7 +22,7 @@ Welcome to the *FIRST*\ |reg| Robotics Competition Control System Documentation!
 
 .. toctree::
    :maxdepth: 1
-   :caption: WPILib Programming Basics
+   :caption: Programming Basics
 
    docs/software/what-is-wpilib
    docs/2020-overview/index
@@ -43,7 +43,7 @@ Welcome to the *FIRST*\ |reg| Robotics Competition Control System Documentation!
 
 .. toctree::
    :maxdepth: 1
-   :caption: WPILib Software Tools
+   :caption: Software Tools
 
    docs/software/driverstation/index
    docs/software/wpilib-tools/shuffleboard/index
@@ -55,7 +55,7 @@ Welcome to the *FIRST*\ |reg| Robotics Competition Control System Documentation!
 
 .. toctree::
    :maxdepth: 1
-   :caption: WPILib Advanced Programming
+   :caption: Advanced Programming
 
    docs/software/vision-processing/index
    docs/software/commandbased/index
@@ -67,14 +67,14 @@ Welcome to the *FIRST*\ |reg| Robotics Competition Control System Documentation!
 
 .. toctree::
    :maxdepth: 1
-   :caption: WPILib Examples and Tutorials
+   :caption: Examples and Tutorials
 
    docs/software/examples-tutorials/wpilib-examples
    docs/software/examples-tutorials/trajectory-tutorial/index
 
 .. toctree::
    :maxdepth: 1
-   :caption: WPILib Hardware
+   :caption: Hardware
 
    docs/hardware/hardware-basics/index
    docs/hardware/hardware-tutorials/index


### PR DESCRIPTION
This PR removes the redundant "WPILib" in many of the root TOC captions. This isn't necessary as the LabVIEW section is quite clearly defined. It doesn't break any existing links and is fairly cheap.

Also, this fixes some line overflow due to translations being quite verbose.