### PR TITLE
Update robotbuilder-writing-command-code.rst

### DIFF
--- a/source/docs/software/wpilib-tools/robotbuilder/writing-code/robotbuilder-writing-command-code.rst
+++ b/source/docs/software/wpilib-tools/robotbuilder/writing-code/robotbuilder-writing-command-code.rst
@@ -63,7 +63,7 @@ Generated CloseClaw Class
              // Called when the command is initially scheduled.
              @Override
              public void initialize() {
-                 m_claw.open(); // (1)
+                 m_claw.close(); // (1)
              }
 
              // Called every time the scheduler runs while the command is scheduled.


### PR DESCRIPTION
Close claw Initialize was supposed to call m_claw.close(), not m_claw.open()