### PR TITLE
Update beta docs to remove info about importer

### DIFF
--- a/source/docs/beta/tasks/task-3-port-code.rst
+++ b/source/docs/beta/tasks/task-3-port-code.rst
@@ -8,8 +8,6 @@ Overview
 
 The purpose of this task is to port your robot code to the new development environment and bring it to a fully functional state. Make sure to post in the discussions or file a bug in the tracker for any items that do not seem to be working properly.
 
-For C++/Java teams, the Project Importer will attempt to update your code to handle many of the breaking changes for 2022. Please include in your report any items that were not properly updated or that you had to change in order for your code to compile or work correctly.
-
 Desired Feedback
 ----------------
 

--- a/source/docs/beta/tasks/task-4-new-features.rst
+++ b/source/docs/beta/tasks/task-4-new-features.rst
@@ -18,7 +18,7 @@ The purpose of this task is to test any newly developed or heavily modified feat
 **C++/Java**
 
 - 3D Geometry classes & ComputerVisionUtil
-- Linear Time-Varying controllers for unicycles (Ramsete replacement) and diff drives
+- Linear Time-Varying controllers for unicycles (Ramsete replacement) and differential drives
 
 Desired Feedback
 ----------------


### PR DESCRIPTION
The importer handles renames, but not the changes made in 2023 Also spell out differential