### PR TITLE
Update to Inspector v1.5

### DIFF
--- a/.github/workflows/update-rli-commands.yml
+++ b/.github/workflows/update-rli-commands.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Run Inspector
       - name: Inspect RLIs
-        uses: Starlight220/Inspector@v1.4
+        uses: Starlight220/Inspector@v1.5
         id: inspector
         with:
           root: ${{ github.workspace }}


### PR DESCRIPTION
I made some changes to how Inspector is packaged, resulting in a significant speedup when building the container at the beginning of a CI run (~37s now vs ~1m26s before).