### PR TITLE
Update CI tasks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
   build-pdf:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: 3.9
@@ -22,7 +22,7 @@ jobs:
       run: |
         make latexpdf
     - name: Archive PDF
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: frc-docs-pdf
         path: build/latex/firstroboticscompetition.pdf
@@ -31,7 +31,7 @@ jobs:
   build-html:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: 3.9
@@ -47,7 +47,7 @@ jobs:
       run: |
         make html
     - name: Archive HTML
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: frc-docs-html
         path: build/html/
@@ -86,7 +86,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install Dependencies
@@ -99,8 +99,8 @@ jobs:
   check-linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install Dependencies
@@ -113,8 +113,8 @@ jobs:
   check-image-size:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install Dependencies
@@ -127,7 +127,7 @@ jobs:
   check-spelling:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:
@@ -137,11 +137,11 @@ jobs:
   check-redirects:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout main
       run: |
         git fetch origin main --depth=1
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install Dependencies
@@ -157,10 +157,10 @@ jobs:
   check-formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - uses: psf/black@22.1.0
       with:
-        black_args: ". --check"
+        options: "--check"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,8 +10,8 @@ jobs:
     if: github.repository_owner	== 'wpilibsuite'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install Dependencies

--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'wpilibsuite' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Merge

--- a/.github/workflows/update-rli-commands.yml
+++ b/.github/workflows/update-rli-commands.yml
@@ -48,7 +48,7 @@ jobs:
         run: exit 1
 
       - name: Checkout [Common]
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout PR [Comment]
         run: gh pr checkout $NUMBER
@@ -100,7 +100,7 @@ jobs:
 
       # ---- Common - Post Report ----
       - name: Find Comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v2
         id: fc
         with:
           issue-number: ${{ github.event.issue.number }}
@@ -110,14 +110,14 @@ jobs:
 
       - name: Create comment
         if: ${{ steps.fc.outputs.comment-id == 0 }}
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           body: ${{ env.REPORT }}
           issue-number: ${{ github.event.issue.number }}
 
       - name: Update comment
         if: ${{ steps.fc.outputs.comment-id != 0 }}
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           body: |
             ${{ env.REPORT }}


### PR DESCRIPTION
Updates actions to fix deprecation warnings.

`khan/pull-request-comment-trigger` used in `update-rli-commands.yml` still uses the deprecated API.