### PR TITLE
Add danger notice at the top of ML docs

### DIFF
--- a/source/docs/software/examples-tutorials/machine-learning/adding-more-data.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/adding-more-data.rst
@@ -3,7 +3,7 @@
 Adding More Data
 ================
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 These steps detail how to record a new video, upload it to Supervisely, and label the frames. You can skip this article if you want to use the WPILib dataset directly.
 

--- a/source/docs/software/examples-tutorials/machine-learning/adding-more-data.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/adding-more-data.rst
@@ -3,6 +3,8 @@
 Adding More Data
 ================
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 These steps detail how to record a new video, upload it to Supervisely, and label the frames. You can skip this article if you want to use the WPILib dataset directly.
 
 .. note:: If you cannot access Supervisely, you can use the WPILib dataset directly in later steps.

--- a/source/docs/software/examples-tutorials/machine-learning/how-it-works.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/how-it-works.rst
@@ -3,7 +3,7 @@
 How it Works
 ============
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 Dockerfile
 ----------

--- a/source/docs/software/examples-tutorials/machine-learning/how-it-works.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/how-it-works.rst
@@ -3,6 +3,8 @@
 How it Works
 ============
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 Dockerfile
 ----------
 

--- a/source/docs/software/examples-tutorials/machine-learning/index.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/index.rst
@@ -3,7 +3,7 @@
 Machine Learning
 ================
 
-.. Warning:: We are aware that you will get an exception while trying to train your model with the Jupyter notebook. The WPILib team and Amazon are working hard on a solution and hope to have something in the next few days. Until we do, you will not be able to train your models. We will post the status here as it changes, so please check back often. We are very sorry that this issue occurred and hope to get it resolved as quickly as possible.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
 
 This technology experiment is a way for teams to automatically detect game pieces and other interesting objects with machine learning. It uses Amazon Web Services to train and test, so teams do not need to own especially powerful computers.
 

--- a/source/docs/software/examples-tutorials/machine-learning/index.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/index.rst
@@ -3,7 +3,7 @@
 Machine Learning
 ================
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 This technology experiment is a way for teams to automatically detect game pieces and other interesting objects with machine learning. It uses Amazon Web Services to train and test, so teams do not need to own especially powerful computers.
 

--- a/source/docs/software/examples-tutorials/machine-learning/inference.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/inference.rst
@@ -3,6 +3,8 @@
 Inference
 =========
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 Inference with the Google Coral
 
 1. Acquire a Raspberry Pi 3 or newer, and a `Google Coral USB Accelerator <https://www.amazon.com/dp/B07S214S5Y>`__.

--- a/source/docs/software/examples-tutorials/machine-learning/inference.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/inference.rst
@@ -3,7 +3,7 @@
 Inference
 =========
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 Inference with the Google Coral
 

--- a/source/docs/software/examples-tutorials/machine-learning/setting-up-the-data.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/setting-up-the-data.rst
@@ -3,6 +3,8 @@
 Setting Up the Data
 ====================
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 Machine learning works by "learning" the important features of objects by evaluating thousands of pictures. The pictures have boxes drawn around the important objects such as game pieces. Each kind of object to be detected is called a class. WPILib provides a pre-labeled dataset. You can also add additional images to the provided dataset, but you will need to label them.
 
 Getting Data

--- a/source/docs/software/examples-tutorials/machine-learning/setting-up-the-data.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/setting-up-the-data.rst
@@ -3,7 +3,7 @@
 Setting Up the Data
 ====================
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 Machine learning works by "learning" the important features of objects by evaluating thousands of pictures. The pictures have boxes drawn around the important objects such as game pieces. Each kind of object to be detected is called a class. WPILib provides a pre-labeled dataset. You can also add additional images to the provided dataset, but you will need to label them.
 

--- a/source/docs/software/examples-tutorials/machine-learning/testing.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/testing.rst
@@ -3,7 +3,7 @@
 Testing
 =======
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 These steps are for testing your model in SageMaker, before you load it onto your Raspberry Pi with Google Coral. It will use your model to annotate a video, and output the video for you to view. This is useful if you think you may have under or over fitted, or if you think you may not have enough data to develop a strong model.
 

--- a/source/docs/software/examples-tutorials/machine-learning/testing.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/testing.rst
@@ -3,6 +3,8 @@
 Testing
 =======
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 These steps are for testing your model in SageMaker, before you load it onto your Raspberry Pi with Google Coral. It will use your model to annotate a video, and output the video for you to view. This is useful if you think you may have under or over fitted, or if you think you may not have enough data to develop a strong model.
 
 .. note:: You can skip these steps if you would like to not test your model.

