### PR TITLE
Fix code formatting error

### DIFF
--- a/source/docs/software/actuators/addressable-leds.rst
+++ b/source/docs/software/actuators/addressable-leds.rst
@@ -41,7 +41,7 @@ After the length of the strip has been set, you'll have to create an ``Addressab
 Setting the Entire Strip to One Color
 -------------------------------------
 
-Color can be set to an individual led on the strip using two methods.``setRGB`` which takes RGB values as an input and ``setHSV()`` which takes HSV values as an input.
+Color can be set to an individual led on the strip using two methods. ``setRGB()`` which takes RGB values as an input and ``setHSV()`` which takes HSV values as an input.
 
 Using RGB Values
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
https://docs.wpilib.org/en/latest/docs/software/actuators/addressable-leds.html#setting-the-entire-strip-to-one-color
```
``setRGB``
```
Isn't formatted correctly