### PR TITLE
Add warning about powering off while deploying

### DIFF
--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -3,6 +3,8 @@ Building and Deploying Robot Code
 
 Robot projects must be compiled ("built") and deployed in order to run on the roboRIO.  Since the code is not compiled natively on the robot controller, this is known as "cross-compilation."
 
+.. warning:: Avoid powering off the robot while deploying robot code. Interrupting the deployment process can corrupt the roboRIO filesystem and prevent your code from working until the roboRIO is :doc:`re-imaged <docs/zero-to-robot/step-3/imaging-your-roborio>`.
+
 To build and deploy a robot project, do one of:
 
 1. Open the Command Palette and enter/select "Build Robot Code"

--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -3,7 +3,7 @@ Building and Deploying Robot Code
 
 Robot projects must be compiled ("built") and deployed in order to run on the roboRIO.  Since the code is not compiled natively on the robot controller, this is known as "cross-compilation."
 
-.. warning:: Avoid powering off the robot while deploying robot code. Interrupting the deployment process can corrupt the roboRIO filesystem and prevent your code from working until the roboRIO is :doc:`re-imaged <docs/zero-to-robot/step-3/imaging-your-roborio>`.
+.. warning:: Avoid powering off the robot while deploying robot code. Interrupting the deployment process can corrupt the roboRIO filesystem and prevent your code from working until the roboRIO is :doc:`re-imaged </docs/zero-to-robot/step-3/imaging-your-roborio>`.
 
 To build and deploy a robot project, do one of:
 

--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -3,8 +3,6 @@ Building and Deploying Robot Code
 
 Robot projects must be compiled ("built") and deployed in order to run on the roboRIO.  Since the code is not compiled natively on the robot controller, this is known as "cross-compilation."
 
-.. warning:: Avoid powering off the robot while deploying robot code. Interrupting the deployment process can corrupt the roboRIO filesystem and prevent your code from working until the roboRIO is :doc:`re-imaged </docs/zero-to-robot/step-3/imaging-your-roborio>`.
-
 To build and deploy a robot project, do one of:
 
 1. Open the Command Palette and enter/select "Build Robot Code"
@@ -13,6 +11,10 @@ To build and deploy a robot project, do one of:
 
 .. image:: images/deploying-robot-code/building-code-options.png
 
-Deploy robot code by selecting "Deploy Robot Code" from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to the roboRIO. If successful, we will see a "Build Successful" message (1) and the RioLog will open with the console output from the robot program as it runs (2).
+Deploy robot code by selecting "Deploy Robot Code" from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to the roboRIO. 
+
+.. warning:: Avoid powering off the robot while deploying robot code. Interrupting the deployment process can corrupt the roboRIO filesystem and prevent your code from working until the roboRIO is :doc:`re-imaged </docs/zero-to-robot/step-3/imaging-your-roborio>`.
+
+If successful, we will see a "Build Successful" message (1) and the RioLog will open with the console output from the robot program as it runs (2).
 
 .. image:: images/deploying-robot-code/build-successful.png

--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -11,7 +11,7 @@ To build and deploy a robot project, do one of:
 
 .. image:: images/deploying-robot-code/building-code-options.png
 
-Deploy robot code by selecting "Deploy Robot Code" from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to the roboRIO. 
+Deploy robot code by selecting "Deploy Robot Code" from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to the roboRIO.
 
 .. warning:: Avoid powering off the robot while deploying robot code. Interrupting the deployment process can corrupt the roboRIO filesystem and prevent your code from working until the roboRIO is :doc:`re-imaged </docs/zero-to-robot/step-3/imaging-your-roborio>`.
 


### PR DESCRIPTION
This adds a short warning about powering off the robot mid-deployment, since I've seen and heard reports of that causing somewhat difficult-to-diagnose issues at events. "Deploying Robot Code" seemed like the natural place to put it, but if there's somewhere else it should be added then let me know.