### PR TITLE
Update changelog with SwerveDriveOdometry changes, remove incorrect info

### DIFF
--- a/source/docs/yearly-overview/yearly-changelog.rst
+++ b/source/docs/yearly-overview/yearly-changelog.rst
@@ -88,7 +88,6 @@ Breaking Changes
 .. danger:: Updated ``DifferentialDrive`` and ``MecanumDrive`` classes to use North-West-Up axis conventions to match the rest of WPILib. The Z-axis (i.e. turning) will need to be inverted to restore the old behavior.
 
 - Removed deprecated ``MakeMatrix()`` from ``StateSpaceUtil``
-- Removed deprecated ``CameraServer`` class
 - Removed deprecated ``KilloughDrive`` class
 - Removed deprecated ``SpeedController`` and ``SpeedControllerGroup`` classes. Use MotorController and MotorControllerGroup instead
 - Removed deprecated ``MatrixUtils`` class
@@ -98,6 +97,7 @@ Breaking Changes
 - Refactored command ``interruptible`` to be an enum property (``getInterruptionBehavior()``) of the command object rather than a boolean flag when scheduling; the ``withInterruptBehavior(InterruptBehavior)`` decorator can be used to set this property
 - Command lifecycle methods of command groups cannot be overridden
 - [C++ only] Command Decorators changed to return ``CommandPtr`` -- a new move-only value type for holding commands
+- ``SwerveDriveOdometry`` and ``SwerveDrivePoseEstimator`` now use wheel distances instead of wheel speeds; Use ``SwerveModulePosition`` to represent a swerve module's angle and distance driven.
 - Removed wpi versions of C++20 methods
 
    - Use ``std::numbers`` instead of ``wpi::numbers`` (include ``<numbers>``)


### PR DESCRIPTION
Closes #1966

`CameraServer` was not removed