### PR TITLE
Set base url to root domain

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -166,6 +166,10 @@ html_logo = "assets/wpilibDocsLogo.png"
 # URL favicon
 html_favicon = "assets/FIRSTicon_RGB_withTM.ico"
 
+# Specify canonical root
+# This tells search engines that this domain is preferred
+html_baseurl = "https://docs.wpilib.org/"
+
 html_theme_options = {
     "collapse_navigation": True,
     "sticky_navigation": False,


### PR DESCRIPTION
RTD no longer injects it for us (we still want to keep frcdocs.wpi.edu domains and not redirect them). 