### PR TITLE
Force docutils 0.16.0 due to incompatibility

### DIFF
--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -14,3 +14,4 @@ sphinxext-linkcheckdiff==0.1.0
 sphinxext-rediraffe==0.2.5
 sphinx-version-warning==1.1.2
 sphinx-panels==0.5.2
+docutils==0.16


### PR DESCRIPTION
See https://github.com/sphinx-doc/sphinx/issues/9001 