### PR TITLE
Update odometry tutorials after API changes

### DIFF
--- a/source/docs/software/kinematics-and-odometry/differential-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/differential-drive-odometry.rst
@@ -6,11 +6,14 @@ A user can use the differential drive kinematics classes in order to perform :re
 
 Creating the Odometry Object
 ----------------------------
-The ``DifferentialDriveOdometry`` class requires one mandatory argument and one optional argument. The mandatory argument is the angle reported by your gyroscope (as a Rotation2d). The optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
+The ``DifferentialDriveOdometry`` class constructor requires three mandatory arguments and one optional argument. The mandatory arguments are:
 
-.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. By default, WPILib gyros exhibit the opposite behavior, so you should negate the gyro angle.
+* The angle reported by your gyroscope (as a ``Rotation2d``)
+* The initial left and right encoder readings. In Java, these are each a ``double``, and must represent the distance travelled by each side in meters.  In C++, the :doc:`units library </docs/software/basic-programming/cpp-units>` must be used to represent your wheel positions.
 
-.. important:: The encoder positions must be reset to zero before constructing the ``DifferentialDriveOdometry`` class.
+The optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
+
+.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose. See :ref:`Field Coordinate System <docs/software/advanced-controls/geometry/coordinate-systems:Field Coordinate System>` for more information about the coordinate system.
 
 .. tabs::
 
@@ -20,14 +23,19 @@ The ``DifferentialDriveOdometry`` class requires one mandatory argument and one 
       // our starting pose is 5 meters along the long end of the field and in the
       // center of the field along the short end, facing forward.
       DifferentialDriveOdometry m_odometry = new DifferentialDriveOdometry(
-        getGyroHeading(), new Pose2d(5.0, 13.5, new Rotation2d()));
+        m_gyro.getRotation2d(),
+        m_leftEncoder.getDistance(), m_rightEncoder.getDistance(),
+        new Pose2d(5.0, 13.5, new Rotation2d()));
 
    .. code-tab:: c++
 
       // Creating my odometry object. Here,
       // our starting pose is 5 meters along the long end of the field and in the
       // center of the field along the short end, facing forward.
