### PR TITLE
Pin WPILib doc links to last release in stable

### DIFF
--- a/source/docs/contributing/wpilib/index.rst
+++ b/source/docs/contributing/wpilib/index.rst
@@ -13,11 +13,11 @@ Core Repository
    :maxdepth: 1
 
    Overview <https://github.com/wpilibsuite/allwpilib>
-   Styleguide & wpiformat <https://github.com/wpilibsuite/styleguide/blob/main/README.md>
-   Building with CMake <https://github.com/wpilibsuite/allwpilib/blob/main/README-CMAKE.md>
-   Using Development Builds <https://github.com/wpilibsuite/allwpilib/blob/main/OtherVersions.md>
-   Maven Artifacts <https://github.com/wpilibsuite/allwpilib/blob/main/MavenArtifacts.md>
-   Contributor Guidelines <https://github.com/wpilibsuite/allwpilib/blob/main/CONTRIBUTING.md>
+   Styleguide & wpiformat <https://github.com/wpilibsuite/styleguide/blob/v2022.4.1/README.md>
+   Building with CMake <https://github.com/wpilibsuite/allwpilib/blob/v2022.4.1/README-CMAKE.md>
+   Using Development Builds <https://github.com/wpilibsuite/allwpilib/blob/v2022.4.1/OtherVersions.md>
+   Maven Artifacts <https://github.com/wpilibsuite/allwpilib/blob/v2022.4.1/MavenArtifacts.md>
+   Contributor Guidelines <https://github.com/wpilibsuite/allwpilib/blob/v2022.4.1/CONTRIBUTING.md>
 
 NetworkTables
 -------------
@@ -25,4 +25,4 @@ NetworkTables
 .. toctree::
    :maxdepth: 1
 
-   NetworkTables 3 Protocol Spec <https://github.com/wpilibsuite/allwpilib/blob/main/ntcore/doc/networktables3.adoc>
+   NetworkTables 3 Protocol Spec <https://github.com/wpilibsuite/allwpilib/blob/v2022.4.1/ntcore/doc/networktables3.adoc>

--- a/source/docs/software/vscode-overview/3rd-party-libraries.rst
+++ b/source/docs/software/vscode-overview/3rd-party-libraries.rst
@@ -103,9 +103,9 @@ WPILib Command Libraries
 
 The WPILib old and :doc:`new </docs/software/commandbased/index>` command libraries have been split into vendor libraries in order to reduce the chances of mixing the two which will not work correctly. They are both installed by the wpilib installer for offline installation. They may also be installed with the following online links:
 
-`Old Command Library <https://raw.githubusercontent.com/wpilibsuite/allwpilib/main/wpilibOldCommands/WPILibOldCommands.json>`__
+`Old Command Library <https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2022.4.1/wpilibOldCommands/WPILibOldCommands.json>`__
 
-`New Command Library <https://raw.githubusercontent.com/wpilibsuite/allwpilib/main/wpilibNewCommands/WPILibNewCommands.json>`__
+`New Command Library <https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2022.4.1/wpilibNewCommands/WPILibNewCommands.json>`__
 
 To remove a library dependency from a project, select **Manage Current Libraries** from the **Manage Vendor Libraries** menu, check the box for any libraries to uninstall and click OK. These libraries will be removed as dependencies from the project.
 
@@ -114,4 +114,4 @@ Romi Library
 
 A Romi Library has been created to contain several helper classes that are a part of the ``RomiReference`` example.
 
-`Romi Vendordep <https://raw.githubusercontent.com/wpilibsuite/romi-vendordep/main/RomiVendordep.json>`__.
+`Romi Vendordep <https://raw.githubusercontent.com/wpilibsuite/romi-vendordep/v2022.2.1/RomiVendordep.json>`__.


### PR DESCRIPTION
Fixes broken link due to rename of OtherVersions.md and ensures beta documents are linked in stable