### PR TITLE
Don't give external links access to the referrer

### DIFF
--- a/source/_static/js/external-links-new-tab.js
+++ b/source/_static/js/external-links-new-tab.js
@@ -1,3 +1,4 @@
 $(document).ready(function () {
     $('a.external').attr('target', '_blank');
+    $('a.external').attr('rel', 'noopener');
 });


### PR DESCRIPTION
Links to cross-origin destinations are unsafe.
https://web.dev/external-anchors-use-rel-noopener/