### PR TITLE
Update Offline Preparation

### DIFF
--- a/source/docs/zero-to-robot/step-2/index.rst
+++ b/source/docs/zero-to-robot/step-2/index.rst
@@ -7,8 +7,8 @@ Step 2: Installing Software
    :maxdepth: 1
 
    control-system-software
-   labview-setup
    offline-installation-preparations
+   labview-setup
    frc-game-tools
    imaging-your-roborio
    radio-programming

--- a/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
+++ b/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
@@ -27,12 +27,12 @@ LabVIEW Teams
 
 -  LabVIEW USB (from *FIRST*\ |reg| Choice) or `Download <https://www.ni.com/en-us/support/downloads/drivers/download.labview-software-for-frc.html>`__ (Note: Click on link for "Individual Offline Installers")
 
-C++/Java Teams
+Java/C++ Teams
 ^^^^^^^^^^^^^^
 
--  `C++/Java WPILib Installer <https://github.com/wpilibsuite/allwpilib/releases>`__
+-  `Java/C++ WPILib Installer <https://github.com/wpilibsuite/allwpilib/releases>`__
 
-.. note:: After downloading the C++/Java WPILib installer, run it once while connected to the internet and download VS Code for all platforms and save the downloaded VS Code zip file for future offline installations.
+.. note:: After downloading the Java/C++ WPILib installer, run it once while connected to the internet and download VS Code for all platforms and save the downloaded VS Code zip file for future offline installations.
 
 3rd Party Libraries/Software
 ----------------------------

--- a/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
+++ b/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
@@ -5,6 +5,8 @@ Offline Installation Preparation
 
 This article contains instructions/links to components you will want to gather if you need to do offline installation of the FRC\ |reg| Control System software.
 
+.. tip:: This document compiles all the download links from the following documents to make it easier to install on offline computers or on multiple computers. If you are you installing on a single computer that is connected to the internet, you can skip this page.
+
 Documentation
 -------------
 
@@ -29,6 +31,8 @@ C++/Java Teams
 ^^^^^^^^^^^^^^
 
 -  `C++/Java WPILib Installer <https://github.com/wpilibsuite/allwpilib/releases>`__
+
+.. note:: After downloading the C++/Java WPILib installer, run it once while connected to the internet and download VS Code for all platforms and save the downloaded VS Code zip file for future offline installations.
 
 3rd Party Libraries/Software
 ----------------------------

--- a/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
+++ b/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
@@ -29,11 +29,8 @@ C++/Java Teams
 ^^^^^^^^^^^^^^
 
 -  `C++/Java WPILib Installer <https://github.com/wpilibsuite/allwpilib/releases>`__
--  Visual Studio Code (if using Windows, run the installer and use it to download the appropriate VS Code file. If using macOS/Linux, download Visual Studio Code from `here <https://code.visualstudio.com/download>`__)
 
 3rd Party Libraries/Software
 ----------------------------
-
-A number of software components were broken out of WPILib in 2017 and are now maintained by third parties. See `this blog <https://www.firstinspires.org/robotics/frc/blog/2017-control-system-update>`__ for more details.
 
 A directory of available 3rd party software that plugs in to WPILib can be found on :ref:`docs/software/vscode-overview/3rd-party-libraries:3rd Party Libraries`.


### PR DESCRIPTION
Remove outdated information about downloading VS Code
Clean up 3rd party information since they change was 4 years ago
Move offline installation higher in TOC