-      frc::DifferentialDriveOdometry m_odometry{GetGyroHeading(),
+      frc::DifferentialDriveOdometry m_odometry{
+        m_gyro.GetRotation2d(),
+        units::meter_t{m_leftEncoder.GetDistance()},
+        units::meter_t{m_rightEncoder.GetDistance()},
         frc::Pose2d{5_m, 13.5_m, 0_rad}};
 
 
@@ -35,7 +43,7 @@ Updating the Robot Pose
 -----------------------
 The ``update`` method can be used to update the robot's position on the field. This method must be called periodically, preferably in the ``periodic()`` method of a :ref:`Subsystem <docs/software/commandbased/subsystems:Subsystems>`. The ``update`` method returns the new updated pose of the robot. This method takes in the gyro angle of the robot, along with the left encoder distance and right encoder distance.
 
-.. note:: The encoder distances in Java must be in meters. In C++, the units library can be used to represent the distance using any linear distance unit. If the robot is moving forward in a straight line, **both** distances (left and right) must be positive.
+.. note:: If the robot is moving forward in a straight line, **both** distances (left and right) must be increasing.
 
 .. tabs::
 
@@ -43,32 +51,32 @@ The ``update`` method can be used to update the robot's position on the field. T
 
       @Override
       public void periodic() {
-        // Get my gyro angle. We are negating the value because gyros return positive
-        // values as the robot turns clockwise. This is not standard convention that is
-        // used by the WPILib classes.
-        var gyroAngle = Rotation2d.fromDegrees(-m_gyro.getAngle());
+        // Get my gyro angle.
+        var gyroAngle = m_gyro.getRotation2d();
 
         // Update the pose
-        m_pose = m_odometry.update(gyroAngle, m_leftEncoder.getDistance(), m_rightEncoder.getDistance());
+        m_pose = m_odometry.update(gyroAngle,
+          m_leftEncoder.getDistance(),
+          m_rightEncoder.getDistance());
       }
 
    .. code-tab:: c++
 
       void Periodic() override {
-        // Get my gyro angle. We are negating the value because gyros return positive
-        // values as the robot turns clockwise. This is not standard convention that is
-        // used by the WPILib classes.
-        frc::Rotation2d gyroAngle{units::degree_t(-m_gyro.GetAngle())};
+        // Get my gyro angle.
+        frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
 
         // Update the pose
-        m_pose = m_odometry.Update(gyroAngle, m_leftEncoder.GetDistance(), m_rightEncoder.GetDistance());
+        m_pose = m_odometry.Update(gyroAngle,
+          units::meter_t{m_leftEncoder.GetDistance()},
+          units::meter_t{m_rightEncoder.GetDistance()});
       }
 
 Resetting the Robot Pose
 ------------------------
-The robot pose can be reset via the ``resetPose`` method. This method accepts two arguments -- the new field-relative pose and the current gyro angle.
+The robot pose can be reset via the ``resetPosition`` method. This method accepts four arguments: the current gyro angle, the left and right wheel positions, and the new field-relative pose.
 
-.. important:: If at any time, you decide to reset your gyroscope, the ``resetPose`` method MUST be called with the new gyro angle. Furthermore, the encoders must also be reset to zero when resetting the pose.
+.. important:: If at any time, you decide to reset your gyroscope or encoders, the ``resetPosition`` method MUST be called with the new gyro angle and wheel distances.
 
 .. note:: A full example of a differential drive robot with odometry is available here: `C++ <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibcExamples/src/main/cpp/examples/DifferentialDriveBot>`_ / `Java <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdrivebot>`_.
 

--- a/source/docs/software/kinematics-and-odometry/differential-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/differential-drive-odometry.rst
@@ -51,7 +51,7 @@ The ``update`` method can be used to update the robot's position on the field. T
 
       @Override
       public void periodic() {
-        // Get my gyro angle.
+        // Get the rotation of the robot from the gyro.
         var gyroAngle = m_gyro.getRotation2d();
 
         // Update the pose
@@ -63,7 +63,7 @@ The ``update`` method can be used to update the robot's position on the field. T
    .. code-tab:: c++
 
       void Periodic() override {
-        // Get my gyro angle.
+        // Get the rotation of the robot from the gyro.
         frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
 
         // Update the pose

--- a/source/docs/software/kinematics-and-odometry/differential-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/differential-drive-odometry.rst
@@ -43,7 +43,7 @@ Updating the Robot Pose
 -----------------------
 The ``update`` method can be used to update the robot's position on the field. This method must be called periodically, preferably in the ``periodic()`` method of a :ref:`Subsystem <docs/software/commandbased/subsystems:Subsystems>`. The ``update`` method returns the new updated pose of the robot. This method takes in the gyro angle of the robot, along with the left encoder distance and right encoder distance.
 
-.. note:: If the robot is moving forward in a straight line, **both** distances (left and right) must be increasing.
+.. note:: If the robot is moving forward in a straight line, **both** distances (left and right) must be increasing positively -- the rate of change must be positive.
 
 .. tabs::
 

--- a/source/docs/software/kinematics-and-odometry/differential-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/differential-drive-odometry.rst
@@ -9,7 +9,7 @@ Creating the Odometry Object
 The ``DifferentialDriveOdometry`` class constructor requires three mandatory arguments and one optional argument. The mandatory arguments are:
 
 * The angle reported by your gyroscope (as a ``Rotation2d``)
-* The initial left and right encoder readings. In Java, these are each a ``double``, and must represent the distance travelled by each side in meters.  In C++, the :doc:`units library </docs/software/basic-programming/cpp-units>` must be used to represent your wheel positions.
+* The initial left and right encoder readings. In Java, these are each a ``double``, and must represent the distance traveled by each side in meters.  In C++, the :doc:`units library </docs/software/basic-programming/cpp-units>` must be used to represent your wheel positions.
 
 The optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -6,9 +6,11 @@ A user can use the mecanum drive kinematics classes in order to perform :ref:`od
 
 Creating the odometry object
 ----------------------------
-The ``MecanumDriveOdometry`` class requires two mandatory arguments and one optional argument. The mandatory arguments are the kinematics object that represents your mecanum drive (in the form of a ``MecanumDriveKinematics`` class) and the angle reported by your gyroscope (as a Rotation2d). The third optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
+The ``MecanumDriveOdometry`` class requires three mandatory arguments and one optional argument. The mandatory arguments are the kinematics object that represents your mecanum drive (in the form of a ``MecanumDriveKinematics`` class), the angle reported by your gyroscope (as a ``Rotation2d``), and the initial positions of the wheels (as ``MecanumDriveWheelPositions``). The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 
 .. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. By default, WPILib gyros exhibit the opposite behavior, so you should negate the gyro angle.
+
+.. note:: The ``MecanumDriveWheelPositions`` class in Java must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
 
 .. tabs::
 
@@ -25,11 +27,18 @@ The ``MecanumDriveOdometry`` class requires two mandatory arguments and one opti
         m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation, m_backRightLocation
       );
 
-      // Creating my odometry object from the kinematics object. Here,
-      // our starting pose is 5 meters along the long end of the field and in the
-      // center of the field along the short end, facing forward.
-      MecanumDriveOdometry m_odometry = new MecanumDriveOdometry(m_kinematics,
-        getGyroHeading(), new Pose2d(5.0, 13.5, new Rotation2d()));
+      // Creating my odometry object from the kinematics object and the initial wheel positions.
+      // Here, our starting pose is 5 meters along the long end of the field and in the
+      // center of the field along the short end, facing the opposing alliance wall.
+      MecanumDriveOdometry m_odometry = new MecanumDriveOdometry(
+        m_kinematics,
+        getGyroHeading(),
+        new MecanumDriveWheelPositions(
+          m_frontLeftEncoder.getDistance(), m_frontRightEncoder.getDistance(),
+          m_backLeftEncoder.getDistance(), m_backRightEncoder.getDistance()
+        ),
+        new Pose2d(5.0, 13.5, new Rotation2d())
+      );
 
    .. code-tab:: c++
 
@@ -41,21 +50,28 @@ The ``MecanumDriveOdometry`` class requires two mandatory arguments and one opti
 
       // Creating my kinematics object using the wheel locations.
       frc::MecanumDriveKinematics m_kinematics{
-        m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation,
-        m_backRightLocation};
+        m_frontLeftLocation, m_frontRightLocation,
+        m_backLeftLocation, m_backRightLocation
+      };
 
       // Creating my odometry object from the kinematics object. Here,
       // our starting pose is 5 meters along the long end of the field and in the
       // center of the field along the short end, facing forward.
-      frc::MecanumDriveOdometry m_odometry{m_kinematics, GetGyroHeading(),
+      frc::MecanumDriveOdometry m_odometry{
+        m_kinematics,
+        GetGyroHeading(),
+        frc::MecanumDriveWheelPositions{
+          units::meters_t(m_frontLeftEncoder.GetDistance()),
+          units::meterst(m_frontRightEncoder.GetDistance()),
+          units::meters_t(m_backLeftEncoder.GetDistance()),
+          units::meters_t(m_backRightEncoder.GetDistance())
+        },
         frc::Pose2d{5_m, 13.5_m, 0_rad}};
 
 
 Updating the robot pose
 -----------------------
-The ``update`` method of the odometry class updates the robot position on the field. The update method takes in the gyro angle of the robot, along with a ``MecanumDriveWheelSpeeds`` object representing the speed of each of the 4 wheels on the robot. This ``update`` method must be called periodically, preferably in the ``periodic()`` method of a :ref:`Subsystem <docs/software/commandbased/subsystems:Subsystems>`. The ``update`` method returns the new updated pose of the robot.
-
-.. note:: The ``MecanumDriveWheelSpeeds`` class in Java must be constructed with each wheel speed in meters per second. In C++, the units library must be used to represent your wheel speeds.
+The ``update`` method of the odometry class updates the robot position on the field. The update method takes in the gyro angle of the robot, along with a ``MecanumDriveWheelPositions`` object representing the position of each of the 4 wheels on the robot. This ``update`` method must be called periodically, preferably in the ``periodic()`` method of a :ref:`Subsystem <docs/software/commandbased/subsystems:Subsystems>`. The ``update`` method returns the new updated pose of the robot.
 
 .. tabs::
 
@@ -63,10 +79,10 @@ The ``update`` method of the odometry class updates the robot position on the fi
 
       @Override
       public void periodic() {
-        // Get my wheel speeds
-        var wheelSpeeds = new MecanumDriveWheelSpeeds(
-            m_frontLeftEncoder.getRate(), m_frontRightEncoder.getRate(),
-            m_backLeftEncoder.getRate(), m_backRightEncoder.getRate());
+        // Get my wheel positions
+        var wheelPositions = new MecanumDriveWheelPositions(
+            m_frontLeftEncoder.getDistance(), m_frontRightEncoder.getDistance(),
+            m_backLeftEncoder.getDistance(), m_backRightEncoder.getDistance());
 
         // Get my gyro angle. We are negating the value because gyros return positive
         // values as the robot turns clockwise. This is not standard convention that is
@@ -74,18 +90,18 @@ The ``update`` method of the odometry class updates the robot position on the fi
         var gyroAngle = Rotation2d.fromDegrees(-m_gyro.getAngle());
 
         // Update the pose
-        m_pose = m_odometry.update(gyroAngle, wheelSpeeds);
+        m_pose = m_odometry.update(gyroAngle, wheelPositions);
       }
 
    .. code-tab:: c++
 
       void Periodic() override {
-         // Get my wheel speeds
-         frc::MecanumDriveWheelSpeeds wheelSpeeds{
-           units::meters_per_second_t(m_frontLeftEncoder.GetRate()),
-           units::meters_per_second_t(m_frontRightEncoder.GetRate()),
-           units::meters_per_second_t(m_backLeftEncoder.GetRate()),
-           units::meters_per_second_t(m_backRightEncoder.GetRate())};
+         // Get my wheel positions
+         frc::MecanumDriveWheelPositions wheelPositions{
+           units::meters_t(m_frontLeftEncoder.GetDistance()),
+           units::meterst(m_frontRightEncoder.GetDistance()),
+           units::meters_t(m_backLeftEncoder.GetDistance()),
+           units::meters_t(m_backRightEncoder.GetDistance())};
 
          // Get my gyro angle. We are negating the value because gyros return positive
          // values as the robot turns clockwise. This is not standard convention that is
@@ -93,12 +109,12 @@ The ``update`` method of the odometry class updates the robot position on the fi
          frc::Rotation2d gyroAngle{units::degree_t(-m_gyro.GetAngle())};
 
          // Update the pose
-         m_pose = m_odometry.Update(gyroAngle, wheelSpeeds);
+         m_pose = m_odometry.Update(gyroAngle, wheelPositions);
        }
 
 Resetting the Robot Pose
 ------------------------
-The robot pose can be reset via the ``resetPose`` method. This method accepts two arguments -- the new field-relative pose and the current gyro angle.
+The robot pose can be reset via the ``resetPose`` method. This method accepts three arguments -- the new field-relative pose, the current gyro angle, and the current wheel positions.
 
 .. important:: If at any time, you decide to reset your gyroscope, the ``resetPose`` method MUST be called with the new gyro angle.
 

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -61,10 +61,10 @@ The ``MecanumDriveOdometry`` class requires three mandatory arguments and one op
         m_kinematics,
         m_gyro.GetRotation2d(),
         frc::MecanumDriveWheelPositions{
-          units::meters_t(m_frontLeftEncoder.GetDistance()),
-          units::meters_t(m_frontRightEncoder.GetDistance()),
-          units::meters_t(m_backLeftEncoder.GetDistance()),
-          units::meters_t(m_backRightEncoder.GetDistance())
+          units::meter_t(m_frontLeftEncoder.GetDistance()),
+          units::meter_t(m_frontRightEncoder.GetDistance()),
+          units::meter_t(m_backLeftEncoder.GetDistance()),
+          units::meter_t(m_backRightEncoder.GetDistance())
         },
         frc::Pose2d{5_m, 13.5_m, 0_rad}};
 
@@ -96,10 +96,10 @@ The ``update`` method of the odometry class updates the robot position on the fi
       void Periodic() override {
          // Get my wheel positions
          frc::MecanumDriveWheelPositions wheelPositions{
-           units::meters_t(m_frontLeftEncoder.GetDistance()),
-           units::meterst(m_frontRightEncoder.GetDistance()),
-           units::meters_t(m_backLeftEncoder.GetDistance()),
-           units::meters_t(m_backRightEncoder.GetDistance())};
+           units::meter_t(m_frontLeftEncoder.GetDistance()),
+           units::meter_t(m_frontRightEncoder.GetDistance()),
+           units::meter_t(m_backLeftEncoder.GetDistance()),
+           units::meter_t(m_backRightEncoder.GetDistance())};
 
          // Get my gyro angle.
          frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -8,7 +8,7 @@ Creating the odometry object
 ----------------------------
 The ``MecanumDriveOdometry`` class requires three mandatory arguments and one optional argument. The mandatory arguments are the kinematics object that represents your mecanum drive (in the form of a ``MecanumDriveKinematics`` class), the angle reported by your gyroscope (as a ``Rotation2d``), and the initial positions of the wheels (as ``MecanumDriveWheelPositions``). The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 
-.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. By default, WPILib gyros exhibit the opposite behavior, so you should negate the gyro angle.
+.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase.  The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose.
 
 .. note:: The ``MecanumDriveWheelPositions`` class in Java must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
 
@@ -32,7 +32,7 @@ The ``MecanumDriveOdometry`` class requires three mandatory arguments and one op
       // center of the field along the short end, facing the opposing alliance wall.
       MecanumDriveOdometry m_odometry = new MecanumDriveOdometry(
         m_kinematics,
-        getGyroHeading(),
+        m_gyro.getRotation2d(),
         new MecanumDriveWheelPositions(
           m_frontLeftEncoder.getDistance(), m_frontRightEncoder.getDistance(),
           m_backLeftEncoder.getDistance(), m_backRightEncoder.getDistance()
@@ -59,7 +59,7 @@ The ``MecanumDriveOdometry`` class requires three mandatory arguments and one op
       // center of the field along the short end, facing forward.
       frc::MecanumDriveOdometry m_odometry{
         m_kinematics,
-        GetGyroHeading(),
+        m_gyro.GetRotation2d(),
         frc::MecanumDriveWheelPositions{
           units::meters_t(m_frontLeftEncoder.GetDistance()),
           units::meterst(m_frontRightEncoder.GetDistance()),
@@ -84,10 +84,8 @@ The ``update`` method of the odometry class updates the robot position on the fi
             m_frontLeftEncoder.getDistance(), m_frontRightEncoder.getDistance(),
             m_backLeftEncoder.getDistance(), m_backRightEncoder.getDistance());
 
-        // Get my gyro angle. We are negating the value because gyros return positive
-        // values as the robot turns clockwise. This is not standard convention that is
-        // used by the WPILib classes.
-        var gyroAngle = Rotation2d.fromDegrees(-m_gyro.getAngle());
+        // Get my gyro angle.
+        var gyroAngle = m_gyro.getRotation2d();
 
         // Update the pose
         m_pose = m_odometry.update(gyroAngle, wheelPositions);
@@ -103,10 +101,8 @@ The ``update`` method of the odometry class updates the robot position on the fi
            units::meters_t(m_backLeftEncoder.GetDistance()),
            units::meters_t(m_backRightEncoder.GetDistance())};
 
-         // Get my gyro angle. We are negating the value because gyros return positive
-         // values as the robot turns clockwise. This is not standard convention that is
-         // used by the WPILib classes.
-         frc::Rotation2d gyroAngle{units::degree_t(-m_gyro.GetAngle())};
+         // Get my gyro angle.
+         frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
 
          // Update the pose
          m_pose = m_odometry.Update(gyroAngle, wheelPositions);

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -10,7 +10,7 @@ The ``MecanumDriveOdometry`` class requires three mandatory arguments and one op
 
 The mandatory arguments are:
 
-* The kinematics object that represents your mecanum drive (in the form of a ``MecanumDriveKinematics`` class)
+* The kinematics object that represents your mecanum drive (as a ``MecanumDriveKinematics`` instance)
 * The angle reported by your gyroscope (as a ``Rotation2d``)
 * The initial positions of the wheels (as ``MecanumDriveWheelPositions``). In Java, this must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
 
@@ -87,8 +87,8 @@ The ``update`` method of the odometry class updates the robot position on the fi
       public void periodic() {
         // Get my wheel positions
         var wheelPositions = new MecanumDriveWheelPositions(
-            m_frontLeftEncoder.getDistance(), m_frontRightEncoder.getDistance(),
-            m_backLeftEncoder.getDistance(), m_backRightEncoder.getDistance());
+          m_frontLeftEncoder.getDistance(), m_frontRightEncoder.getDistance(),
+          m_backLeftEncoder.getDistance(), m_backRightEncoder.getDistance());
 
         // Get my gyro angle.
         var gyroAngle = m_gyro.getRotation2d();
@@ -100,23 +100,23 @@ The ``update`` method of the odometry class updates the robot position on the fi
    .. code-tab:: c++
 
       void Periodic() override {
-         // Get my wheel positions
-         frc::MecanumDriveWheelPositions wheelPositions{
-           units::meter_t(m_frontLeftEncoder.GetDistance()),
-           units::meter_t(m_frontRightEncoder.GetDistance()),
-           units::meter_t(m_backLeftEncoder.GetDistance()),
-           units::meter_t(m_backRightEncoder.GetDistance())};
+        // Get my wheel positions
+        frc::MecanumDriveWheelPositions wheelPositions{
+          units::meter_t(m_frontLeftEncoder.GetDistance()),
+          units::meter_t(m_frontRightEncoder.GetDistance()),
+          units::meter_t(m_backLeftEncoder.GetDistance()),
+          units::meter_t(m_backRightEncoder.GetDistance())};
 
-         // Get my gyro angle.
-         frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
+        // Get my gyro angle.
+        frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
 
-         // Update the pose
-         m_pose = m_odometry.Update(gyroAngle, wheelPositions);
-       }
+        // Update the pose
+        m_pose = m_odometry.Update(gyroAngle, wheelPositions);
+      }
 
 Resetting the Robot Pose
 ------------------------
-The robot pose can be reset via the ``resetPose`` method. This method accepts three arguments -- the new field-relative pose, the current gyro angle, and the current wheel positions.
+The robot pose can be reset via the ``resetPosition`` method. This method accepts three arguments: the current gyro angle, the current wheel positions, and the new field-relative pose.
 
 .. important:: If at any time, you decide to reset your gyroscope, the ``resetPose`` method MUST be called with the new gyro angle.
 

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -62,7 +62,7 @@ The ``MecanumDriveOdometry`` class requires three mandatory arguments and one op
         m_gyro.GetRotation2d(),
         frc::MecanumDriveWheelPositions{
           units::meters_t(m_frontLeftEncoder.GetDistance()),
-          units::meterst(m_frontRightEncoder.GetDistance()),
+          units::meters_t(m_frontRightEncoder.GetDistance()),
           units::meters_t(m_backLeftEncoder.GetDistance()),
           units::meters_t(m_backRightEncoder.GetDistance())
         },

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -6,11 +6,17 @@ A user can use the mecanum drive kinematics classes in order to perform :ref:`od
 
 Creating the odometry object
 ----------------------------
-The ``MecanumDriveOdometry`` class requires three mandatory arguments and one optional argument. The mandatory arguments are the kinematics object that represents your mecanum drive (in the form of a ``MecanumDriveKinematics`` class), the angle reported by your gyroscope (as a ``Rotation2d``), and the initial positions of the wheels (as ``MecanumDriveWheelPositions``). The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
+The ``MecanumDriveOdometry`` class requires three mandatory arguments and one optional argument.
+
+The mandatory arguments are:
+
+* The kinematics object that represents your mecanum drive (in the form of a ``MecanumDriveKinematics`` class)
+* The angle reported by your gyroscope (as a ``Rotation2d``)
+* The initial positions of the wheels (as ``MecanumDriveWheelPositions``). In Java, this must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
+
+The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 
 .. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase.  The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose.
-
-.. note:: The ``MecanumDriveWheelPositions`` class in Java must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
 
 .. tabs::
 

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -90,7 +90,7 @@ The ``update`` method of the odometry class updates the robot position on the fi
           m_frontLeftEncoder.getDistance(), m_frontRightEncoder.getDistance(),
           m_backLeftEncoder.getDistance(), m_backRightEncoder.getDistance());
 
-        // Get my gyro angle.
+        // Get the rotation of the robot from the gyro.
         var gyroAngle = m_gyro.getRotation2d();
 
         // Update the pose
@@ -107,7 +107,7 @@ The ``update`` method of the odometry class updates the robot position on the fi
           units::meter_t{m_backLeftEncoder.GetDistance()},
           units::meter_t{m_backRightEncoder.GetDistance()}};
 
-        // Get my gyro angle.
+        // Get the rotation of the robot from the gyro.
         frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
 
         // Update the pose

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -6,17 +6,17 @@ A user can use the mecanum drive kinematics classes in order to perform :ref:`od
 
 Creating the odometry object
 ----------------------------
-The ``MecanumDriveOdometry`` class requires three mandatory arguments and one optional argument.
+The ``MecanumDriveOdometry`` class constructor requires three mandatory arguments and one optional argument.
 
 The mandatory arguments are:
 
 * The kinematics object that represents your mecanum drive (as a ``MecanumDriveKinematics`` instance)
 * The angle reported by your gyroscope (as a ``Rotation2d``)
-* The initial positions of the wheels (as ``MecanumDriveWheelPositions``). In Java, this must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
+* The initial positions of the wheels (as ``MecanumDriveWheelPositions``). In Java, this must be constructed with each wheel position in meters. In C++, the :doc:`units library </docs/software/basic-programming/cpp-units>` must be used to represent your wheel positions.
 
 The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 
-.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase.  The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose. See :ref:`Field Coordinate System <docs/software/advanced-controls/geometry/coordinate-systems:Field Coordinate System>` for more information.
+.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase.  The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose. See :ref:`Field Coordinate System <docs/software/advanced-controls/geometry/coordinate-systems:Field Coordinate System>` for more information about the coordinate system.
 
 .. tabs::
 
@@ -67,10 +67,10 @@ The fourth optional argument is the starting pose of your robot on the field (as
         m_kinematics,
         m_gyro.GetRotation2d(),
         frc::MecanumDriveWheelPositions{
-          units::meter_t(m_frontLeftEncoder.GetDistance()),
-          units::meter_t(m_frontRightEncoder.GetDistance()),
-          units::meter_t(m_backLeftEncoder.GetDistance()),
-          units::meter_t(m_backRightEncoder.GetDistance())
+          units::meter_t{m_frontLeftEncoder.GetDistance()},
+          units::meter_t{m_frontRightEncoder.GetDistance()},
+          units::meter_t{m_backLeftEncoder.GetDistance()},
+          units::meter_t{m_backRightEncoder.GetDistance()}
         },
         frc::Pose2d{5_m, 13.5_m, 0_rad}};
 
@@ -102,10 +102,10 @@ The ``update`` method of the odometry class updates the robot position on the fi
       void Periodic() override {
         // Get my wheel positions
         frc::MecanumDriveWheelPositions wheelPositions{
-          units::meter_t(m_frontLeftEncoder.GetDistance()),
-          units::meter_t(m_frontRightEncoder.GetDistance()),
-          units::meter_t(m_backLeftEncoder.GetDistance()),
-          units::meter_t(m_backRightEncoder.GetDistance())};
+          units::meter_t{m_frontLeftEncoder.GetDistance()},
+          units::meter_t{m_frontRightEncoder.GetDistance()},
+          units::meter_t{m_backLeftEncoder.GetDistance()},
+          units::meter_t{m_backRightEncoder.GetDistance()}};
 
         // Get my gyro angle.
         frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
@@ -118,7 +118,7 @@ Resetting the Robot Pose
 ------------------------
 The robot pose can be reset via the ``resetPosition`` method. This method accepts three arguments: the current gyro angle, the current wheel positions, and the new field-relative pose.
 
-.. important:: If at any time, you decide to reset your gyroscope, the ``resetPose`` method MUST be called with the new gyro angle.
+.. important:: If at any time, you decide to reset your gyroscope or encoders, the ``resetPosition`` method MUST be called with the new gyro angle and wheel positions.
 
 .. note:: A full example of a mecanum drive robot with odometry is available here: `C++ <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibcExamples/src/main/cpp/examples/MecanumBot>`_ / `Java <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/mecanumbot>`_.
 

--- a/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/mecanum-drive-odometry.rst
@@ -16,7 +16,7 @@ The mandatory arguments are:
 
 The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 
-.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase.  The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose.
+.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase.  The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose. See :ref:`Field Coordinate System <docs/software/advanced-controls/geometry/coordinate-systems:Field Coordinate System>` for more information.
 
 .. tabs::
 

--- a/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
@@ -10,11 +10,11 @@ The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument
 
 The mandatory arguments are:
 
-* The kinematics object that represents your swerve drive (in the form of a ``SwerveDriveKinematics`` class)
+* The kinematics object that represents your swerve drive (as a ``SwerveDriveKinematics`` instance)
 * The angle reported by your gyroscope (as a ``Rotation2d``)
-* The initial positions of the swerve modules (as an array of ``SwerveModulePosition``). In Java, this must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
+* The initial positions of the swerve modules (as an array of ``SwerveModulePosition``). In Java, this must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
 
-The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
+The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 
 .. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose.
 
@@ -70,7 +70,7 @@ The fourth optional argument is the starting pose of your robot on the field (as
 
 Updating the robot pose
 -----------------------
-The ``update`` method of the odometry class updates the robot position on the field. The update method takes in the gyro angle of the robot, along with a series of module positions (distances and angles) in the form of a ``SwerveModulePosition`` each. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
+The ``update`` method of the odometry class updates the robot position on the field. The update method takes in the gyro angle of the robot, along with an array of ``SwerveModulePosition`` objects. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
 
 This ``update`` method must be called periodically, preferably in the ``periodic()`` method of a :ref:`Subsystem <docs/software/commandbased/subsystems:Subsystems>`. The ``update`` method returns the new updated pose of the robot.
 
@@ -95,7 +95,7 @@ This ``update`` method must be called periodically, preferably in the ``periodic
 
       void Periodic() override {
         // Get my gyro angle.
-        frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();;
+        frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
 
         // Update the pose
         m_pose = m_odometry.Update(gyroAngle,
@@ -107,7 +107,7 @@ This ``update`` method must be called periodically, preferably in the ``periodic
 
 Resetting the Robot Pose
 ------------------------
-The robot pose can be reset via the ``resetPose`` method. This method accepts three arguments -- the new field-relative pose, the current gyro angle, and an array of the current module positions (as in the constructor).
+The robot pose can be reset via the ``resetPosition`` method. This method accepts three arguments: the current gyro angle, an array of the current module positions (as in the constructor and update method), and the new field-relative pose.
 
 .. important:: If at any time, you decide to reset your gyroscope, the ``resetPosition`` method MUST be called with the new gyro angle.
 

--- a/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
@@ -79,20 +79,24 @@ This ``update`` method must be called periodically, preferably in the ``periodic
 
         // Update the pose
         m_pose = m_odometry.update(gyroAngle,
-          m_frontLeftModule.getPosition(), m_frontRightModule.getPosition(),
-          m_backLeftModule.getPosition(), m_backRightModule.getPosition());
+          new SwerveModulePosition[] {
+            m_frontLeftModule.getPosition(), m_frontRightModule.getPosition(),
+            m_backLeftModule.getPosition(), m_backRightModule.getPosition()
+          });
       }
 
    .. code-tab:: c++
 
       void Periodic() override {
-         // Get my gyro angle.
-         frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();;
+        // Get my gyro angle.
+        frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();;
 
-         // Update the pose
-         m_pose = m_odometry.Update(gyroAngle,
-           m_frontLeftModule.GetPosition(), m_frontRightModule.GetPosition(),
-           m_backLeftModule.GetPosition(), m_backRightModule.GetPosition());
+        // Update the pose
+        m_pose = m_odometry.Update(gyroAngle,
+          {
+            m_frontLeftModule.GetPosition(), m_frontRightModule.GetPosition(),
+            m_backLeftModule.GetPosition(), m_backRightModule.GetPosition()
+          };
       }
 
 Resetting the Robot Pose

--- a/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
@@ -6,17 +6,17 @@ A user can use the swerve drive kinematics classes in order to perform :ref:`odo
 
 Creating the odometry object
 ----------------------------
-The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument (only C++), three mandatory arguments, and one optional argument. The template argument (only C++) is an integer representing the number of swerve modules.
+The ``SwerveDriveOdometry<int NumModules>`` class constructor requires one template argument (only C++), three mandatory arguments, and one optional argument. The template argument (only C++) is an integer representing the number of swerve modules.
 
 The mandatory arguments are:
 
 * The kinematics object that represents your swerve drive (as a ``SwerveDriveKinematics`` instance)
 * The angle reported by your gyroscope (as a ``Rotation2d``)
-* The initial positions of the swerve modules (as an array of ``SwerveModulePosition``). In Java, this must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
+* The initial positions of the swerve modules (as an array of ``SwerveModulePosition``). In Java, this must be constructed with each wheel position in meters. In C++, the :doc:`units library </docs/software/basic-programming/cpp-units>` must be used to represent your wheel positions. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
 
 The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 
-.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose. See :ref:`Field Coordinate System <docs/software/advanced-controls/geometry/coordinate-systems:Field Coordinate System>` for more information.
+.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose. See :ref:`Field Coordinate System <docs/software/advanced-controls/geometry/coordinate-systems:Field Coordinate System>` for more information about the coordinate system.
 
 .. tabs::
 
@@ -109,7 +109,7 @@ Resetting the Robot Pose
 ------------------------
 The robot pose can be reset via the ``resetPosition`` method. This method accepts three arguments: the current gyro angle, an array of the current module positions (as in the constructor and update method), and the new field-relative pose.
 
-.. important:: If at any time, you decide to reset your gyroscope, the ``resetPosition`` method MUST be called with the new gyro angle.
+.. important::  If at any time, you decide to reset your gyroscope or wheel encoders, the ``resetPosition`` method MUST be called with the new gyro angle and wheel encoder positions.
 
 .. note:: The implementation of ``getPosition() / GetPosition()`` above is left to the user. The idea is to get the module position (distance and angle) from each module. For a full example, see here: `C++ <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibcExamples/src/main/cpp/examples/SwerveBot>`_ / `Java <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot>`_.
 

--- a/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
@@ -8,7 +8,7 @@ Creating the odometry object
 ----------------------------
 The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument (only C++), three mandatory arguments, and one optional argument. The template argument (only C++) is an integer representing the number of swerve modules. The mandatory arguments are the kinematics object that represents your swerve drive (in the form of a ``SwerveDriveKinematics`` class), the angle reported by your gyroscope (as a ``Rotation2d``), and the initial positions of the swerve modules (as an array of ``SwerveModulePosition``). The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
 
-.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. By default, WPILib gyros exhibit the opposite behavior, so you should negate the gyro angle.
+.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose.
 
 .. note:: The ``SwerveModulePosition`` class in Java must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
 
@@ -31,7 +31,7 @@ The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument
       // Here, our starting pose is 5 meters along the long end of the field and in the
       // center of the field along the short end, facing the opposing alliance wall.
       SwerveDriveOdometry m_odometry = new SwerveDriveOdometry(
-        m_kinematics, getGyroHeading(),
+        m_kinematics, m_gyro.getRotation2d(),
         new SwerveModulePosition[] {
           m_frontLeftModule.getPosition(),
           m_frontRightModule.getPosition(),
@@ -56,7 +56,7 @@ The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument
       // Creating my odometry object from the kinematics object. Here,
       // our starting pose is 5 meters along the long end of the field and in the
       // center of the field along the short end, facing forward.
-      frc::SwerveDriveOdometry<4> m_odometry{m_kinematics, GetGyroHeading(),
+      frc::SwerveDriveOdometry<4> m_odometry{m_kinematics, m_gyro.GetRotation2d(),
         {m_frontLeft.GetPosition(), m_frontRight.GetPosition(),
         m_backLeft.GetPosition(), m_backRight.GetPosition()},
         frc::Pose2d{5_m, 13.5_m, 0_rad}};
@@ -74,10 +74,8 @@ This ``update`` method must be called periodically, preferably in the ``periodic
 
       @Override
       public void periodic() {
-        // Get my gyro angle. We are negating the value because gyros return positive
-        // values as the robot turns clockwise. This is not standard convention that is
-        // used by the WPILib classes.
-        var gyroAngle = Rotation2d.fromDegrees(-m_gyro.getAngle());
+        // Get my gyro angle.
+        var gyroAngle = m_gyro.getRotation2d();
 
         // Update the pose
         m_pose = m_odometry.update(gyroAngle,
@@ -88,10 +86,8 @@ This ``update`` method must be called periodically, preferably in the ``periodic
    .. code-tab:: c++
 
       void Periodic() override {
-         // Get my gyro angle. We are negating the value because gyros return positive
-         // values as the robot turns clockwise. This is not standard convention that is
-         // used by the WPILib classes.
-         frc::Rotation2d gyroAngle{units::degree_t(-m_gyro.GetAngle())};
+         // Get my gyro angle.
+         frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();;
 
          // Update the pose
          m_pose = m_odometry.Update(gyroAngle,

--- a/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
@@ -80,7 +80,7 @@ This ``update`` method must be called periodically, preferably in the ``periodic
 
       @Override
       public void periodic() {
-        // Get my gyro angle.
+        // Get the rotation of the robot from the gyro.
         var gyroAngle = m_gyro.getRotation2d();
 
         // Update the pose
@@ -94,7 +94,7 @@ This ``update`` method must be called periodically, preferably in the ``periodic
    .. code-tab:: c++
 
       void Periodic() override {
-        // Get my gyro angle.
+        // Get the rotation of the robot from the gyro.
         frc::Rotation2d gyroAngle = m_gyro.GetRotation2d();
 
         // Update the pose

--- a/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
@@ -6,11 +6,17 @@ A user can use the swerve drive kinematics classes in order to perform :ref:`odo
 
 Creating the odometry object
 ----------------------------
-The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument (only C++), three mandatory arguments, and one optional argument. The template argument (only C++) is an integer representing the number of swerve modules. The mandatory arguments are the kinematics object that represents your swerve drive (in the form of a ``SwerveDriveKinematics`` class), the angle reported by your gyroscope (as a ``Rotation2d``), and the initial positions of the swerve modules (as an array of ``SwerveModulePosition``). The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
+The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument (only C++), three mandatory arguments, and one optional argument. The template argument (only C++) is an integer representing the number of swerve modules.
+
+The mandatory arguments are:
+
+* The kinematics object that represents your swerve drive (in the form of a ``SwerveDriveKinematics`` class)
+* The angle reported by your gyroscope (as a ``Rotation2d``)
+* The initial positions of the swerve modules (as an array of ``SwerveModulePosition``). In Java, this must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
+
+The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
 
 .. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose.
-
-.. note:: The ``SwerveModulePosition`` class in Java must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
 
 .. tabs::
 

--- a/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
@@ -6,9 +6,11 @@ A user can use the swerve drive kinematics classes in order to perform :ref:`odo
 
 Creating the odometry object
 ----------------------------
-The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument (only C++), two mandatory arguments, and one optional argument. The template argument (only C++) is an integer representing the number of swerve modules. The mandatory arguments are the kinematics object that represents your swerve drive (in the form of a ``SwerveDriveKinematics`` class) and the angle reported by your gyroscope (as a Rotation2d). The third optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
+The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument (only C++), three mandatory arguments, and one optional argument. The template argument (only C++) is an integer representing the number of swerve modules. The mandatory arguments are the kinematics object that represents your swerve drive (in the form of a ``SwerveDriveKinematics`` class), the angle reported by your gyroscope (as a ``Rotation2d``), and the initial positions of the swerve modules (as an array of ``SwerveModulePosition``). The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
 
 .. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. By default, WPILib gyros exhibit the opposite behavior, so you should negate the gyro angle.
+
+.. note:: The ``SwerveModulePosition`` class in Java must be constructed with each wheel position in meters. In C++, the units library must be used to represent your wheel positions.
 
 .. tabs::
 
@@ -25,11 +27,17 @@ The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument
         m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation, m_backRightLocation
       );
 
-      // Creating my odometry object from the kinematics object. Here,
-      // our starting pose is 5 meters along the long end of the field and in the
-      // center of the field along the short end, facing forward.
-      SwerveDriveOdometry m_odometry = new SwerveDriveOdometry(m_kinematics,
-        getGyroHeading(), new Pose2d(5.0, 13.5, new Rotation2d()));
+      // Creating my odometry object from the kinematics object and the initial wheel positions.
+      // Here, our starting pose is 5 meters along the long end of the field and in the
+      // center of the field along the short end, facing the opposing alliance wall.
+      SwerveDriveOdometry m_odometry = new SwerveDriveOdometry(
+        m_kinematics, getGyroHeading(),
+        new SwerveModulePosition[] {
+          m_frontLeftModule.getPosition(),
+          m_frontRightModule.getPosition(),
+          m_backLeftModule.getPosition(),
+          m_backRightModule.getPosition()
+        }, new Pose2d(5.0, 13.5, new Rotation2d()));
 
    .. code-tab:: c++
 
@@ -41,19 +49,22 @@ The ``SwerveDriveOdometry<int NumModules>`` class requires one template argument
 
       // Creating my kinematics object using the module locations.
       frc::SwerveDriveKinematics<4> m_kinematics{
-        m_frontLeftLocation, m_frontRightLocation, m_backLeftLocation,
-        m_backRightLocation};
+        m_frontLeftLocation, m_frontRightLocation,
+        m_backLeftLocation, m_backRightLocation
+      };
 
       // Creating my odometry object from the kinematics object. Here,
       // our starting pose is 5 meters along the long end of the field and in the
       // center of the field along the short end, facing forward.
       frc::SwerveDriveOdometry<4> m_odometry{m_kinematics, GetGyroHeading(),
+        {m_frontLeft.GetPosition(), m_frontRight.GetPosition(),
+        m_backLeft.GetPosition(), m_backRight.GetPosition()},
         frc::Pose2d{5_m, 13.5_m, 0_rad}};
 
 
 Updating the robot pose
 -----------------------
-The ``update`` method of the odometry class updates the robot position on the field. The update method takes in the gyro angle of the robot, along with a series of module states (speeds and angles) in the form of a ``SwerveModuleState`` each. It is important that the order in which you pass the ``SwerveModuleState`` objects is the same as the order in which you created the kinematics object.
+The ``update`` method of the odometry class updates the robot position on the field. The update method takes in the gyro angle of the robot, along with a series of module positions (distances and angles) in the form of a ``SwerveModulePosition`` each. It is important that the order in which you pass the ``SwerveModulePosition`` objects is the same as the order in which you created the kinematics object.
 
 This ``update`` method must be called periodically, preferably in the ``periodic()`` method of a :ref:`Subsystem <docs/software/commandbased/subsystems:Subsystems>`. The ``update`` method returns the new updated pose of the robot.
 
@@ -69,8 +80,9 @@ This ``update`` method must be called periodically, preferably in the ``periodic
         var gyroAngle = Rotation2d.fromDegrees(-m_gyro.getAngle());
 
         // Update the pose
-        m_pose = m_odometry.update(gyroAngle, m_frontLeftModule.getState(), m_frontRightModule.getState(),
-            m_backLeftModule.getState(), m_backRightModule.getState());
+        m_pose = m_odometry.update(gyroAngle,
+          m_frontLeftModule.getPosition(), m_frontRightModule.getPosition(),
+          m_backLeftModule.getPosition(), m_backRightModule.getPosition());
       }
 
    .. code-tab:: c++
@@ -82,16 +94,17 @@ This ``update`` method must be called periodically, preferably in the ``periodic
          frc::Rotation2d gyroAngle{units::degree_t(-m_gyro.GetAngle())};
 
          // Update the pose
-         m_pose = m_odometry.Update(gyroAngle, m_frontLeftModule.GetState(), m_frontRightModule.GetState(),
-            m_backLeftModule.GetState(), m_backRightModule.GetState());
-       }
+         m_pose = m_odometry.Update(gyroAngle,
+           m_frontLeftModule.GetPosition(), m_frontRightModule.GetPosition(),
+           m_backLeftModule.GetPosition(), m_backRightModule.GetPosition());
+      }
 
 Resetting the Robot Pose
 ------------------------
-The robot pose can be reset via the ``resetPose`` method. This method accepts two arguments -- the new field-relative pose and the current gyro angle.
+The robot pose can be reset via the ``resetPose`` method. This method accepts three arguments -- the new field-relative pose, the current gyro angle, and an array of the current module positions (as in the constructor).
 
-.. important:: If at any time, you decide to reset your gyroscope, the ``resetPose`` method MUST be called with the new gyro angle.
+.. important:: If at any time, you decide to reset your gyroscope, the ``resetPosition`` method MUST be called with the new gyro angle.
 
-.. note:: The implementation of ``getState() / GetState()`` above is left to the user. The idea is to get the module state (speed and angle) from each module. For a full example, see here: `C++ <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibcExamples/src/main/cpp/examples/SwerveBot>`_ / `Java <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot>`_.
+.. note:: The implementation of ``getPosition() / GetPosition()`` above is left to the user. The idea is to get the module position (distance and angle) from each module. For a full example, see here: `C++ <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibcExamples/src/main/cpp/examples/SwerveBot>`_ / `Java <https://github.com/wpilibsuite/allwpilib/tree/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot>`_.
 
 In addition, the ``GetPose`` (C++) / ``getPoseMeters`` (Java) methods can be used to retrieve the current robot pose without an update.

--- a/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-odometry.rst
@@ -16,7 +16,7 @@ The mandatory arguments are:
 
 The fourth optional argument is the starting pose of your robot on the field (as a ``Pose2d``). By default, the robot will start at ``x = 0, y = 0, theta = 0``.
 
-.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose.
+.. note:: 0 degrees / radians represents the robot angle when the robot is facing directly toward your opponent's alliance station. As your robot turns to the left, your gyroscope angle should increase. The ``Gyro`` interface supplies ``getRotation2d``/``GetRotation2d`` that you can use for this purpose. See :ref:`Field Coordinate System <docs/software/advanced-controls/geometry/coordinate-systems:Field Coordinate System>` for more information.
 
 .. tabs::
 


### PR DESCRIPTION
Closes #1975

One thought- instead of negating the gyro's `getAngle` reading and passing to a `Rotation2d`, can we just demonstrate using `getRotation`? That's an inbuilt method in all of WPILib's gyros (part of the `Gyro` interface alongside `getAngle`).