### PR TITLE
Update debouncer docs

### DIFF
--- a/source/docs/software/advanced-controls/filters/debouncer.rst
+++ b/source/docs/software/advanced-controls/filters/debouncer.rst
@@ -1,7 +1,21 @@
 Debouncer
 =========
 
-The ``Debouncer`` class is used to filter out unwanted quick on/off cycles.  These cycles are usually due to a sensor error like noise or reflections and not the actual event the sensor is trying to record.  The ``Debouncer`` works by only recording a change in signal after that change has persisted for a specified period of time.
+A debouncer is a filter used to eliminate unwanted quick on/off cycles (termed "bounces," originally from the physical vibrations of a switch as it is thrown). These cycles are usually due to a sensor error like noise or reflections and not the actual event the sensor is trying to record.
+
+Debouncing is implemented in WPILib by the ``Debouncer`` class (`Java <https://first.wpi.edu/wpilib/allwpilib/docs/development/java/edu/wpi/first/math/filter/Debouncer.html>`__, `C++ <https://first.wpi.edu/wpilib/allwpilib/docs/development/cpp/classfrc_1_1_debouncer.html>`__), which filters a boolean stream so that the output only changes if the input sustains a change for some nominal time period.
+
+Modes
+-----
+
+The WPILib ``Debouncer`` can be configured in three different modes:
+
+  * Rising (default): debounces rising edges (transitions from `false` to `true`) only.
+  * Falling: debounces falling edges (transitions from `true` to `false`) only.
+  * Both: Debounces all transitions.
+
+Usage
+-----
 
 .. tabs::
 
@@ -10,8 +24,8 @@ The ``Debouncer`` class is used to filter out unwanted quick on/off cycles.  The
     // Initializes a DigitalInput on DIO 0
     DigitalInput input = new DigitalInput(0);
 
-    // Creates a Debouncer.
-    Debouncer m_debouncer = new Debouncer(0.1);
+    // Creates a Debouncer in "both" mode.
+    Debouncer m_debouncer = new Debouncer(0.1, Debouncer.DebounceType.kBoth);
 
     // So if currently false the signal must go true for at least .1 seconds before being read as a True signal.
     if (m_debouncer.calculate(input.get())) {
@@ -23,8 +37,8 @@ The ``Debouncer`` class is used to filter out unwanted quick on/off cycles.  The
     // Initializes a DigitalInput on DIO 0
     frc::DigitalInput input{0};
 
-    // Creates a Debouncer.
-    frc::Debouncer m_debouncer{100_ms};
+    // Creates a Debouncer in "both" mode.
+    frc::Debouncer m_debouncer{100_ms, frc::Debouncer::DebounceType::kBoth};
 
     // So if currently false the signal must go true for at least .1 seconds before being read as a True signal.
     if (m_debouncer.calculate(input.Get())) {

--- a/source/docs/software/commandbased/binding-commands-to-triggers.rst
+++ b/source/docs/software/commandbased/binding-commands-to-triggers.rst
@@ -158,6 +158,29 @@ The ``Trigger`` class (including its ``Button`` subclasses) can be composed to c
 
 Note that these methods return a ``Trigger``, not a ``Button``, so the ``Trigger`` binding method names must be used even when buttons are composed.
 
+Debouncing Triggers
+-------------------
+
+To avoid rapid repeated activation, triggers (especially those originating from digital inputs) can be debounced with the :ref:`WPILib Debouncer class <docs/software/advanced-controls/filters/debouncer:Debouncer>` using the `debounce` method:
+
+.. tabs::
+
+  .. code-tab:: java
+
+    // debounces exampleButton with a 0.1s debounce time, rising edges only
+    exampleButton.debounce(0.1).whenActive(new ExampleCommand());
+
+    // debounces exampleButton with a 0.1s debounce time, both rising and falling edges
+    exampleButton.debounce(0.1, Debouncer.DebounceType.kBoth).whenActive(new ExampleCommand());
+
+  .. code-tab:: c++
+
+    // debounces exampleButton with a 100ms debounce time, rising edges only
+    exampleButton.Debounce(100_ms).WhenActive(new ExampleCommand());
+
+    // debounces exampleButton with a 100ms debounce time, both rising and falling edges
+    exampleButton.Debounce(100_ms, Debouncer::DebounceType::Both).WhenActive(new ExampleCommand());
+
 Creating Your Own Custom Trigger
 --------------------------------
 

--- a/source/docs/yearly-overview/yearly-changelog.rst
+++ b/source/docs/yearly-overview/yearly-changelog.rst
@@ -31,7 +31,7 @@ General Library
 - Added C++ TankDrive example
 - Added ``PS4Controller`` controller class
 - Added better message for when an I2C port is out of range
-- Added ``Debouncer`` (`Java <https://first.wpi.edu/wpilib/allwpilib/docs/development/java/edu/wpi/first/wpilibj/Debouncer.html>`__/ `C++ <https://first.wpi.edu/wpilib/allwpilib/docs/development/cpp/classfrc_1_1_debouncer.html>`__) class. This helps with filtering rising and falling edges when dealing with boolean values
+- Added ``Debouncer`` (`Java <https://first.wpi.edu/wpilib/allwpilib/docs/development/java/edu/wpi/first/math/filter/Debouncer.html>`__, `C++ <https://first.wpi.edu/wpilib/allwpilib/docs/development/cpp/classfrc_1_1_debouncer.html>`__) class. This helps with filtering rising and falling edges when dealing with boolean values
 - Added ``PneumaticHub`` class for use with the REV Pneumatic Hub
 - GenericHID has been updated to static functions to use for non-defined controller types.
 - ``XboxController`` has migrated away from taking arguments in functions and instead has functions with no arguments. An example conversion is below:
@@ -77,7 +77,7 @@ We have committed to several organizational renames that will allow us greater f
 - Several packages moved from ``wpilibj`` to ``math``: ``controller``, ``estimator``, ``geometry``, ``kinematics``, ``math``, ``spline``, ``system``, ``trajectory``
 - ``wpiutil.math`` was moved to ``math``
 - ``wpiutil`` is now ``util``
-- ``SlewRateLimiter``, ``LinearFilter``, and ``MedianFilter`` now live in ``math.filters``
+- ``SlewRateLimiter``, ``LinearFilter``, and ``MedianFilter`` now live in ``math.filters``, along with the newly-added ``Debouncer``.
 - ``Timer`` has moved from ``frc2`` to ``frc``
 - Motor controllers (``VictorSPX``, ``PWMSparkMax``, etc) have been moved to a ``motorcontrol`` package.
 - ``edu.wpi.cscore`` has moved to ``edu.wpi.first.cscore``


### PR DESCRIPTION
updates debouncer docs to have a better usage example and to reflect its current location in `filters`.  adds a debounced trigger example.