### PR TITLE
Drivetrain Simulation note: write code in steps 1-2 in a separate subsystem 

### DIFF
--- a/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/simulation-instance.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/simulation-instance.rst
@@ -2,6 +2,8 @@ Step 1: Creating Simulated Instances of Hardware
 ================================================
 The WPILib simulation framework contains several ``XXXSim`` classes, where ``XXX`` represents physical hardware such as encoders or gyroscopes. These simulation classes can be used to set positions and velocities (for encoders) and angles (for gyroscopes) from a model of your drivetrain. See :ref:`the Device Simulation article<docs/software/wpilib-tools/robot-simulation/device-sim:Device Simulation>` for more info about these simulation hardware classes and simulation of vendor devices.
 
+.. note:: If you are using the command-based framework, it is recommended that you write the code in steps 1-2 in a separate subsystem named ``Drivetrain``.
+
 Simulating Encoders
 -------------------
 The ``EncoderSim`` class allows users to set encoder positions and velocities on a given ``Encoder`` object. When running on real hardware, the ``Encoder`` class interacts with real sensors to count revolutions (and convert them to distance units automatically if configured to do so); however, in simulation there are no such measurements to make. The ``EncoderSim`` class can accept these simulated readings from a model of your drivetrain.

--- a/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/simulation-instance.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/simulation-instance.rst
@@ -2,7 +2,7 @@ Step 1: Creating Simulated Instances of Hardware
 ================================================
 The WPILib simulation framework contains several ``XXXSim`` classes, where ``XXX`` represents physical hardware such as encoders or gyroscopes. These simulation classes can be used to set positions and velocities (for encoders) and angles (for gyroscopes) from a model of your drivetrain. See :ref:`the Device Simulation article<docs/software/wpilib-tools/robot-simulation/device-sim:Device Simulation>` for more info about these simulation hardware classes and simulation of vendor devices.
 
-.. note:: Simulation objects associated with a particular subsystem should live in that subsystem. An example of this is in the ``StateSpaceDriveSimulation`` (`Java <https://github.com/wpilibsuite/allwpilib/blob/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java>`__, `C++ <https://github.com/wpilibsuite/allwpilib/blob/main/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/subsystems/DriveSubsystem.cpp>`__) example. 
+.. note:: Simulation objects associated with a particular subsystem should live in that subsystem. An example of this is in the ``StateSpaceDriveSimulation`` (`Java <https://github.com/wpilibsuite/allwpilib/blob/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java>`__, `C++ <https://github.com/wpilibsuite/allwpilib/blob/main/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/subsystems/DriveSubsystem.cpp>`__) example.
 
 Simulating Encoders
 -------------------

--- a/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/simulation-instance.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/simulation-instance.rst
@@ -2,7 +2,7 @@ Step 1: Creating Simulated Instances of Hardware
 ================================================
 The WPILib simulation framework contains several ``XXXSim`` classes, where ``XXX`` represents physical hardware such as encoders or gyroscopes. These simulation classes can be used to set positions and velocities (for encoders) and angles (for gyroscopes) from a model of your drivetrain. See :ref:`the Device Simulation article<docs/software/wpilib-tools/robot-simulation/device-sim:Device Simulation>` for more info about these simulation hardware classes and simulation of vendor devices.
 
-.. note:: If you are using the command-based framework, it is recommended that you write the code in steps 1-2 in a separate subsystem named ``Drivetrain``.
+.. note:: Simulation objects associated with a particular subsystem should live in that subsystem. An example of this is in the ``StateSpaceDriveSimulation`` (`Java <https://github.com/wpilibsuite/allwpilib/blob/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/statespacedifferentialdrivesimulation/subsystems/DriveSubsystem.java>`__, `C++ <https://github.com/wpilibsuite/allwpilib/blob/main/wpilibcExamples/src/main/cpp/examples/StateSpaceDifferentialDriveSimulation/cpp/subsystems/DriveSubsystem.cpp>`__) example. 
 
 Simulating Encoders
 -------------------


### PR DESCRIPTION
It is not clear where to write the code in steps 1-2; for this reason, I added a note indicating that if the user is using the command-based framework, they should write the following code in a separate subsystem. 