### PR TITLE
Replacing the second xEntry with a yEntry

### DIFF
--- a/source/docs/software/networktables/networktables-intro.rst
+++ b/source/docs/software/networktables/networktables-intro.rst
@@ -99,7 +99,7 @@ The NetworkTables classes are instantiated automatically when your program start
       class EasyNetworkExample : public frc::TimedRobot {
          public:
          nt::NetworkTableEntry xEntry;
-         nt::NetworkTableEntry xEntry;
+         nt::NetworkTableEntry yEntry;
 
          void RobotInit() {
             auto inst = nt::NetworkTableInstance::GetDefault();
@@ -113,7 +113,7 @@ The NetworkTables classes are instantiated automatically when your program start
 
          void TeleopPeriodic() {
             xEntry.SetDouble(x);
-            xEntry.SetDouble(Y);
+            yEntry.SetDouble(Y);
             x += 0.05;
             y += 0.05;
          }


### PR DESCRIPTION
Replacing the second xEntry with a yEntry value.

This is for issue #1468 
https://github.com/wpilibsuite/frc-docs/issues/1468