### PR TITLE
Fix several capitalization issues in the counters page

### DIFF
--- a/source/docs/software/hardware-apis/sensors/counters.rst
+++ b/source/docs/software/hardware-apis/sensors/counters.rst
@@ -102,7 +102,7 @@ To get the pulse width, call the :code:`getPeriod()` method:
     .. code-tab:: java
 
         // Return the measured pulse width in seconds
-        counter.GetPeriod();
+        counter.getPeriod();
 
     .. code-tab:: c++
 

--- a/source/docs/software/hardware-apis/sensors/counters.rst
+++ b/source/docs/software/hardware-apis/sensors/counters.rst
@@ -107,7 +107,7 @@ To get the pulse width, call the :code:`getPeriod()` method:
     .. code-tab:: c++
 
         // Return the measured pulse width in seconds
-        counter.getPeriod();
+        counter.GetPeriod();
 
 Pulse-length mode
 ~~~~~~~~~~~~~~~~~
@@ -130,7 +130,7 @@ In pulse-length mode, the counter will count either up or down depending on the 
             counter.setUpSourceEdge(true, true);
 
             // Set the counter to count down if the pulses are longer than .05 seconds
-            counter.SetPulseLengthMode(.05)
+            counter.setPulseLengthMode(.05)
         }
 
     .. code-tab:: c++
@@ -146,7 +146,7 @@ In pulse-length mode, the counter will count either up or down depending on the 
             counter.SetUpSourceEdge(true, true);
 
             // Set the counter to count down if the pulses are longer than .05 seconds
-            counter.setPulseLengthMode(.05)
+            counter.SetPulseLengthMode(.05)
 
 External direction mode
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Change the example code from `counter.GetPeriod()` to the correct `counter.getPeriod()` in the Java example of using semi-period mode.