### PR TITLE
Add quiet flag to sphinxbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # You can set these variables from the command line.
 
-SPHINXOPTS    = -W --keep-going
+SPHINXOPTS    = -W --keep-going -q
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
From https://www.sphinx-doc.org/en/master/man/sphinx-build.html:
```
-q
    Do not output anything on standard output, only write warnings and errors to standard error.
```
This makes it much easier to find errors and warnings that are normally
buried in the middle of the build log.