### PR TITLE
fix linkcheck on PRs running on main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,7 +86,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: main
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9


### PR DESCRIPTION
the check links action for PRs was running on main and not on PR, as seen by this actions run where the broken link was fixed, but shown as broken since it was run on main and not the PR version.