### PR TITLE
CTRE links update

### DIFF
--- a/source/docs/software/actuators/using-motor-controllers.rst
+++ b/source/docs/software/actuators/using-motor-controllers.rst
@@ -44,4 +44,4 @@ For information regarding the SPARK MAX CAN Motor Controller, which can be used 
 CTRE CAN Motor Controllers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Please refer to the third party CTRE documentation on the Phoenix software for more detailed information. The documentation is available `here. <https://phoenix-documentation.readthedocs.io/en/latest/>`_
+Please refer to the third party CTRE documentation on the Phoenix software for more detailed information. The documentation is available `here. <https://docs.ctre-phoenix.com/>`_

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -15,33 +15,49 @@ A list of common third-party CAN devices from various vendors, along with links 
 Cross-the-Road Electronics
 --------------------------
 
-Cross-the-Road Electronics (CTRE) offers several CAN peripherals with external libraries:
+Cross-the-Road Electronics (CTRE) offers several CAN peripherals with external libraries. Documentation for the accompanying software (Phoenix Framework) can be found `here <https://docs.ctre-phoenix.com/>`__.
 
 CTRE Motor Controllers
 ^^^^^^^^^^^^^^^^^^^^^^
 
+- **Talon FX (with Falcon 500 Motor)**
+
+    - API Documentation (`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_f_x.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_f_x.html>`__)
+    - `Hardware Manual <http://www.ctr-electronics.com/downloads/pdf/Falcon%20500%20User%20Guide.pdf>`__
+    - `Other Resources <https://www.ctr-electronics.com/talon-fx.html#product_tabs_technical_resources>`__
+
 - **Talon SRX**
 
     - API Documentation (`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_s_r_x.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_s_r_x.html>`__)
-    - `Technical Manual <https://www.ctr-electronics.com/Talon%20SRX%20User's%20Guide.pdf>`__
+    - `Hardware Manual <https://www.ctr-electronics.com/Talon%20SRX%20User's%20Guide.pdf>`__
+    - `Other Resources <https://www.ctr-electronics.com/talon-srx.html#product_tabs_technical_resources>`__
 
 - **Victor SPX**
 
     - API Documentation (`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_victor_s_p_x.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_victor_s_p_x.html>`__)
-    - `Technical Manual <https://www.ctr-electronics.com/downloads/pdf/Victor%20SPX%20User's%20Guide.pdf>`__
+    - `Hardware Manual <https://www.ctr-electronics.com/downloads/pdf/Victor%20SPX%20User's%20Guide.pdf>`__
+    - `Other Resources <https://www.ctr-electronics.com/victor-spx.html#product_tabs_technical_resources>`__
 
 CTRE Sensors
 ^^^^^^^^^^^^
 
+- **CANcoder**
+
+    - API Documentation(`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1sensors_1_1_c_a_n_coder.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1sensors_1_1_c_a_n_coder.html>`__)
+    - `Hardware Manual <https://www.ctr-electronics.com/downloads/pdf/CANCoder%20User's%20Guide.pdf>`__
+    - `Other Resources <https://www.ctr-electronics.com/cancoder.html#product_tabs_technical_resources>`__
+
 - **Pigeon IMU**
 
     - API Documentation(`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1sensors_1_1_pigeon_i_m_u.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1sensors_1_1_pigeon_i_m_u.html>`__)
-    - `Technical Manual <https://www.ctr-electronics.com/downloads/pdf/Pigeon%20IMU%20User's%20Guide.pdf>`__
+    - `Hardware Manual <https://www.ctr-electronics.com/downloads/pdf/Pigeon%20IMU%20User's%20Guide.pdf>`__
+    - `Other Resources <https://www.ctr-electronics.com/gadgeteer-imu-module-pigeon.html#product_tabs_technical_resources>`__
 
 - **CANifier**
 
     - API Documentation (`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1_c_a_nifier.html#ad9a05fae7065d3f39f7bc8a86f15b0a1>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1_c_a_nifier.html#a706308fce1dea96785bf3ac845bafc02>`__)
-    - `Technical Manual <https://www.ctr-electronics.com/downloads/pdf/CANifier%20User's%20Guide.pdf>`__
+    - `Hardware Manual <https://www.ctr-electronics.com/downloads/pdf/CANifier%20User's%20Guide.pdf>`__
+    - `Other Resources <https://www.ctr-electronics.com/can-can-canifier-driver-led-driver-gpio.html#product_tabs_technical_resources>`__
 
 REV Robotics
 ------------

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -15,7 +15,11 @@ A list of common third-party CAN devices from various vendors, along with links 
 Cross-the-Road Electronics
 --------------------------
 
