### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on: [pull_request, push]
 
 jobs:
-  build:
+  build-pdf:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -20,14 +20,6 @@ jobs:
       run: |
         sudo apt-fast -y update
         sudo apt-fast install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra dvipng librsvg2-bin
-    - name: Build HTML
-      run: |
-        make html SPHINXOPTS="-j 3"
-    - name: Archive HTML
-      uses: actions/upload-artifact@v2
-      with:
-        name: frc-docs-html
-        path: build/html/
     - name: Build PDF
       run: |
         make latexpdf SPHINXOPTS="-j 3"
@@ -36,6 +28,31 @@ jobs:
       with:
         name: frc-docs-pdf
         path: build/latex/firstroboticscompetition.pdf
+        if-no-files-found: error
+        
+  build-html:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Tune
+      uses: abbbi/github-actions-tune@v1
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+        cache: 'pip'
+    - name: Install Python Dependencies
+      run: |
+        pip install -r source/requirements.txt
+    - name: Build HTML
+      run: |
+        make html SPHINXOPTS="-j 3"
+    - name: Archive HTML
+      uses: actions/upload-artifact@v2
+      with:
+        name: frc-docs-html
+        path: build/html/
+        if-no-files-found: error
+        
   check-links:
     runs-on: ubuntu-latest
     steps:
@@ -52,6 +69,7 @@ jobs:
     - name: Check Links
       run: |
         make linkcheck
+        
   check-linting:
     runs-on: ubuntu-latest
     steps:
@@ -65,6 +83,7 @@ jobs:
     - name: Check Lint
       run: |
         make lint
+        
   check-image-size:
     runs-on: ubuntu-latest
     steps:
@@ -75,6 +94,7 @@ jobs:
     - name: Check Image Size
       run: |
         make sizecheck
+        
   check-spelling:
     runs-on: ubuntu-latest
     steps:
@@ -84,6 +104,7 @@ jobs:
         with:
           locale: "US"
           reporter: "github-check"
+          
   check-redirects:
     runs-on: ubuntu-latest
     steps:
@@ -103,6 +124,7 @@ jobs:
     - name: Check redirects format
       run: |
         [[ $(<source/redirects.txt) == $(git show origin/main:source/redirects.txt)* ]] || { echo "Error: redirects.txt can only be appended to. Lines cannot be modified or deleted."; exit 1; }
+        
   check-formatting:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Run Tune
+      uses: abbbi/github-actions-tune@v1
     - uses: actions/setup-python@v4
       with:
         python-version: 3.9
@@ -16,11 +18,11 @@ jobs:
         pip install -r source/requirements.txt
     - name: Install LaTeX
       run: |
-        sudo apt-get update
-        sudo apt install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra dvipng librsvg2-bin
+        sudo apt-fast -y update
+        sudo apt-fast install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra dvipng librsvg2-bin
     - name: Build HTML
       run: |
-        make html
+        make html SPHINXOPTS="-j 3"
     - name: Archive HTML
       uses: actions/upload-artifact@v2
       with:
@@ -28,7 +30,7 @@ jobs:
         path: build/html/
     - name: Build PDF
       run: |
-        make latexpdf
+        make latexpdf SPHINXOPTS="-j 3"
     - name: Archive PDF
       uses: actions/upload-artifact@v2
       with:
@@ -37,10 +39,10 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Checkout main
-      run: |
-        git fetch origin main --depth=1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: main
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-fast install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra dvipng librsvg2-bin
     - name: Build PDF
       run: |
-        make latexpdf SPHINXOPTS="-j 3"
+        make latexpdf
     - name: Archive PDF
       uses: actions/upload-artifact@v2
       with:
@@ -45,7 +45,7 @@ jobs:
         pip install -r source/requirements.txt
     - name: Build HTML
       run: |
-        make html SPHINXOPTS="-j 3"
+        make html
     - name: Archive HTML
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run Tune
-      uses: abbbi/github-actions-tune@v1
     - uses: actions/setup-python@v4
       with:
         python-version: 3.9

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
+        cache: 'pip'
     - name: Install Python Dependencies
       run: |
         pip install -r source/requirements.txt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run Tune
-      uses: abbbi/github-actions-tune@v1
     - uses: actions/setup-python@v4
       with:
         python-version: 3.9


### PR DESCRIPTION
Cuts down build times from 16+ min to sub 8 min. 

- Use apt-fast
- Cache python packages
- Disable man pages
- Multithread builds
- Split PDF and HTML builds into separate jobs 
- Fail build if artifact not found

*Note, if merged please do a squash merge