### PR TITLE
Improve PathWeaver JSON import docs

### DIFF
--- a/source/docs/software/wpilib-tools/pathweaver/integrating-robot-program.rst
+++ b/source/docs/software/wpilib-tools/pathweaver/integrating-robot-program.rst
@@ -12,9 +12,10 @@ The ``fromPathweaverJson`` (Java) / ``FromPathweaverJson`` (C++) static methods 
    .. code-tab:: java
 
       String trajectoryJSON = "paths/YourPath.wpilib.json";
+      Trajectory trajectory = new Trajectory();
       try {
         Path trajectoryPath = Filesystem.getDeployDirectory().toPath().resolve(trajectoryJSON);
-        Trajectory trajectory = TrajectoryUtil.fromPathweaverJson(trajectoryPath);
+        trajectory = TrajectoryUtil.fromPathweaverJson(trajectoryPath);
       } catch (IOException ex) {
         DriverStation.reportError("Unable to open trajectory: " + trajectoryJSON, ex.getStackTrace());
       }
@@ -32,3 +33,5 @@ The ``fromPathweaverJson`` (Java) / ``FromPathweaverJson`` (C++) static methods 
        wpi::sys::path::append(deployDirectory, "YourPath.wpilib.json");
 
        frc::Trajectory trajectory = frc::TrajectoryUtil::FromPathweaverJson(deployDirectory);
+
+.. note:: In the examples above, ``YourPath`` should be replaced with the name of your path.


### PR DESCRIPTION
This changes the Java code to declare the trajectory outside of the try-catch block and clarifies that YourPath should be replaced with the actual name of the path