### PR TITLE
Update Shuffleboard Gradle Example

### DIFF
--- a/source/docs/software/dashboards/shuffleboard/custom-widgets/creating-plugins.rst
+++ b/source/docs/software/dashboards/shuffleboard/custom-widgets/creating-plugins.rst
@@ -48,8 +48,8 @@ For Gradle:
    }
 
    dependencies {
-      compileOnly("edu.wpi.first.shuffleboard", "api", "2020.+")
-      compileOnly("edu.wpi.first.shuffleboard.plugin", "networktables", "2020.+")
+      compileOnly 'edu.wpi.first.shuffleboard:api:2020.+'
+      compileOnly 'edu.wpi.first.shuffleboard.plugin:networktables:2020.+'
    }
 
 


### PR DESCRIPTION
Uses 2020 due to Shuffleboard not publishing 2021.

Closes #1325 