### PR TITLE
Revert "Add encoder noise bug to known issues doc"

### DIFF
--- a/source/docs/yearly-overview/known-issues.rst
+++ b/source/docs/yearly-overview/known-issues.rst
@@ -8,12 +8,6 @@ This article details known issues (and workarounds) for FRC\ |reg| Control Syste
 Open Issues
 -----------
 
-No Encoder Noise for Certain Simulation Classes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-**Issue:** The position getters for certain simulation classes (``ElevatorSim`` in C++, ``SingleJointedArmSim`` in C++ and Java) will not add measurement noise as configured in the constructor.
-
-**Workaround:** Use the ``getOutput(0)`` (Java) / ``GetOutput(0)`` (C++) method on the simulation class instead.
-
 Chinese characters in Driver Station Log
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Reverts wpilibsuite/frc-docs#1058
Fixed in https://github.com/wpilibsuite/allwpilib/pull/3043