### PR TITLE
Update code formatting article to use spotless 6.12.0

### DIFF
--- a/source/docs/software/advanced-gradlerio/code-formatting.rst
+++ b/source/docs/software/advanced-gradlerio/code-formatting.rst
@@ -18,7 +18,7 @@ Necessary ``build.gradle`` changes are required to get Spotless functional. In t
    plugins {
       id "java"
       id "edu.wpi.first.GradleRIO" version "2022.1.1"
-      id 'com.diffplug.spotless' version '6.1.0'
+      id 'com.diffplug.spotless' version '6.12.0'
    }
 
 Then ensure you add a required ``spotless {}`` block to correctly configure spotless. This can just get placed at the end of your ``build.gradle``.


### PR DESCRIPTION
With the JVM updated to 17, following the current code formatting article will result in errors. (can be worked around but the issue was fixed in a later version of spotless)

I've tested the updated version with the rest of the article and it works as normal.