### PR TITLE
Add LabVIEW Version Notes

### DIFF
--- a/source/docs/zero-to-robot/step-2/frc-game-tools.rst
+++ b/source/docs/zero-to-robot/step-2/frc-game-tools.rst
@@ -19,7 +19,7 @@ Requirements
 - Windows 7 or higher (Windows 7, 8, 8.1, 10). Windows 10 is the recommended OS.
 - Download the FRC Game Tools from `NI <https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html>`__.
 
-.. note:: The dropdown on this page will still say 2020 because the software is still based on LabVIEW for FRC 2020, this will still download the 2021 installer with the 2021 DS and roboRIO image versions.
+.. note:: The dropdown on this page will say 2020 because the software is still based on LabVIEW for FRC 2020, this will download the 2021 installer with the 2021 DS and roboRIO image versions.
 
 .. image:: images/labview/offline-installer.png
 

--- a/source/docs/zero-to-robot/step-2/frc-game-tools.rst
+++ b/source/docs/zero-to-robot/step-2/frc-game-tools.rst
@@ -16,6 +16,8 @@ The LabVIEW runtime components required for the Driver Station and Utilities are
 Requirements
 ------------
 
+.. warning:: The 2021 FRC Game Tools are not yet available (as of 1/6/21), they are expected to be available on the afternoon of 1/7 at the link indicated below.
+
 - Windows 7 or higher (Windows 7, 8, 8.1, 10). Windows 10 is the recommended OS.
 - Download the FRC Game Tools from `NI <https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html>`__.
 

--- a/source/docs/zero-to-robot/step-2/frc-game-tools.rst
+++ b/source/docs/zero-to-robot/step-2/frc-game-tools.rst
@@ -19,6 +19,8 @@ Requirements
 - Windows 7 or higher (Windows 7, 8, 8.1, 10). Windows 10 is the recommended OS.
 - Download the FRC Game Tools from `NI <https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html>`__.
 
+.. note:: The dropdown on this page will still say 2020 because the software is still based on LabVIEW for FRC 2020, this will still download the 2021 installer with the 2021 DS and roboRIO image versions.
+
 .. image:: images/labview/offline-installer.png
 
 If you wish to install on other machines offline, click :guilabel:`Individual Offline Installers` before clicking :guilabel:`Download` to download the full installer.

--- a/source/docs/zero-to-robot/step-2/frc-game-tools.rst
+++ b/source/docs/zero-to-robot/step-2/frc-game-tools.rst
@@ -19,8 +19,6 @@ Requirements
 - Windows 7 or higher (Windows 7, 8, 8.1, 10). Windows 10 is the recommended OS.
 - Download the FRC Game Tools from `NI <https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html>`__.
 
-.. note:: The dropdown on this page will say 2020 because the software is still based on LabVIEW for FRC 2020, this will download the 2021 installer with the 2021 DS and roboRIO image versions.
-
 .. image:: images/labview/offline-installer.png
 
 If you wish to install on other machines offline, click :guilabel:`Individual Offline Installers` before clicking :guilabel:`Download` to download the full installer.

--- a/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
+++ b/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
@@ -17,6 +17,7 @@ Installers
 
 All Teams
 ^^^^^^^^^
+.. warning:: The 2021 FRC Game Tools are not yet available (as of 1/6/21), they are expected to be available on the afternoon of 1/7 at the link indicated below.
 
 -  `2021 FRC Game Tools <https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html>`__ (Note: Click on link for "Individual Offline Installers")
 -  `2020 FRC Radio Configuration Utility <https://firstfrc.blob.core.windows.net/frc2020/Radio/FRC_Radio_Configuration_20_0_0.zip>`__ or `2020 FRC Radio Configuration Utility Israel Version <https://firstfrc.blob.core.windows.net/frc2020/Radio/FRC_Radio_Configuration_20_0_0_IL.zip>`__

--- a/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
+++ b/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
@@ -18,11 +18,10 @@ Installers
 All Teams
 ^^^^^^^^^
 
--  `2020 FRC Game Tools <https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html>`__ (Note: Click on link for "Individual Offline Installers")
+-  `2021 FRC Game Tools <https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html>`__ (Note: Click on link for "Individual Offline Installers")
 -  `2020 FRC Radio Configuration Utility <https://firstfrc.blob.core.windows.net/frc2020/Radio/FRC_Radio_Configuration_20_0_0.zip>`__ or `2020 FRC Radio Configuration Utility Israel Version <https://firstfrc.blob.core.windows.net/frc2020/Radio/FRC_Radio_Configuration_20_0_0_IL.zip>`__
 -  (Optional - Veterans Only!) `Classmate/Acer PC Image <https://frc-events.firstinspires.org/services/DSImages/>`__
 