-Cross-the-Road Electronics (CTRE) offers several CAN peripherals with external libraries. Documentation for the accompanying software (Phoenix Framework) can be found `here <https://docs.ctre-phoenix.com/>`__.
+Cross-the-Road Electronics (CTRE) offers several CAN peripherals with external libraries. General resources for all CTRE devices include: 
+
+- `Phoenix Device Software Documentation <https://docs.ctre-phoenix.com/>`__ 
+
+- `Phoenix Device Software Examples <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages>`__ 
 
 CTRE Motor Controllers
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -23,19 +27,19 @@ CTRE Motor Controllers
 - **Talon FX (with Falcon 500 Motor)**
 
     - API Documentation (`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_f_x.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_f_x.html>`__)
-    - `Hardware Manual <http://www.ctr-electronics.com/downloads/pdf/Falcon%20500%20User%20Guide.pdf>`__
+    - `Hardware User's Manual <http://www.ctr-electronics.com/downloads/pdf/Falcon%20500%20User%20Guide.pdf>`__
     - `Other Resources <https://www.ctr-electronics.com/talon-fx.html#product_tabs_technical_resources>`__
 
 - **Talon SRX**
 
     - API Documentation (`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_s_r_x.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_s_r_x.html>`__)
-    - `Hardware Manual <https://www.ctr-electronics.com/Talon%20SRX%20User's%20Guide.pdf>`__
+    - `Hardware User's Manual <https://www.ctr-electronics.com/Talon%20SRX%20User's%20Guide.pdf>`__
     - `Other Resources <https://www.ctr-electronics.com/talon-srx.html#product_tabs_technical_resources>`__
 
 - **Victor SPX**
 
     - API Documentation (`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_victor_s_p_x.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_victor_s_p_x.html>`__)
-    - `Hardware Manual <https://www.ctr-electronics.com/downloads/pdf/Victor%20SPX%20User's%20Guide.pdf>`__
+    - `Hardware User's Manual <https://www.ctr-electronics.com/downloads/pdf/Victor%20SPX%20User's%20Guide.pdf>`__
     - `Other Resources <https://www.ctr-electronics.com/victor-spx.html#product_tabs_technical_resources>`__
 
 CTRE Sensors
@@ -44,19 +48,19 @@ CTRE Sensors
 - **CANcoder**
 
     - API Documentation(`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1sensors_1_1_c_a_n_coder.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1sensors_1_1_c_a_n_coder.html>`__)
-    - `Hardware Manual <https://www.ctr-electronics.com/downloads/pdf/CANCoder%20User's%20Guide.pdf>`__
+    - `Hardware User's Manual <https://www.ctr-electronics.com/downloads/pdf/CANCoder%20User's%20Guide.pdf>`__
     - `Other Resources <https://www.ctr-electronics.com/cancoder.html#product_tabs_technical_resources>`__
 
 - **Pigeon IMU**
 
     - API Documentation(`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1sensors_1_1_pigeon_i_m_u.html>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1sensors_1_1_pigeon_i_m_u.html>`__)
-    - `Hardware Manual <https://www.ctr-electronics.com/downloads/pdf/Pigeon%20IMU%20User's%20Guide.pdf>`__
+    - `Hardware User's Manual <https://www.ctr-electronics.com/downloads/pdf/Pigeon%20IMU%20User's%20Guide.pdf>`__
     - `Other Resources <https://www.ctr-electronics.com/gadgeteer-imu-module-pigeon.html#product_tabs_technical_resources>`__
 
 - **CANifier**
 
     - API Documentation (`Java <https://www.ctr-electronics.com/downloads/api/java/html/classcom_1_1ctre_1_1phoenix_1_1_c_a_nifier.html#ad9a05fae7065d3f39f7bc8a86f15b0a1>`__, `C++ <https://www.ctr-electronics.com/downloads/api/cpp/html/classctre_1_1phoenix_1_1_c_a_nifier.html#a706308fce1dea96785bf3ac845bafc02>`__)
-    - `Hardware Manual <https://www.ctr-electronics.com/downloads/pdf/CANifier%20User's%20Guide.pdf>`__
+    - `Hardware User's Manual <https://www.ctr-electronics.com/downloads/pdf/CANifier%20User's%20Guide.pdf>`__
     - `Other Resources <https://www.ctr-electronics.com/can-can-canifier-driver-led-driver-gpio.html#product_tabs_technical_resources>`__
 
 REV Robotics

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -15,11 +15,11 @@ A list of common third-party CAN devices from various vendors, along with links 
 Cross-the-Road Electronics
 --------------------------
 
