### PR TITLE
Fix Drivetrain Simulation Code Example

### DIFF
--- a/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.rst
@@ -172,7 +172,7 @@ You can calculate the measurement noise of your sensors by taking multiple data 
       private DifferentialDrivetrainSim m_driveSim = DifferentialDrivetrainSim.createKitbotSim(
         KitbotMotor.kDualCIMPerSide, // 2 CIMs per side.
         KitbotGearing.k10p71,        // 10.71:1
-        KitbotWheelSize.SixInch,     // 6" diameter wheels.
+        KitbotWheelSize.kSixInch,     // 6" diameter wheels.
         null                         // No measurement noise.
       );
 

--- a/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.rst
@@ -130,14 +130,14 @@ You can calculate the measurement noise of your sensors by taking multiple data 
       static constexpr auto KvAngular = 1.5_V / 1_rad_per_s;
       static constexpr auto KaAngular = 0.3_V / 1_rad_per_s_sq;
       // The track width is 0.7112 meters.
-      static constexpr auto TrackWidth = 0.7112_m;
+      static constexpr auto kTrackwidth = 0.7112_m;
 
       // Create the simulation model of our drivetrain.
       frc::sim::DifferentialDrivetrainSim m_driveSim{
         // Create a linear system from our identification gains.
         frc::LinearSystemId::IdentifyDrivetrainSystem(
-          KvLinear, KaLinear, KvAngular, KaAngular, TrackWidth),
-        TrackWidth,
+          KvLinear, KaLinear, KvAngular, KaAngular, kTrackWidth),
+        kTrackWidth,
         frc::DCMotor::GetNEO(2), // 2 NEO motors on each side of the drivetrain.
         7.29,               // 7.29:1 gearing reduction.
         3_in,               // The robot uses 3" radius wheels.

--- a/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.rst
@@ -172,7 +172,7 @@ You can calculate the measurement noise of your sensors by taking multiple data 
       private DifferentialDrivetrainSim m_driveSim = DifferentialDrivetrainSim.createKitbotSim(
         KitbotMotor.kDualCIMPerSide, // 2 CIMs per side.
         KitbotGearing.k10p71,        // 10.71:1
-        KitbotWheelSize.kSixInch,     // 6" diameter wheels.
+        KitbotWheelSize.kSixInch,    // 6" diameter wheels.
         null                         // No measurement noise.
       );
 

--- a/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.rst
+++ b/source/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.rst
@@ -129,13 +129,15 @@ You can calculate the measurement noise of your sensors by taking multiple data 
       static constexpr auto KaLinear = 0.2_V / 1_mps_sq;
       static constexpr auto KvAngular = 1.5_V / 1_rad_per_s;
       static constexpr auto KaAngular = 0.3_V / 1_rad_per_s_sq;
+      // The track width is 0.7112 meters.
+      static constexpr auto TrackWidth = 0.7112_m;
 
       // Create the simulation model of our drivetrain.
       frc::sim::DifferentialDrivetrainSim m_driveSim{
         // Create a linear system from our identification gains.
         frc::LinearSystemId::IdentifyDrivetrainSystem(
-          KvLinear, KaLinear, KvAngular, KaAngular),
-        0.7112_m,           // The track width is 0.7112 meters.
+          KvLinear, KaLinear, KvAngular, KaAngular, TrackWidth),
+        TrackWidth,
         frc::DCMotor::GetNEO(2), // 2 NEO motors on each side of the drivetrain.
         7.29,               // 7.29:1 gearing reduction.
         3_in,               // The robot uses 3" radius wheels.


### PR DESCRIPTION
`IdentifyDrivetrainSystem` currently has 2 overloads https://first.wpi.edu/wpilib/allwpilib/docs/release/cpp/classfrc_1_1_linear_system_id.html#a683b6de8c6a77b64329f0184b8f2bff2 -- they use inconsistent types and the example given has types consistent with the 5 argument overload. It is very possible that the 4 argument version is just using the wrong units and should be changed to match the example instead.