### PR TITLE
Fix shuffleboard code example missing return statement

### DIFF
--- a/source/docs/software/dashboards/shuffleboard/custom-widgets/creating-custom-data-types.rst
+++ b/source/docs/software/dashboards/shuffleboard/custom-widgets/creating-custom-data-types.rst
@@ -136,7 +136,7 @@ For example,
 
       @Override
       public List<DataType> getDataTypes() {
-         List.of(PointDataType.Instance);
+         return List.of(PointDataType.Instance);
       }
 
    }


### PR DESCRIPTION
Added a return statement to a function that should return a list but didn't. Reopened of #1536 but targeting correct branch.