### PR TITLE
correct roboRIO capitalization

### DIFF
--- a/source/docs/hardware/sensors/serial-buses.rst
+++ b/source/docs/hardware/sensors/serial-buses.rst
@@ -61,7 +61,7 @@ To communicate to peripheral devices over RS-232, each pin should be wired to it
 
 The RS-232 bus can also be used through the `MXP expansion port`_.
 
-The RoboRIO RS-232 serial port uses RS-232 signaling levels (+/- 15v). The MXP serial port uses CMOS signaling levels (+/- 3.3v).
+The roboRIO RS-232 serial port uses RS-232 signaling levels (+/- 15v). The MXP serial port uses CMOS signaling levels (+/- 3.3v).
 
 .. note:: By default, the onboard RS-232 port is utilized by the roboRIO's serial console. In order to use it for an external device, the serial console must be disabled using the :ref:`Imaging Tool <docs/zero-to-robot/step-3/imaging-your-roborio:Imaging your roboRIO>` or :ref:`docs/software/roborio-info/roborio-web-dashboard:roboRIO Web Dashboard`.
 

--- a/source/docs/software/advanced-gradlerio/gradlew-tasks.rst
+++ b/source/docs/software/advanced-gradlerio/gradlew-tasks.rst
@@ -19,7 +19,7 @@ EmbeddedTools tasks
 
 ``./gradlew deploy`` - Deploy all artifacts on all targets. This will deploy your robot project to the available targets (IE, roboRIO).
 
-``./gradlew discoverRoborio`` - Determine the address(es) of target RoboRIO. This will print out the IP address of a connected roboRIO.
+``./gradlew discoverRoborio`` - Determine the address(es) of target roboRIO. This will print out the IP address of a connected roboRIO.
 
 GradleRIO tasks
 ---------------
@@ -32,7 +32,7 @@ GradleRIO tasks
 
 ``./gradlew InstallAllTools`` - Installs all available tools. This excludes the development environment such as VSCode. It's the users requirement to ensure the required dependencies (Java) is installed. Only recommended for advanced users!
 
-``./gradlew riolog`` - Runs a console displaying output from the default RoboRIO (roborio)
+``./gradlew riolog`` - Runs a console displaying output from the default roboRIO (roborio)
 
 ``./gradlew simulateExternalCpp`` - Simulate External Task for native executable. Exports a JSON file for use by editors / tools
 


### PR DESCRIPTION
https://docs.wpilib.org/en/stable/docs/contributing/frc-docs/style-guide.html#:~:text=roboRIO%20(not%20RoboRIO%2C%20roboRio%2C%20or%20RoboRio)