### PR TITLE
Add librsvg2-bin as apt dep

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,6 +9,8 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
+  apt_packages:
+    - librsvg2-bin
  
 formats:
   - htmlzip


### PR DESCRIPTION
ReadTheDocs no longer installs this for us. Required for PDF builds.

Pending: Waiting for build to verify functionality