### PR TITLE
Fix and Improve Internal Links Style Guide

### DIFF
--- a/source/docs/contributing/frc-docs/style-guide.rst
+++ b/source/docs/contributing/frc-docs/style-guide.rst
@@ -16,15 +16,6 @@ Suffix filenames with the ``.rst`` extension.
 
 .. note:: If you are having issues editing files with the ``.rst`` extension, the recommended text editor is `Notepad++ <https://notepad-plus-plus.org/>`__. Please make sure that `tabs are replaced with spaces <https://stackoverflow.com/questions/455037/convert-tabs-to-spaces-in-notepad>`__, and the space indentation is set to ``3``.
 
-Page References
----------------
-
-Pages references will be auto-generated based on the page filename and section title.
-
-For example, given the following file ``contributing.rst`` and a section called ``Page References``, you would reference this by doing ``:ref:`contributing:Page References```
-
-.. note:: Please note that document structure is preserved in references, with the root being the location of the ``conf.py`` file. To access documents in sub-folders, simply prepend the folder path before the filename. IE, ``:ref:`docs/software/hardware-apis/sensors/ultrasonics-sensors:Ultrasonics - Sensors```
-
 Text
 ----
 
@@ -151,6 +142,15 @@ NOT
 
    .. warning::
       This is a warning!
+
+Page References
+---------------
+
+Pages references will be auto-generated based on the page filename and section title.
+
+For example, given the following file ``contributing.rst`` and a section called ``Page References``, you would reference this by doing ``:ref:`contributing:Page References```
+
+.. note:: Please note that document structure is preserved in references, with the root being the location of the ``conf.py`` file. To access documents in sub-folders, simply prepend the folder path before the filename. IE, ``:ref:`docs/software/hardware-apis/sensors/ultrasonics-sensors:Ultrasonics - Sensors```
 
 Links
 -----

--- a/source/docs/contributing/frc-docs/style-guide.rst
+++ b/source/docs/contributing/frc-docs/style-guide.rst
@@ -143,19 +143,22 @@ NOT
    .. warning::
       This is a warning!
 
-Page References
----------------
-
-Pages references will be auto-generated based on the page filename and section title.
-
-For example, given the following file ``contributing.rst`` and a section called ``Page References``, you would reference this by doing ``:ref:`contributing:Page References```
-
-.. note:: Please note that document structure is preserved in references, with the root being the location of the ``conf.py`` file. To access documents in sub-folders, simply prepend the folder path before the filename. IE, ``:ref:`docs/software/hardware-apis/sensors/ultrasonics-sensors:Ultrasonics - Sensors```
-
 Links
 -----
 
-It is preferred to format links as anonymous hyperlinks. The important thing to note is the **two** underscores appending the text. In the situation that only one underscore is used, issues may arise when compiling the document.
+Internal Links
+^^^^^^^^^^^^^^
+
+Internal links will be auto-generated based on the page filename and section title.
+
+For example, given the following file ``contributing.rst`` and a section called ``Internal Links``, you would reference this by doing ``:ref:`contributing:Internal Links```
+
+.. note:: Please note that document structure is preserved in references, with the root being the location of the ``conf.py`` file. To access documents in sub-folders, simply prepend the folder path before the filename. IE, ``:ref:`docs/software/hardware-apis/sensors/ultrasonics-sensors:Ultrasonics - Sensors```
+
+External Links
+^^^^^^^^^^^^^^
+
+It is preferred to format external links as anonymous hyperlinks. The important thing to note is the **two** underscores appending the text. In the situation that only one underscore is used, issues may arise when compiling the document.
 
 .. code-block:: ReST
 

--- a/source/docs/contributing/frc-docs/style-guide.rst
+++ b/source/docs/contributing/frc-docs/style-guide.rst
@@ -149,11 +149,17 @@ Links
 Internal Links
 ^^^^^^^^^^^^^^
 
-Internal links will be auto-generated based on the page filename and section title.
+Internal Links will be auto-generated based on the ReStructuredText filename and section title.
 
-For example, given the following file ``contributing.rst`` and a section called ``Internal Links``, you would reference this by doing ``:ref:`contributing:Internal Links```
+For example, here are several ways to link to sections and documents.
 
-.. note:: Please note that document structure is preserved in references, with the root being the location of the ``conf.py`` file. To access documents in sub-folders, simply prepend the folder path before the filename. IE, ``:ref:`docs/software/hardware-apis/sensors/ultrasonics-sensors:Ultrasonics - Sensors```
+Use this format to reference a document section. You must use the absolute path of the document. ``:ref:`docs/software/hardware-apis/sensors/ultrasonics-software:Analog ultrasonics``` renders to :ref:`docs/software/hardware-apis/sensors/ultrasonics-software:Analog ultrasonics`.
+
+Use this format to reference a section of the same document. Note the single underscore. ```Images`_`` renders to `Images`_.
+
+Use this format to reference the top-level of a document. You can use relative paths ``:doc:`build-instructions``` renders to :doc:`build-instructions` Or to use absolute paths, put a forward slash at the beginning of the path ``:doc:`/docs/software/hardware-apis/sensors/ultrasonics-software``` renders to :doc:`/docs/software/hardware-apis/sensors/ultrasonics-software`. Note that the text rendered is the main section title of the target page regardless of the target filename.
+
+When using ``:ref:`` or ``:doc:`` you may customize the displayed text by surrounding the actual link with angle brackets ``<>`` and adding the custom text between the first backtick ````` and the first angle bracket ``<``. For example ``:ref:`custom text <docs/software/hardware-apis/sensors/ultrasonics-software:Analog ultrasonics>``` renders to :ref:`custom text <docs/software/hardware-apis/sensors/ultrasonics-software:Analog ultrasonics>`.
 
 External Links
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
This fixes and improves the Page References section of the Style Guide.

If there's a better way to format these examples rather than strung together in a paragraph, that would be great.