### PR TITLE
Fixes basic vision example errors

### DIFF
--- a/source/docs/software/vision-processing/wpilibpi/basic-vision-example.rst
+++ b/source/docs/software/vision-processing/wpilibpi/basic-vision-example.rst
@@ -67,10 +67,10 @@ This is an example of a basic vision setup that posts the target's location in t
 
                rect = cv2.minAreaRect(contour)
                center, size, angle = rect
-               center = [int(dim) for dim in center] # Convert to int so we can draw
+               center = tuple([int(dim) for dim in center]) # Convert to int so we can draw
 
                # Draw rectangle and circle
-               cv2.drawContours(output_img, np.int0(cv2.boxPoints(rect)), -1, color = (0, 0, 255), thickness = 2)
+               cv2.drawContours(output_img, [cv2.boxPoints(rect).astype(int)], -1, color = (0, 0, 255), thickness = 2)
                cv2.circle(output_img, center = center, radius = 3, color = (0, 0, 255), thickness = -1)
 
                x_list.append((center[0] - width / 2) / (width / 2))


### PR DESCRIPTION
While running the python basic vision example on WPILibPi v2021.2.1 I encountered the following errors:

```
  File "uploaded.py", line 78, in <module>

    main()

  File "uploaded.py", line 64, in main

    cv2.drawContours(output_img, np.int0(cv2.boxPoints(rect)), -1, color = (0, 0, 255), thickness = 2)

cv2.error: OpenCV(3.4.7) /__w/3/s/work/2021-01-19-WPILibPi/stage3/rootfs/usr/src/opencv-3.4.7/modules/imgproc/src/drawing.cpp:2511: error: (-215:Assertion failed) npoints > 0 in function 'drawContours'
```

and

```
  File "uploaded.py", line 78, in <module>

    main()

  File "uploaded.py", line 65, in main

    cv2.circle(output_img, center = center, radius = 3, color = (0, 0, 255), thickness = -1)

SystemError: new style getargs format but argument is not a tuplen
```

The proposed changes resolve these errors. I can validate that this example now works on WPILibPi v2021.2.1 running on a Raspberry Pi 3 B+.
I'm not that familiar with Python so let me know if there is a more elegant solution to these changes, particularly at line 70 where we convert a a numpy array of floats to a tuple of ints.