### PR TITLE
Declare static import for Commands factories

### DIFF
--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -229,6 +229,8 @@ While static factories are manageable for single-subsystem commands, they excel 
 
   .. code-tab:: java
 
+    import static edu.wpi.first.wpilibj2.command.Commands.*;
+
     public class AutoRoutines {
 
         public static Command driveAndIntake(Drivetrain drivetrain, Intake intake) {
@@ -251,7 +253,7 @@ While static factories are manageable for single-subsystem commands, they excel 
 
     // TODO
 
-Also, note the use of static factories to construct sequential and parallel command groups: this is equivalent to the ``andThen`` and ``alongWith`` decorators, but can be more expressive in some cases. Their use is a matter of personal preference.
+Also, note the use of static factories from ``Commands`` to construct sequential and parallel command groups: this is equivalent to the ``andThen`` and ``alongWith`` decorators, but can be more expressive in some cases. Their use is a matter of personal preference.
 
 
 Subclassing Command Groups

--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -229,8 +229,6 @@ While static factories are manageable for single-subsystem commands, they excel 
 
   .. code-tab:: java
 
-    import edu.wpi.first.wpilibj2.command.Commands;
-
     public class AutoRoutines {
 
         public static Command driveAndIntake(Drivetrain drivetrain, Intake intake) {
@@ -253,7 +251,7 @@ While static factories are manageable for single-subsystem commands, they excel 
 
     // TODO
 
-Also, note the use of static factories from ``Commands`` to construct sequential and parallel command groups: this is equivalent to the ``andThen`` and ``alongWith`` decorators, but can be more expressive in some cases. Their use is a matter of personal preference.
+Also, note the use of static factories to construct sequential and parallel command groups: this is equivalent to the ``andThen`` and ``alongWith`` decorators, but can be more expressive in some cases. Their use is a matter of personal preference.
 
 
 Subclassing Command Groups

--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -229,19 +229,19 @@ While static factories are manageable for single-subsystem commands, they excel 
 
   .. code-tab:: java
 
-    import static edu.wpi.first.wpilibj2.command.Commands.*;
+    import edu.wpi.first.wpilibj2.command.Commands;
 
     public class AutoRoutines {
 
         public static Command driveAndIntake(Drivetrain drivetrain, Intake intake) {
-            return parallel(
+            return Commands.parallel(
                 drivetrain.commandDrive(0.5,0.5),
                 intake.runIntakeCommand(1.0)
             ).withTimeout(5.0);
         }
 
         public static Command intakeThenOuttake(Intake intake) {
-            return sequence(
+            return Commands.sequence(
                 intake.runIntakeCommand(1.0).withTimeout(2.0),
                 new WaitCommand(3.0),
                 intake.runIntakeCommand(-1).withTimeout(2.0)


### PR DESCRIPTION
It is currently unclear where `parallel` and `sequence` are from, but the addition of a static import will make it clear.