### PR TITLE
[DO NOT MERGE] Testing HoverXRef with MathJax3

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -144,6 +144,11 @@ IMAGE_SIZE_EXCLUSIONS = [
 # Required to display LaTeX in hover content
 hoverxref_mathjax = True
 
+# Development hoverXRef content
+hoverxref_project = 'frc-docs'
+hoverxref_version = 'latest'
+hoverxref_api_host = 'https://readthedocs.org'
+
 # Use MathJax3 for better page loading times
 mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
 

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -29,7 +29,7 @@ shutilwhich==1.1.0
 six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 smmap==4.0.0; python_version >= "3.6"
 snowballstemmer==2.1.0; python_version >= "3.5"
-sphinx-hoverxref==0.5b1
+-e git://github.com/daltz333/sphinx-hoverxref@mathjax3#egg=sphinx_hoverxref
 sphinx-notfound-page==0.6
 sphinx-panels==0.5.2
 sphinx-rtd-theme==0.5.1


### PR DESCRIPTION
Doing some development making ``sphinx-hoverxref`` compatible with MathJax3. This is strictly for testing purposes for the RTD PR builder.

DO NOT MERGE.