### PR TITLE
Open external links in new tab

### DIFF
--- a/source/_static/js/external-links-new-tab.js
+++ b/source/_static/js/external-links-new-tab.js
@@ -1,0 +1,3 @@
+$(document).ready(function () {
+    $('a.external').attr('target', '_blank');
+});

--- a/source/conf.py
+++ b/source/conf.py
@@ -196,7 +196,7 @@ def setup(app):
 
     # Fix rtd version/language menu on iOS
     app.add_js_file("js/fix-rtd-menu-ios.js")
-    
+
     # Launch external links in a new tab/window
     app.add_js_file("js/external-links-new-tab.js")
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -196,6 +196,9 @@ def setup(app):
 
     # Fix rtd version/language menu on iOS
     app.add_js_file("js/fix-rtd-menu-ios.js")
+    
+    # Launch external links in a new tab/window
+    app.add_js_file("js/external-links-new-tab.js")
 
 
 # -- Options for latex generation --------------------------------------------


### PR DESCRIPTION
Adds a small JS file to add the target=_blank attribute to external links so they open in a new tab. Many of our external links are to downloads/installers and the user wants the documentation to stay open. This is especially useful for embedding the documentation like in a course currently under construction where the GitHub links will not work in the embed without this.