### PR TITLE
Allow manual publish to stable

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -33,7 +33,7 @@ jobs:
           git merge --ff-only main
 
       - name: Push
-        if: env.PUBLISH_STABLE == 'true'
+        if: ${{ env.PUBLISH_STABLE == 'true' || github.event.action == "workflow_dispatch" }}
         env:
           PUBLISH_STABLE: ${{ secrets.PUBLISH_STABLE }}
         run: |


### PR DESCRIPTION
This makes a workflow_dispatch on the publish_stable workflow (from a wpilib member) push to stable. This allows for a manual push to stable without the need to toggle automatic push to stable twice.