### PR TITLE
Fix websocket link in yearly changelog

### DIFF
--- a/source/docs/yearly-overview/yearly-changelog.rst
+++ b/source/docs/yearly-overview/yearly-changelog.rst
@@ -10,7 +10,7 @@ A number of improvements have been made to FRC\ |reg| Control System software fo
 Major Features
 --------------
 
-- A hardware-level `WebSocket interface <https://github.com/wpilibsuite/allwpilib/blob/v2021.1.1/simulation/halsim_ws_core/doc/hardware_ws_api.md>` has been added to allow remote access to robot code being simulated in a desktop environment.
+- A hardware-level `WebSocket interface <https://github.com/wpilibsuite/allwpilib/blob/v2021.1.1/simulation/halsim_ws_core/doc/hardware_ws_api.md>`_ has been added to allow remote access to robot code being simulated in a desktop environment.
 
 - Support for the :doc:`Romi </docs/romi-robot/index>` robot platform. Romi robot code runs in the desktop simulator environment and talks to the Romi via the new WebSocket interface.
 


### PR DESCRIPTION
Fix link to websockets, https://github.com/wpilibsuite/allwpilib/blob/v2021.1.1/simulation/halsim_ws_core/doc/hardware_ws_api.md in the yearly changelog (https://docs.wpilib.org/en/stable/docs/yearly-overview/yearly-changelog.html)