### PR TITLE
Workaround for Broken TOC Navigation

### DIFF
--- a/source/_extensions/sphinx_toctreeish.py
+++ b/source/_extensions/sphinx_toctreeish.py
@@ -1,0 +1,62 @@
+import re
+from typing import List
+
+from docutils import nodes
+from docutils.nodes import Node
+from docutils.statemachine import StringList, ViewList
+
+import sphinx
+from sphinx import addnodes
+from sphinx.directives.other import TocTree
+
+class TocTreeish(TocTree) :
+
+    def run(self) -> List[Node]:
+        assert self.options.get("hidden",False) == False
+
+        rootln = nodes.bullet_list()
+
+        delme = []
+        for entry in self.content:
+            node = addnodes.compact_paragraph()
+
+            if re.search(r"\s", entry):
+              if entry.startswith("_ "):
+                # Raw syntax: parse...
+                tmp = nodes.paragraph()
+                self.state.nested_parse(ViewList([entry[2:]]), 0, tmp)
+
+                # ... rip out the parsed thing into a compact paragraph...
+                node += tmp.children[0].children
+
+                # ... and prevent the real toctree from seeing it
+                delme += [ entry ]
+              else:
+                assert False, "TocTreeish doesn't understand spaced things"
+            elif entry == "self":
+                assert False, "TocTreeish doesn't do 'self'"
+            else:
+                # Single word, must be a doc xref.  Fake one up!
+                pxr = addnodes.pending_xref(entry, reftype='doc',
+                        refdomain='std', refexplicit=False, reftarget=entry)
+                pxr += nodes.inline('', entry, classes="xref std std-doc")
+                node += pxr
+
+            rootln.children += nodes.bullet_list('', nodes.list_item('', node))
+
+        for d in delme:
+            self.content.remove(d)
+
+        self.options["hidden"] = True
+        res = super().run()
+
+        # Push our list into the wrapper that still gets generated despite
+        # setting the toctree to hidden.
+        wrappernode = res[-1]
+        wrappernode.append(rootln)
+
+        return res
+
+def setup(app):
+    app.add_directive("toctreeish", TocTreeish)
+    return {'version': "1", 'parallel_read_safe': True}

--- a/source/_extensions/sphinx_toctreeish.py
+++ b/source/_extensions/sphinx_toctreeish.py
@@ -9,10 +9,10 @@ import sphinx
 from sphinx import addnodes
 from sphinx.directives.other import TocTree
 
-class TocTreeish(TocTree) :
 
+class TocTreeish(TocTree):
     def run(self) -> List[Node]:
-        assert self.options.get("hidden",False) == False
+        assert self.options.get("hidden", False) == False
 
         rootln = nodes.bullet_list()
 
@@ -21,28 +21,33 @@ class TocTreeish(TocTree) :
             node = addnodes.compact_paragraph()
 
             if re.search(r"\s", entry):
-              if entry.startswith("_ "):
-                # Raw syntax: parse...
-                tmp = nodes.paragraph()
-                self.state.nested_parse(ViewList([entry[2:]]), 0, tmp)
+                if entry.startswith("_ "):
+                    # Raw syntax: parse...
+                    tmp = nodes.paragraph()
+                    self.state.nested_parse(ViewList([entry[2:]]), 0, tmp)
 
-                # ... rip out the parsed thing into a compact paragraph...
-                node += tmp.children[0].children
+                    # ... rip out the parsed thing into a compact paragraph...
+                    node += tmp.children[0].children
 
-                # ... and prevent the real toctree from seeing it
-                delme += [ entry ]
-              else:
-                assert False, "TocTreeish doesn't understand spaced things"
+                    # ... and prevent the real toctree from seeing it
+                    delme += [entry]
+                else:
+                    assert False, "TocTreeish doesn't understand spaced things"
             elif entry == "self":
                 assert False, "TocTreeish doesn't do 'self'"
             else:
                 # Single word, must be a doc xref.  Fake one up!
-                pxr = addnodes.pending_xref(entry, reftype='doc',
-                        refdomain='std', refexplicit=False, reftarget=entry)
-                pxr += nodes.inline('', entry, classes="xref std std-doc")
+                pxr = addnodes.pending_xref(
+                    entry,
+                    reftype="doc",
+                    refdomain="std",
+                    refexplicit=False,
+                    reftarget=entry,
+                )
+                pxr += nodes.inline("", entry, classes="xref std std-doc")
                 node += pxr
 
-            rootln.children += nodes.bullet_list('', nodes.list_item('', node))
+            rootln.children += nodes.bullet_list("", nodes.list_item("", node))
 
         for d in delme:
             self.content.remove(d)
@@ -57,6 +62,7 @@ class TocTreeish(TocTree) :
 
         return res
 
+
 def setup(app):
     app.add_directive("toctreeish", TocTreeish)
-    return {'version': "1", 'parallel_read_safe': True}
+    return {"version": "1", "parallel_read_safe": True}

--- a/source/conf.py
+++ b/source/conf.py
@@ -10,9 +10,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('./_extensions/'))
 
 
 # -- Project information -----------------------------------------------------
@@ -45,6 +46,7 @@ extensions = [
     "notfound.extension",
     "versionwarning.extension",
     "sphinx_panels",
+    "sphinx_toctreeish"
 ]
 
 versionwarning_messages = {

--- a/source/conf.py
+++ b/source/conf.py
@@ -13,7 +13,8 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('./_extensions/'))
+
+sys.path.insert(0, os.path.abspath("./_extensions/"))
 
 
 # -- Project information -----------------------------------------------------
@@ -46,7 +47,7 @@ extensions = [
     "notfound.extension",
     "versionwarning.extension",
     "sphinx_panels",
-    "sphinx_toctreeish"
+    "sphinx_toctreeish",
 ]
 
 versionwarning_messages = {

--- a/source/docs/software/wpilib-tools/robot-simulation/index.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/index.rst
@@ -1,15 +1,17 @@
+.. Usage of toctreeish is due to https://github.com/sphinx-doc/sphinx/issues/701
+
 Robot Simulation
 ================
 
-.. toctree::
+.. toctreeish::
    :maxdepth: 1
 
    introduction
    simulation-gui
-   /docs/software/wpilib-tools/glass/widgets
-   /docs/software/wpilib-tools/glass/command-based-widgets
-   /docs/software/wpilib-tools/glass/field2d-widget
-   /docs/software/wpilib-tools/glass/plots
+   _ :ref:`Widgets <docs/software/wpilib-tools/glass/widgets:Glass Widgets>`
+   _ :ref:`Widgets for the Command-Based Framework <docs/software/wpilib-tools/glass/command-based-widgets:Widgets for the Command-Based Framework>`
+   _ :ref:`The Field2d Widget <docs/software/wpilib-tools/glass/field2d-widget:The Field2d Widget>`
+   _ :ref:`Plots <docs/software/wpilib-tools/glass/plots:Plots>`
    physics-sim
    device-sim
    unit-testing


### PR DESCRIPTION
This causes special TOC entries to be hidden from the root TOC. This prevents weird behavior such as it "appearing" in the simulation section, but "prev/next" flow is broken. This properly redirects them to Plots in "Glass". Unfortunately, Sphinx only supports a unique rst tree structure, so this is a workaround until #9076 can be solved.

Somewhat addresses #1318 by redirection, instead of duplication. This should not be a proper extension, as it's a hack and should be fixed upstream.