### PR TITLE
Update miktex-packages.txt

### DIFF
--- a/miktex-packages.txt
+++ b/miktex-packages.txt
@@ -120,7 +120,7 @@ miktex-devnag-bin-x64-2.9
 miktex-dict-english
 miktex-dict-french
 miktex-dict-german
-miktex-doc-2.9
+miktex-doc
 miktex-dvicopy-bin-x64-2.9
 miktex-dvipdfmx
 miktex-dvipdfmx-bin-x64-2.9
@@ -188,7 +188,7 @@ miktex-ps2pk-bin-x64-2.9
 miktex-psutils-bin-x64-2.9
 miktex-qt5-bin-x64
 miktex-runtime-bin-x64-2.9
-miktex-tdsutil-bin-x64-2.9
+miktex-tdsutil-bin-x64
 miktex-teckit-bin-x64-2.9
 miktex-tex
 miktex-tex-bin-x64-2.9


### PR DESCRIPTION
Just set up frc-docs on a new machine and MikTex barfed on the reqs file on these two packages. Looking at the list here it looks like the -2.9 was removed from the names at some point?
https://miktex.org/pkg/az

Adjusting the file per this commit allowed the mpm command to run properly.