### PR TITLE
Add template lag to troubleshooting

### DIFF
--- a/source/docs/software/wpilib-tools/robot-characterization/characterization-routine.rst
+++ b/source/docs/software/wpilib-tools/robot-characterization/characterization-routine.rst
@@ -74,3 +74,5 @@ After all four tests have been completed, the :guilabel:`Save Data` button will 
    :alt: Saving the test data
 
 This will save the data as a JSON file with the specified location/name. A timestamp (``%Y%m%d-%H%M``) will be appended to the chosen filename if the :guilabel:`Add Timestamp` button is checked.
+
+.. note:: You can run a preliminary check on the quality of the characterization data by enabling prints on Driver Station. After exiting autonmous in each test, the console should output ``Collected : n in t seconds`` where ``n`` should be ``200 * t`` (rounded). More information can be found :ref:`here <docs/software/wpilib-tools/robot-characterization/viewing-diagnostics:Template Lag>`

--- a/source/docs/software/wpilib-tools/robot-characterization/viewing-diagnostics.rst
+++ b/source/docs/software/wpilib-tools/robot-characterization/viewing-diagnostics.rst
@@ -20,7 +20,7 @@ The vertical "mirroring" visible here is normal, and is simply the result of the
 
 The quasistatic test ought to have nearly linear velocity, and nearly-zero acceleration (hense "quasistatic"). The dynamic test ought to have velocity that asymptotically approaches a steady-state speed (the shape of the curve should be exponential, in fact), and acceleration that, accordingly, rapidly falls to zero (also exponentially, as the derivative of an exponential function is also an exponential function).
 
-Deviation from this behavior is a sign of an :ref:`error <docs/software/wpilib-tools/robot-characterization/viewing-diagnostics:Diagnostics Plots for Common Failure Modes>`, either in your robot setup, analysis settings, or your test procedure.
+Deviation from this behavior is a sign of an :ref:`error <docs/software/wpilib-tools/robot-characterization/viewing-diagnostics:Common Failure Modes>`, either in your robot setup, analysis settings, or your test procedure.
 
 Voltage-Domain Diagnostics
 --------------------------
@@ -51,10 +51,10 @@ This plot is interactive, and may be rotated by clicking-and-dragging. The quasi
 
 The discontinuity corresponds to ``kS``, which always opposes the direction of motion and thus changes direction as the plot crosses the 0 velocity mark.
 
-Diagnostics Plots for Common Failure Modes
-------------------------------------------
+Common Failure Modes
+^^^^^^^^^^^^^^^^^^^^
 
-When something has gone wrong with the characterization, the diagnostic plots provide crucial clues as to *what* has gone wrong.  This section describes some common failures encountered while running the characterization tool, the identifying features of their diagnostic plots, and the steps that can be taken to fix them.
+When something has gone wrong with the characterization, diagnostic plots and console output provide crucial clues as to *what* has gone wrong.  This section describes some common failures encountered while running the characterization tool, the identifying features of their diagnostic plots, and the steps that can be taken to fix them.
 
 Improperly Set Motion Threshold
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -99,3 +99,10 @@ Magnetic Encoders Velocity Noise
 Magnetic encoders such as the `CTRE Mag Encoder <http://www.ctr-electronics.com/srx-magnetic-encoder.html>`__ and the `AndyMark magnetic encoder <https://www.andymark.com/products/am-mag-encoder>`__ are extremely popular in FRC.  However, a particular noise pattern has been observed when these encoders are used on robot drives, whose particular cause is not yet known.  This noise pattern is uniquely distinguished by significant velocity noise proportional to motor velocity, and is particularly common on the kit-of-parts `toughbox mini <https://www.andymark.com/products/toughbox-mini-options>`__ gearboxes.
 
 Characterization constants can sometimes be accurately determined even from data polluted this noise by increasing the accel window size setting.  However, this sort of encoder noise is problematic for robot code much the same way it is problematic for the characterization tool.  As the root cause of the noise is not known, it is recommended to try a different encoder setup if this is observed, either by moving the encoders to a different shaft or replacing them with a different type of encoder.
+
+Template Lag
+^^^^^^^^^^^^
+
+With the new characterization tool, the logging code might not be able to keep up with its 5 ms refresh rate thus causing faulty data to be collected.
+
+To see if this is the case, enable print statements on the Driver Station whenever running the data logger. When Autonomous mode is exited, the console will output ``Collected : n in t seconds`` where ``n`` is the number of samples and ``t`` is the time elapsed. If the sampling was successful, ``n`` should equal ``200t`` (rounded).


### PR DESCRIPTION
The current FRC-Char template prints the number of data samples collected and the time spent collecting after exiting autonomous. This just adds some troubleshooting options that can be done utilizing this feature.