### PR TITLE
Replace master with main in Git articles

### DIFF
--- a/source/docs/software/basic-programming/git-getting-started.rst
+++ b/source/docs/software/basic-programming/git-getting-started.rst
@@ -107,11 +107,11 @@ If a directory is empty, a file needs to be created in order for git to have som
          > echo "# ExampleRepo" >> README.md
          > git add README.md
          > git commit -m "First commit"
-         [master (root-commit) fafafa] First commit
+         [main (root-commit) fafafa] First commit
           1 file changed, 1 insertions(+), 0 deletions(-)
           create mode 100644 README.md
          > git remote add origin https://github.com/ExampleUser9007/ExampleRepo.git
-         > git push -u origin master
+         > git push -u origin main
 
    .. tab:: Existing Project
 
@@ -122,11 +122,11 @@ If a directory is empty, a file needs to be created in order for git to have som
          Initialized empty Git repository in C:/Users/ExampleUser9007/Documents/Example Folder/.git/
          > git add .
          > git commit -m "First commit"
-         [master (root-commit) fafafa] First commit
+         [main (root-commit) fafafa] First commit
           1 file changed, 1 insertions(+), 0 deletions(-)
           create mode 100644 README.md
          > git remote add origin https://github.com/ExampleUser9007/ExampleRepo.git
-         > git push -u origin master
+         > git push -u origin main
 
 Commits
 -------
@@ -139,7 +139,7 @@ In the previous example, we created a file called README.md. Open that file in y
 
     > git add README.md
     > git commit -m "Adds a description to the repository"
-    [master bcbcbc] Adds a description to the repository
+    [main bcbcbc] Adds a description to the repository
      1 file changed, 2 insertions(+), 0 deletions(-)
     > git push
 
@@ -183,7 +183,7 @@ Branches are a similar to parallel worlds to Git. They start off the same, and t
 
 .. image:: diagrams/branches.drawio.svg
 
-In the above example, Master was branched (or duplicated) into the branch Feature 1 and someone checked out the branch, creating a local copy. Then, someone committed (or uploaded) their changes, merging them into the branch Feature 1. You are "merging" the changes from one branch into another.
+In the above example, main was branched (or duplicated) into the branch Feature 1 and someone checked out the branch, creating a local copy. Then, someone committed (or uploaded) their changes, merging them into the branch Feature 1. You are "merging" the changes from one branch into another.
 
 Creating a Branch
 ^^^^^^^^^^^^^^^^^

--- a/source/docs/software/basic-programming/robot-code-ci.rst
+++ b/source/docs/software/basic-programming/robot-code-ci.rst
@@ -1,7 +1,7 @@
 Setting up CI for Robot Code using GitHub Actions
 =================================================
 
-An important aspect of working in a team environment is being able to test code that is pushed to a central repository such as GitHub. For example, a project manager or lead developer might want to run a set of unit tests before merging a pull request or might want to ensure that all code on the master branch of a repository is in working order.
+An important aspect of working in a team environment is being able to test code that is pushed to a central repository such as GitHub. For example, a project manager or lead developer might want to run a set of unit tests before merging a pull request or might want to ensure that all code on the main branch of a repository is in working order.
 
 `GitHub Actions <https://github.com/features/actions>`_ is a service that allows for teams and individuals to build and run unit tests on code on various branches and on pull requests. These types of services are more commonly known as "Continuous Integration" services. This tutorial will show you how to setup GitHub Actions on robot code projects.
 
@@ -22,12 +22,12 @@ You will now be greeted with a text editor. Replace all the default text with th
     name: CI
 
     # Controls when the action will run. Triggers the workflow on push or pull request
-    # events but only for the master branch.
+    # events but only for the main branch.
     on:
       push:
-        branches: [ master ]
+        branches: [ main ]
       pull_request:
-        branches: [ master ]
+        branches: [ main ]
 
     # A workflow run is made up of one or more jobs that can run sequentially or in parallel
     jobs:
@@ -57,7 +57,7 @@ Then, save changes by clicking the "Start commit" button on the top-right corner
 .. image:: images/robot-ci/image2.png
 
 
-GitHub will now automatically run a build whenever a commit is pushed to master or a pull request is opened. To monitor the status of any build, you can click on the "Actions" tab on the top of the screen.
+GitHub will now automatically run a build whenever a commit is pushed to main or a pull request is opened. To monitor the status of any build, you can click on the "Actions" tab on the top of the screen.
 
 .. image:: images/robot-ci/image3.png
 
@@ -68,14 +68,14 @@ Here is a breakdown of the YAML file above. Although a strict understanding of e
 .. code-block:: yaml
 
     # Controls when the action will run. Triggers the workflow on push or pull request
-    # events but only for the master branch.
+    # events but only for the main branch.
     on:
       push:
-        branches: [ master ]
+        branches: [ main ]
       pull_request:
-        branches: [ master ]
+        branches: [ main ]
 
-This block of code dictates when the Action will run. Currently, the action will run when commits are pushed to master or when pull requests are opened against master.
+This block of code dictates when the Action will run. Currently, the action will run when commits are pushed to main or when pull requests are opened against main.
 
 .. code-block:: yaml
 
@@ -112,7 +112,7 @@ Each job has certain steps that will be executed. This job has three steps. The 
 
 Adding a Build Status Badge to a README.md File
 -----------------------------------------------
-It is helpful to add a CI status badge to the top of your repository's README file to quickly check the status of the latest build on master. To do this, click on the "Actions" tab at the top of the screen and select the "CI" tab on the left side of the screen. Then, click on the "Create status badge" button on the top right and copy the status badge Markdown code.
+It is helpful to add a CI status badge to the top of your repository's README file to quickly check the status of the latest build on main. To do this, click on the "Actions" tab at the top of the screen and select the "CI" tab on the left side of the screen. Then, click on the "Create status badge" button on the top right and copy the status badge Markdown code.
 
 .. image:: images/robot-ci/image4.png
 


### PR DESCRIPTION
Git articles are the only occurrences of the word `master` besides links to other repositories. The links should be changed when we migrate to `main` on all our repos.