### PR TITLE
BASEDIR usage within conf.py

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -225,16 +225,14 @@ user_options = [
 # We generally want to group, merge, and minify the js files
 
 if 'data' in globals():
-    js_build_dir = BASEDIR #allow an alternate basedir if set into globals by another script
+    js_build_dir = BASEDIR # allow an alternate basedir if set into globals by another script
 else:
-    js_build_dir = os.path.dirname(__file__) #otherwise, just use this file's directory as the build idr.
+    js_build_dir = os.path.dirname(__file__) # otherwise, just use this file's directory
 
 js_pid_src_path = os.path.join(js_build_dir, "_static/js/pid-tune/*.js")
 js_pid_output_file = os.path.join(js_build_dir, "_static/js/pid-tune.js")
 
-
 debugJS = False  # flip to true to make the output js more readable
-
 
 def mergeAndMinify(sourceDir, outputFile):
     with open(outputFile, "w") as outf:

--- a/source/conf.py
+++ b/source/conf.py
@@ -224,15 +224,18 @@ user_options = [
 # Handle custom javascript
 # We generally want to group, merge, and minify the js files
 
-if 'data' in globals():
-    js_build_dir = BASEDIR # allow an alternate basedir if set into globals by another script
+if "BASEDIR" in globals():
+    # allow an alternate basedir if set into globals by another script
+    js_build_dir = BASEDIR
 else:
-    js_build_dir = os.path.dirname(__file__) # otherwise, just use this file's directory
+    # otherwise, just use this file's directory
+    js_build_dir = os.path.dirname(__file__)
 
 js_pid_src_path = os.path.join(js_build_dir, "_static/js/pid-tune/*.js")
 js_pid_output_file = os.path.join(js_build_dir, "_static/js/pid-tune.js")
 
 debugJS = False  # flip to true to make the output js more readable
+
 
 def mergeAndMinify(sourceDir, outputFile):
     with open(outputFile, "w") as outf:

--- a/source/conf.py
+++ b/source/conf.py
@@ -223,7 +223,12 @@ user_options = [
 
 # Handle custom javascript
 # We generally want to group, merge, and minify the js files
-js_build_dir = os.path.dirname(__file__)
+
+if 'data' in globals():
+    js_build_dir = BASEDIR #allow an alternate basedir if set into globals by another script
+else:
+    js_build_dir = os.path.dirname(__file__) #otherwise, just use this file's directory as the build idr.
+
 js_pid_src_path = os.path.join(js_build_dir, "_static/js/pid-tune/*.js")
 js_pid_output_file = os.path.join(js_build_dir, "_static/js/pid-tune.js")
 


### PR DESCRIPTION
Allow BASEDIR to define the javascript output directory if it exists