--- a/source/docs/software/examples-tutorials/machine-learning/training.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/training.rst
@@ -3,6 +3,8 @@
 Training
 ========
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 Training on AWS with the provided dataset should take about 2 hours and cost roughly $1. If you add more images or add new labeling classes the cost and time will be higher.
 
 Train with AWS

--- a/source/docs/software/examples-tutorials/machine-learning/training.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/training.rst
@@ -3,7 +3,7 @@
 Training
 ========
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 Training on AWS with the provided dataset should take about 2 hours and cost roughly $1. If you add more images or add new labeling classes the cost and time will be higher.
 

--- a/source/docs/software/examples-tutorials/machine-learning/understanding-precision.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/understanding-precision.rst
@@ -3,7 +3,7 @@
 Understanding Precision
 =======================
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 With a lot of ML projects accuracy is fairly straightforward. But when doing object detection, there are a lot of nuances once you start to think about it.  I will give you a quick overview of what goes into the calculations and what we are reporting.  There are a lot of good articles that go into the subject deeper if you get interested.
 

--- a/source/docs/software/examples-tutorials/machine-learning/understanding-precision.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/understanding-precision.rst
@@ -3,6 +3,8 @@
 Understanding Precision
 =======================
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 With a lot of ML projects accuracy is fairly straightforward. But when doing object detection, there are a lot of nuances once you start to think about it.  I will give you a quick overview of what goes into the calculations and what we are reporting.  There are a lot of good articles that go into the subject deeper if you get interested.
 
 Some terms to start with.

--- a/source/docs/software/examples-tutorials/machine-learning/uploading-data-to-aws-s3.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/uploading-data-to-aws-s3.rst
@@ -3,6 +3,8 @@
 Uploading the Data to AWS S3
 ============================
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 Amazon Web Services (AWS) S3 is Amazon's cloud storage service. You must upload your dataset to S3 in order to use for training with Amazon servers.
 
 .. note:: If you can not access Supervisely, you can skip all of these steps.

--- a/source/docs/software/examples-tutorials/machine-learning/uploading-data-to-aws-s3.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/uploading-data-to-aws-s3.rst
@@ -3,7 +3,7 @@
 Uploading the Data to AWS S3
 ============================
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 Amazon Web Services (AWS) S3 is Amazon's cloud storage service. You must upload your dataset to S3 in order to use for training with Amazon servers.
 

--- a/source/docs/software/examples-tutorials/machine-learning/using-inference-output.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/using-inference-output.rst
@@ -3,7 +3,7 @@
 Using Inference Output
 ======================
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 The Raspberry Pi writes all detection information to NetworkTables, which can be used by your robot code. Below is a Java example for parsing and using this data.
 

--- a/source/docs/software/examples-tutorials/machine-learning/using-inference-output.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/using-inference-output.rst
@@ -3,6 +3,8 @@
 Using Inference Output
 ======================
 
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 The Raspberry Pi writes all detection information to NetworkTables, which can be used by your robot code. Below is a Java example for parsing and using this data.
 
 **NetworkTables Format**

--- a/source/docs/software/examples-tutorials/machine-learning/video-walkthrough.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/video-walkthrough.rst
@@ -1,5 +1,8 @@
 A Video Walkthrough of Machine Learning
 =======================================
+
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+
 At the "RSN Spring Conference, Presented by WPI" in 2020, Brad Miller, Austin Shalit, Frank Grossman, and Grant Perkins from the WPILib team gave a presentation on Machine Learning in FRC.
 
 .. raw:: html

--- a/source/docs/software/examples-tutorials/machine-learning/video-walkthrough.rst
+++ b/source/docs/software/examples-tutorials/machine-learning/video-walkthrough.rst
@@ -1,7 +1,7 @@
 A Video Walkthrough of Machine Learning
 =======================================
 
-.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://www.tensorflow.org/tutorials>`__ solution in the meantime.
+.. danger:: Unfortunately, this documentation is outdated and the methods described here are no longer functional. We are currently working on an a successor project and advise teams to research into a `tensorflow <https://coral.ai/docs/edgetpu/retrain-detection/>`__ solution in the meantime.
 
 At the "RSN Spring Conference, Presented by WPI" in 2020, Brad Miller, Austin Shalit, Frank Grossman, and Grant Perkins from the WPILib team gave a presentation on Machine Learning in FRC.
 


### PR DESCRIPTION
Current ML solution does not work. The INFINITERECHARGEATHOME manual [links](https://firstfrc.blob.core.windows.net/frc2021/Manual/AtHomeChallengesSupplements/2021INFINITERECHARGEatHome-Guides.pdf) to this. This PR adds a danger notice to the top of each ML page advising users to invest in a tensorflow solution until [Axon](https://github.com/wpilibsuite/axon) is stable and documented.