### PR TITLE
Remove or update game specific terms in glossary

### DIFF
--- a/source/docs/software/frc-glossary.rst
+++ b/source/docs/software/frc-glossary.rst
@@ -8,11 +8,8 @@ FRC Glossary
    accelerometer
       A common sensor used to measure acceleration in one or more axis.
 
-   alliance
-      A cooperative of up to four (4) FIRST\ |reg| Robotics Competition teams.
-
    auto
-      The first phase of each :term:`match` is called Autonomous (auto) and consists of the first fifteen (0:15) seconds.
+      The first phase of each match is called Autonomous (auto) and consists of the robot's running pre-programmed instructions.
 
    COTS
       Commercial off the shelf, a standard (i.e. not custom order) part commonly available from a vendor to all teams for purchase.
@@ -48,19 +45,13 @@ FRC Glossary
       Kit of Parts, the collection of items listed on the Kickoff Kit checklists, distributed to the team via FIRST Choice, or paid for completely (except shipping) with a Product Donation Voucher (PDV).
 
    KOP chassis
-      The `AM14U4 <https://www.andymark.com/products/am14u4-kit-of-parts-chassis>`__ chassis distributed to every team (that did not opt out) as part of the :term:`KOP`.
+      The KOP contains a drive base (chassis) distributed to every team (that did not opt out) as part of the :term:`KOP`. For the 2022 season, the KOP chassis is the `AM14U5 <https://www.andymark.com/products/am14u5-6-wheel-drop-center-robot-drive-base-first-kit-of-parts-chassis>`__.
 
    LabVIEW
       One of the three officially supported programming languages.
 
-   match
-      A two (2) minute and thirty (30) second period of time in which an :term:`alliance` plays a FRC game.
-
    NetworkTables
       A way to communicate key / value pairs of data between programs.
-
-   RP
-      Ranking Point, a way of ordering teams rewarding specific objectives in addition to winning the match.
 
    simulation
       A way for teams to test their code without having an actual robot available.


### PR DESCRIPTION
Several terms in glossary weren't used and are game specific and may
change in the future. Updated a few others to be less game specific

Supercedes #1851