### PR TITLE
Install librsvg2 in HTML build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,10 @@ jobs:
     - name: Install Python Dependencies
       run: |
         pip install -r source/requirements.txt
+    - name: Install librsvg2
+      run: |
+        sudo apt-fast -y update
+        sudo apt-fast install -y librsvg2-bin
     - name: Build HTML
       run: |
         make html


### PR DESCRIPTION
This fixes the SVG to PNG conversion errors that aren't failing the
build. They were introduced in the CI refactor when the PDF and HTML
jobs were split. The PDF build still installed the package, but not the
HTML build.