### PR TITLE
Hide Beta test from main index

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -258,6 +258,7 @@ Community translations can be found in a variety of languages in the bottom-left
    :maxdepth: 1
    :titlesonly:
    :caption: FRC Beta Test
+   :hidden:
 
    docs/beta/beta-getting-started/index
    docs/beta/tasks/index


### PR DESCRIPTION
It's not panelized, and available on the left nav bar

Before:
![image](https://user-images.githubusercontent.com/4885091/201496279-2a0b5a1f-86c5-4ca7-8862-b5ab93e17c65.png)




After:
![image](https://user-images.githubusercontent.com/4885091/201496314-cf4c02ca-4730-4cd3-826e-8b193df3932b.png)