-.. note:: The dropdown on the Game Tools page will say 2020 because the software is still based on LabVIEW for FRC 2020, this will download the 2021 installer with the 2021 DS and roboRIO image versions.
 .. note:: There are no changes to the radio tool for the 2021 season so the 20.0.0 version remains the latest available.
 
 LabVIEW Teams

--- a/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
+++ b/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
@@ -22,15 +22,15 @@ All Teams
 -  `2020 FRC Radio Configuration Utility <https://firstfrc.blob.core.windows.net/frc2020/Radio/FRC_Radio_Configuration_20_0_0.zip>`__ or `2020 FRC Radio Configuration Utility Israel Version <https://firstfrc.blob.core.windows.net/frc2020/Radio/FRC_Radio_Configuration_20_0_0_IL.zip>`__
 -  (Optional - Veterans Only!) `Classmate/Acer PC Image <https://frc-events.firstinspires.org/services/DSImages/>`__
 
-.. note:: The dropdown on the Game Tools page will still say 2020 because the software is still based on LabVIEW for FRC 2020, this will still download the 2021 installer with the 2021 DS and roboRIO image versions.
-.. note:: There are no changes to the radio tool for the 2021 season so the 20.0.0 version is still the latest available.
+.. note:: The dropdown on the Game Tools page will say 2020 because the software is still based on LabVIEW for FRC 2020, this will download the 2021 installer with the 2021 DS and roboRIO image versions.
+.. note:: There are no changes to the radio tool for the 2021 season so the 20.0.0 version remains the latest available.
 
 LabVIEW Teams
 ^^^^^^^^^^^^^
 
 -  LabVIEW USB (from *FIRST*\ |reg| Choice) or `Download <https://www.ni.com/en-us/support/downloads/drivers/download.labview-software-for-frc.html>`__ (Note: Click on link for "Individual Offline Installers")
 
-.. note:: The dropdown on this page will still say 2020 because the software is still based on LabVIEW for FRC 2020, the 2021 version is identical to what was used in 2020. If you already have the 2020 version installed see :ref:`docs/yearly-overview/relicensing-labview:Re-licensing LabVIEW for 2021 Season` for info on re-licensing your installation.
+.. note:: The dropdown on this page will say 2020 because the 2021 base LabVIEW version is identical to what was used in 2020. If you already have the 2020 version installed see :ref:`docs/yearly-overview/relicensing-labview:Re-licensing LabVIEW for 2021 Season` for info on re-licensing your installation.
 
 Java/C++ Teams
 ^^^^^^^^^^^^^^

--- a/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
+++ b/source/docs/zero-to-robot/step-2/offline-installation-preparations.rst
@@ -22,12 +22,15 @@ All Teams
 -  `2020 FRC Radio Configuration Utility <https://firstfrc.blob.core.windows.net/frc2020/Radio/FRC_Radio_Configuration_20_0_0.zip>`__ or `2020 FRC Radio Configuration Utility Israel Version <https://firstfrc.blob.core.windows.net/frc2020/Radio/FRC_Radio_Configuration_20_0_0_IL.zip>`__
 -  (Optional - Veterans Only!) `Classmate/Acer PC Image <https://frc-events.firstinspires.org/services/DSImages/>`__
 
+.. note:: The dropdown on the Game Tools page will still say 2020 because the software is still based on LabVIEW for FRC 2020, this will still download the 2021 installer with the 2021 DS and roboRIO image versions.
 .. note:: There are no changes to the radio tool for the 2021 season so the 20.0.0 version is still the latest available.
 
 LabVIEW Teams
 ^^^^^^^^^^^^^
 
 -  LabVIEW USB (from *FIRST*\ |reg| Choice) or `Download <https://www.ni.com/en-us/support/downloads/drivers/download.labview-software-for-frc.html>`__ (Note: Click on link for "Individual Offline Installers")
+
+.. note:: The dropdown on this page will still say 2020 because the software is still based on LabVIEW for FRC 2020, the 2021 version is identical to what was used in 2020. If you already have the 2020 version installed see :ref:`docs/yearly-overview/relicensing-labview:Re-licensing LabVIEW for 2021 Season` for info on re-licensing your installation.
 
 Java/C++ Teams
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
Add notes indicating that 2021 software is available even though dropdowns still say 2020.

Should not be merged until 2021 LV software is actually posted.