### PR TITLE
Replace C++ units to<double>() with value()

### DIFF
--- a/source/docs/software/advanced-controls/controllers/combining-feedforward-feedback.rst
+++ b/source/docs/software/advanced-controls/controllers/combining-feedforward-feedback.rst
@@ -51,9 +51,9 @@ What might a more complete example of combined feedforward/PID control look like
     void TankDriveWithFeedforwardPID(units::meters_per_second_t leftVelocitySetpoint,
                                      units::meters_per_second_t rightVelocitySetpoint) {
       leftMotor.SetVoltage(feedforward.Calculate(leftVelocitySetpoint)
-          + leftPID.Calculate(leftEncoder.getRate(), leftVelocitySetpoint.to<double>());
+          + leftPID.Calculate(leftEncoder.getRate(), leftVelocitySetpoint.value());
       rightMotor.SetVoltage(feedforward.Calculate(rightVelocitySetpoint)
-          + rightPID.Calculate(rightEncoder.getRate(), rightVelocitySetpoint.to<double>());
+          + rightPID.Calculate(rightEncoder.getRate(), rightVelocitySetpoint.value());
     }
 
 Other mechanism types can be handled similarly.

--- a/source/docs/software/advanced-controls/controllers/trapezoidal-profiles.rst
+++ b/source/docs/software/advanced-controls/controllers/trapezoidal-profiles.rst
@@ -127,7 +127,7 @@ The ``calculate`` method returns a ``TrapezoidProfile.State`` class (the same on
   .. code-tab:: c++
 
     auto setpoint = profile.Calculate(elapsedTime);
-    controller.Calculate(encoder.GetDistance(), setpoint.position.to<double>());
+    controller.Calculate(encoder.GetDistance(), setpoint.position.value());
 
 Complete Usage Example
 ----------------------

--- a/source/docs/software/advanced-controls/trajectories/troubleshooting.rst
+++ b/source/docs/software/advanced-controls/trajectories/troubleshooting.rst
@@ -90,8 +90,8 @@ If your odometry is bad, then your Ramsete controller may misbehave, because it 
                             units::meter_t(m_rightEncoder.GetDistance()));
 
         auto translation = m_odometry.GetPose().Translation();
-        m_xEntry.SetDouble(translation.X().to<double>());
-        m_yEntry.SetDouble(translation.Y().to<double>());
+        m_xEntry.SetDouble(translation.X().value());
+        m_yEntry.SetDouble(translation.Y().value());
     }
 
 2. Lay out a tape measure parallel to your robot and push your robot out about one meter along the tape measure. Lay out a tape measure along the Y axis and start over, pushing your robot one meter along the X axis and one meter along the Y axis in a rough arc.
@@ -218,10 +218,10 @@ If your feedforwards are bad then the P controllers for each side of the robot w
 
             m_drive.TankDriveVolts(left, right);
 
-            leftMeasurement.SetDouble(m_drive.GetWheelSpeeds().left.to<double>());
+            leftMeasurement.SetDouble(m_drive.GetWheelSpeeds().left.value());
             leftReference.SetDouble(leftController.GetSetpoint());
 
-            rightMeasurement.SetDouble(m_drive.GetWheelSpeeds().right.to<double>());
+            rightMeasurement.SetDouble(m_drive.GetWheelSpeeds().right.value());
             rightReference.SetDouble(rightController.GetSetpoint());
         },
         {&m_drive});

--- a/source/docs/software/basic-programming/cpp-units.rst
+++ b/source/docs/software/basic-programming/cpp-units.rst
@@ -150,12 +150,12 @@ However, other ``std`` functions work only on ordinary numerical types (e.g. ``d
 Removing the Unit Wrapper
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To convert a container type to a raw numeric value, the ``to<..>()`` method can be used, where the template argument is the underlying type.
+To convert a container type to its underlying value, use the ``value()`` method. This serves as an escape hatch from the units type system, which should be used only when necessary.
 
 .. code-block:: c++
 
    units::meter_t distance = 6.5_m;
-   double distanceMeters = distance.to<double>();
+   double distanceMeters = distance.value();
 
 
 Example of the Units Library in WPILib Code

--- a/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/updating-drivetrain-model.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/updating-drivetrain-model.rst
@@ -67,10 +67,10 @@ There are three main steps to updating the model:
         m_driveSim.Update(20_ms);
 
         // Update all of our sensors.
-        m_leftEncoderSim.SetDistance(m_driveSim.GetLeftPosition().to<double>());
-        m_leftEncoderSim.SetRate(m_driveSim.GetLeftVelocity().to<double>());
-        m_rightEncoderSim.SetDistance(m_driveSim.GetRightPosition().to<double>());
-        m_rightEncoderSim.SetRate(m_driveSim.GetRightVelocity().to<double>());
+        m_leftEncoderSim.SetDistance(m_driveSim.GetLeftPosition().value());
+        m_leftEncoderSim.SetRate(m_driveSim.GetLeftVelocity().value());
+        m_rightEncoderSim.SetDistance(m_driveSim.GetRightPosition().value());
+        m_rightEncoderSim.SetRate(m_driveSim.GetRightVelocity().value());
         m_gyroSim.SetAngle(-m_driveSim.GetHeading().Degrees());
       }
 


### PR DESCRIPTION
We've replaced all instances in allwpilib already since it doesn't
require writing `.template to<double>()` in template contexts, and it's
less typing.