### PR TITLE
Add unofficial resources

### DIFF
--- a/source/docs/software/support/support-resources.rst
+++ b/source/docs/software/support/support-resources.rst
@@ -42,7 +42,7 @@ There are useful forms of support provided by the community through various foru
 - `Chief Delphi <https://chiefdelphi.com>`__
 - `FRC Discord <https://discord.gg/frc>`__
 - `PhotonVision Support (Discord) <https://discord.com/invite/wYxTwym>`__
-- `Limelight Support <https://docs.limelightvision.io/en/latest/>`__
+- `Limelight Support <https://limelightvision.io/pages/contact-us>`__
 
 Bug Reporting
 -------------

--- a/source/docs/software/support/support-resources.rst
+++ b/source/docs/software/support/support-resources.rst
@@ -39,8 +39,11 @@ Other Vendors
 
 Support for vendors outside of the KOP can be found below.
 
-- `PhotonVision Support (Discord) <https://discord.com/invite/wYxTwym>`__
-- `Limelight Support <https://limelightvision.io/pages/contact-us>`__
+- `Copperforge <https://copperforge.cc/docs/software/libcu/>`__
+- `Kauai Labs (NavX) <https://www.kauailabs.com/support/navx-mxp/>`__
+- `Limelight <https://limelightvision.io/pages/contact-us>`__
+- `PhotonVision (Discord) <https://discord.com/invite/wYxTwym>`__
+- `Playing with Fusion <https://www.playingwithfusion.com/contactus.php>`__
 
 Unofficial Support
 ------------------

--- a/source/docs/software/support/support-resources.rst
+++ b/source/docs/software/support/support-resources.rst
@@ -34,7 +34,7 @@ REV Robotics Support
 
 Support for REV Robotics components (SPARK MAX, Sensors, upcoming new control system components) is provided via phone at `844-255-2267 <tel:844-255-2267>`__ or via the email address `support@revrobotics.com <support@revrobotics.com>`__
 
-Other Support
+Other Vendors
 -------------
 
 Support for vendors outside of the KOP can be found below.

--- a/source/docs/software/support/support-resources.rst
+++ b/source/docs/software/support/support-resources.rst
@@ -34,6 +34,16 @@ REV Robotics Support
 
 Support for REV Robotics components (SPARK MAX, Sensors, upcoming new control system components) is provided via phone at `844-255-2267 <tel:844-255-2267>`__ or via the email address `support@revrobotics.com <support@revrobotics.com>`__
 
+Unofficial Support
+------------------
+
+There are useful forms of support provided by the community through various forums and services. The below links and websites are not endorsed by FIRST\ |reg| and are use at your own risk.
+
+- `Chief Delphi <https://chiefdelphi.com>`__
+- `FRC Discord <https://discord.gg/frc>`__
+- `PhotonVision Support (Discord) <https://discord.com/invite/wYxTwym>`__
+- `Limelight Support <https://docs.limelightvision.io/en/latest/>`__
+
 Bug Reporting
 -------------
 

--- a/source/docs/software/support/support-resources.rst
+++ b/source/docs/software/support/support-resources.rst
@@ -34,6 +34,14 @@ REV Robotics Support
 
 Support for REV Robotics components (SPARK MAX, Sensors, upcoming new control system components) is provided via phone at `844-255-2267 <tel:844-255-2267>`__ or via the email address `support@revrobotics.com <support@revrobotics.com>`__
 
+Other Support
+-------------
+
+Support for vendors outside of the KOP can be found below.
+
+- `PhotonVision Support (Discord) <https://discord.com/invite/wYxTwym>`__
+- `Limelight Support <https://limelightvision.io/pages/contact-us>`__
+
 Unofficial Support
 ------------------
 
@@ -41,8 +49,6 @@ There are useful forms of support provided by the community through various foru
 
 - `Chief Delphi <https://chiefdelphi.com>`__
 - `FRC Discord <https://discord.gg/frc>`__
-- `PhotonVision Support (Discord) <https://discord.com/invite/wYxTwym>`__
-- `Limelight Support <https://limelightvision.io/pages/contact-us>`__
 
 Bug Reporting
 -------------


### PR DESCRIPTION
Close #1522 

I opted to not include documentation links, as that would be better fitted for an example page. Vendors are welcome to PR to this page and provide their own links.