-Cross-the-Road Electronics (CTRE) offers several CAN peripherals with external libraries. General resources for all CTRE devices include: 
+Cross-the-Road Electronics (CTRE) offers several CAN peripherals with external libraries. General resources for all CTRE devices include:
 
-- `Phoenix Device Software Documentation <https://docs.ctre-phoenix.com/>`__ 
+- `Phoenix Device Software Documentation <https://docs.ctre-phoenix.com/>`__
 
-- `Phoenix Device Software Examples <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages>`__ 
+- `Phoenix Device Software Examples <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages>`__
 
 CTRE Motor Controllers
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/source/docs/software/driverstation/driver-station.rst
+++ b/source/docs/software/driverstation/driver-station.rst
@@ -64,7 +64,7 @@ The Diagnostics Tab contains additional status indicators that teams can use to 
 1. DS Version - Indicates the Driver Station Version number
 2. roboRIO Image Version - String indicating the version of the roboRIO Image
 3. WPILib Version - String indicating the version of WPILib in use
-4. CAN Device Versions - String indicating the firmware version of devices connected to the CAN bus. These items may not be present if the CTRE Phoenix framework has not been loaded
+4. CAN Device Versions - String indicating the firmware version of devices connected to the CAN bus. These items may not be present if the CTRE Phoenix Framework has not been loaded
 5. Memory Stats - This section shows stats about the roboRIO memory
 6. Connection Indicators - The top half of these indicators show connection status to various components.
 

--- a/source/docs/software/roborio-info/roborio-web-dashboard.rst
+++ b/source/docs/software/roborio-info/roborio-web-dashboard.rst
@@ -14,7 +14,7 @@ Mozilla Firefox are recommended for the best experience.
  devices should be done with software provided by the device vendor. For
  CTRE devices previously serviced using the webdashboard, the appropriate
  software is `CTRE Phoenix
- Tuner <https://phoenix-documentation.readthedocs.io/en/latest/ch03_PrimerPhoenixSoft.html#what-is-phoenix-tuner>`__.
+ Tuner <https://docs.ctre-phoenix.com/en/stable/ch03_PrimerPhoenixSoft.html#what-is-phoenix-tuner>`__.
 
 Opening the WebDash
 -------------------

--- a/source/docs/software/vscode-overview/3rd-party-libraries.rst
+++ b/source/docs/software/vscode-overview/3rd-party-libraries.rst
@@ -74,7 +74,7 @@ Libraries
 
 `Copperforge LibCu Software Library <https://copperforge.cc/docs/software/libcu/>`__ - Library for all Copperforge devices including the Lasershark
 
-`CTRE Phoenix Toolsuite <https://www.ctr-electronics.com/control-system/hro.html#product_tabs_technical_resources>`__ - Contains CANCoder, Canifier, Pigeon, Talon FX, Talon SRX, and Victor SPX Libraries and Phoenix Tuner program for configuring CTRE CAN devices
+`CTRE Phoenix Framework <https://github.com/CrossTheRoadElec/Phoenix-Releases/releases>`__ - Contains CANcoder, CANifier, Pigeon IMU, Talon FX, Talon SRX, and Victor SPX Libraries and Phoenix Tuner program for configuring CTRE CAN devices
 
 `Digilent <https://reference.digilentinc.com/dmc-60c/getting-started>`__ - DMC-60C library
 

--- a/source/docs/zero-to-robot/step-3/index.rst
+++ b/source/docs/zero-to-robot/step-3/index.rst
@@ -1,7 +1,7 @@
 Step 3: Preparing Your Robot
 ============================
 
-.. warning:: The CAN Web Dashboard plugin is no longer supported by the roboRIO Web Dashboard. To configure CTRE CAN devices such as the PCM and PDP, use `CTRE Phoenix Tuner <https://phoenix-documentation.readthedocs.io/en/latest/ch03_PrimerPhoenixSoft.html#what-is-phoenix-tuner>`_
+.. warning:: The CAN Web Dashboard plugin is no longer supported by the roboRIO Web Dashboard. To configure CTRE CAN devices such as the PCM and PDP, use `CTRE Phoenix Tuner <https://docs.ctre-phoenix.com/en/stable/ch03_PrimerPhoenixSoft.html#what-is-phoenix-tuner>`_
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Updates CTRE device list and links.
Utilizes new docs.ctre-phoenix.com URL.