### PR TITLE
changelog: Add blank lines for readability

### DIFF
--- a/source/docs/yearly-overview/yearly-changelog.rst
+++ b/source/docs/yearly-overview/yearly-changelog.rst
@@ -35,6 +35,7 @@ General Library
 - Added ``PneumaticHub`` class for use with the REV Pneumatic Hub
 - GenericHID has been updated to static functions to use for non-defined controller types.
 - ``XboxController`` has migrated away from taking arguments in functions and instead has functions with no arguments. An example conversion is below:
+
   - ``controller.getTriggerAxis(GenericHID.Hand.kLeft)`` -> ``controller.getLeftTriggerAxis()``
   - ``controller.getX(GenericHID.Hand.kLeft)`` -> ``controller.getLeftX()``
 
@@ -53,6 +54,7 @@ Breaking Changes
 - ``InterruptableSendableBase`` has been broken up into ``AsynchronousInterrupt`` & ``SynchronousInterrupt``. Rather then a class, like ``DigitalInput`` extending ``InterruptableSendableBase`` and all interrupt methods being accessed through the ``DigitalInput``, teams should instead construct ``AsynchronousInterrupt`` or ``SynchronousInterrupt``, and pass it the ``DigitalSource`` (e.g. ``DigitalInput``).
 - C++: ``DriverStation.ReportWarning`` and ``DriverStation.ReportError`` have been removed. Use ``FRC_ReportError`` in ``frc\Errors.h`` header. Status of ``frc::err::Error`` can be used for Errors and ``frc::warn::Warning`` can be used for warnings.
 - ``SpeedController`` has been renamed to ``MotorController``
+
   - Various portions of the API still refers to ``SpeedController`` for backwards compatibility. Users should pass ``MotorController`` instead
 
 - Several duplicate ``SpeedController`` methods have been removed. Use ``set`` instead of ``setSpeed``. Use ``disable`` instead of ``setDisable``. Several low level methods have been removed: position, bounds, periodMultiplier, zeroLatch, and raw methods. Use the ``PWM`` class directly if this level of control is needed.


### PR DESCRIPTION
I presume these are meant to be sublists. They weren't because of the missing blank lines.