### PR TITLE
Invert GetY() of controllers where necessary as "up" is -Y not +Y

### DIFF
--- a/source/docs/software/actuators/wpi-drive-classes.rst
+++ b/source/docs/software/actuators/wpi-drive-classes.rst
@@ -196,26 +196,26 @@ Like Arcade Drive, the Curvature Drive mode is used to control the drivetrain us
 
         public void teleopPeriodic() {
             // Tank drive with a given left and right rates
-            myDrive.tankDrive(leftStick.getY(), rightStick.getY());
+            myDrive.tankDrive(-leftStick.getY(), -rightStick.getY());
 
             // Arcade drive with a given forward and turn rate
-            myDrive.arcadeDrive(driveStick.getY(),driveStick.getX());
+            myDrive.arcadeDrive(-driveStick.getY(), driveStick.getX());
 
             // Curvature drive with a given forward and turn rate, as well as a quick-turn button
-            myDrive.curvatureDrive(driveStick.getY(), driveStick.getX(), driveStick.getButton(1));
+            myDrive.curvatureDrive(-driveStick.getY(), driveStick.getX(), driveStick.getButton(1));
         }
 
     .. code-tab:: c++
 
         void TeleopPeriodic() override {
             // Tank drive with a given left and right rates
-            myDrive.TankDrive(leftStick.GetY(), rightStick.GetY());
+            myDrive.TankDrive(-leftStick.GetY(), -rightStick.GetY());
 
             // Arcade drive with a given forward and turn rate
-            myDrive.ArcadeDrive(driveStick.GetY(), driveStick.GetX());
+            myDrive.ArcadeDrive(-driveStick.GetY(), driveStick.GetX());
 
             // Curvature drive with a given forward and turn rate, as well as a quick-turn button
-            myDrive.CurvatureDrive(driveStick.GetY(), driveStick.GetX(), driveStick.GetButton(1));
+            myDrive.CurvatureDrive(-driveStick.GetY(), driveStick.GetX(), driveStick.GetButton(1));
         }
 
 Using the MecanumDrive class to control Mecanum Drive robots
@@ -257,15 +257,15 @@ The MecanumDrive class contains two different default modes of driving your robo
     .. code-tab:: java
 
         public void teleopPeriodic() {
-            m_robotDrive.driveCartesian(m_stick.getX(), m_stick.getY(), m_stick.getZ());
-            m_robotDrive.drivePolar(m_stick.getX(), m_stick.getY(), m_stick.getZ());
+            m_robotDrive.driveCartesian(m_stick.getX(), -m_stick.getY(), m_stick.getZ());
+            m_robotDrive.drivePolar(m_stick.getX(), -m_stick.getY(), m_stick.getZ());
         }
 
     .. code-tab:: c++
 
         void TeleopPeriodic() override {
-            m_robotDrive.driveCartesian(m_stick.GetX(), m_stick.GetY(), m_stick.GetZ());
-            m_robotDrive.drivePolar(m_stick.GetX(), m_stick.GetY(), m_stick.GetZ());
+            m_robotDrive.driveCartesian(m_stick.GetX(), -m_stick.GetY(), m_stick.GetZ());
+            m_robotDrive.drivePolar(m_stick.GetX(), -m_stick.GetY(), m_stick.GetZ());
         }
 
 Field-Oriented Driving

--- a/source/docs/software/commandbased/convenience-features.rst
+++ b/source/docs/software/commandbased/convenience-features.rst
@@ -141,7 +141,7 @@ The ``RunCommand`` class (`Java <https://first.wpi.edu/wpilib/allwpilib/docs/rel
     // A split-stick arcade command, with forward/backward controlled by the left
     // hand, and turning controlled by the right.
     new RunCommand(() -> m_robotDrive.arcadeDrive(
-        driverController.getY(GenericHID.Hand.kLeft),
+        -driverController.getY(GenericHID.Hand.kLeft),
         driverController.getX(GenericHID.Hand.kRight)),
         m_robotDrive)
 
@@ -152,7 +152,7 @@ The ``RunCommand`` class (`Java <https://first.wpi.edu/wpilib/allwpilib/docs/rel
     frc2::RunCommand(
       [this] {
         m_drive.ArcadeDrive(
-            m_driverController.GetY(frc::GenericHID::kLeftHand),
+            -m_driverController.GetY(frc::GenericHID::kLeftHand),
             m_driverController.GetX(frc::GenericHID::kRightHand));
       },
       {&m_drive}))


### PR DESCRIPTION
This does not fix any of the `remoteliteralinclude` examples yet (these will need to be fixed by updating the examples within allwpilib and then bumping the include versions later).

This should probably be sanity checked by people with real robots (I can't do that).