### PR TITLE
Add java locale page to linkcheck ignore

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -122,6 +122,7 @@ linkcheck_ignore = [
     r".*andymark.com.*",
     r".*ti.com/lit/an/spma033a/spma033a.pdf.*",
     r".*wpilibpi.local.*",
+    r".*java.com/en/download/help/locale.xml.*",
 ]
 
 # Sets linkcheck timeout in seconds


### PR DESCRIPTION
I investigated some alternative web pages, but didn't find any good concise ones that listed all versions of windows.