### PR TITLE
Make Path Planning intro render correctly

### DIFF
--- a/source/docs/software/pathplanning/index.rst
+++ b/source/docs/software/pathplanning/index.rst
@@ -7,8 +7,11 @@ Notice on Swerve Support
 ------------------------
 
 Swerve support in path following has a couple of limitations that teams need to be aware of:
+
 - WPILib currently does not support swerve in simulation, please see `this <https://github.com/wpilibsuite/allwpilib/pull/3374>`__ pull request.
+
 - SysID only supports tuning the swerve heading using a General Mechanism project and does not regularly support module velocity data. A workaround is to lock the module's heading into place. This can be done via blocking module rotation using something like a block of wood.
+
 - Pathweaver and Trajectory following currently do not incorporate independent heading. Path following using the WPILib trajectory framework on swerve will be the same as a DifferentialDrive robot.
 
 We are sorry for the inconvenience.


### PR DESCRIPTION
The dot points did not have spaces between them, which makes them rendered as one line.