### PR TITLE
Fix robot code CI examples

### DIFF
--- a/source/docs/software/advanced-gradlerio/robot-code-ci.rst
+++ b/source/docs/software/advanced-gradlerio/robot-code-ci.rst
@@ -45,6 +45,10 @@ You will now be greeted with a text editor. Replace all the default text with th
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
         - uses: actions/checkout@v3
 
+        # Declares the repository safe and not under dubious ownership.
+        - name: Add repository to git safe directories
+          run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
         # Grant execute permission for gradlew
         - name: Grant execute permission for gradlew
           run: chmod +x gradlew
@@ -103,6 +107,10 @@ We specify that we want the job to run on an Ubuntu virtual machine and in a vir
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
         - uses: actions/checkout@v3
 
+        # Declares the repository safe and not under dubious ownership.
+        - name: Add repository to git safe directories
+          run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
         # Grant execute permission for gradlew
         - name: Grant execute permission for gradlew
           run: chmod +x gradlew
@@ -111,7 +119,7 @@ We specify that we want the job to run on an Ubuntu virtual machine and in a vir
         - name: Compile and run tests on robot code
           run: ./gradlew build
 
-Each job has certain steps that will be executed. This job has three steps. The first step involves checking out the repository to access the robot code. The second step involves giving the virtual machine permission to execute gradle tasks using ``./gradlew``. The final step runs ``./gradlew build`` to compile robot code and run any unit tests.
+Each job has certain steps that will be executed. This job has four steps. The first step involves checking out the repository to access the robot code. The second step is a workaround for a `GitHub Actions issue <https://www.github.com/actions/runner/issues/2033>`_. The third step involves giving the virtual machine permission to execute gradle tasks using ``./gradlew``. The final step runs ``./gradlew build`` to compile robot code and run any unit tests.
 
 Adding a Build Status Badge to a README.md File
 -----------------------------------------------

--- a/source/docs/software/advanced-gradlerio/robot-code-ci.rst
+++ b/source/docs/software/advanced-gradlerio/robot-code-ci.rst
@@ -119,7 +119,7 @@ We specify that we want the job to run on an Ubuntu virtual machine and in a vir
         - name: Compile and run tests on robot code
           run: ./gradlew build
 
-Each job has certain steps that will be executed. This job has four steps. The first step involves checking out the repository to access the robot code. The second step is a workaround for a `GitHub Actions issue <https://www.github.com/actions/runner/issues/2033>`_. The third step involves giving the virtual machine permission to execute gradle tasks using ``./gradlew``. The final step runs ``./gradlew build`` to compile robot code and run any unit tests.
+Each job has certain steps that will be executed. This job has four steps. The first step involves checking out the repository to access the robot code. The second step is a workaround for a `GitHub Actions issue <https://github.com/actions/runner/issues/2033>`_. The third step involves giving the virtual machine permission to execute gradle tasks using ``./gradlew``. The final step runs ``./gradlew build`` to compile robot code and run any unit tests.
 
 Adding a Build Status Badge to a README.md File
 -----------------------------------------------

--- a/source/docs/software/advanced-gradlerio/robot-code-ci.rst
+++ b/source/docs/software/advanced-gradlerio/robot-code-ci.rst
@@ -119,7 +119,7 @@ We specify that we want the job to run on an Ubuntu virtual machine and in a vir
         - name: Compile and run tests on robot code
           run: ./gradlew build
 
-Each job has certain steps that will be executed. This job has four steps. The first step involves checking out the repository to access the robot code. The second step is a workaround for a `GitHub Actions issue <https://github.com/actions/runner/issues/2033>`_. The third step involves giving the virtual machine permission to execute gradle tasks using ``./gradlew``. The final step runs ``./gradlew build`` to compile robot code and run any unit tests.
+Each job has certain steps that will be executed. This job has four steps. The first step involves checking out the repository to access the robot code. The second step is a workaround for a `GitHub Actions issue <https://github.com/actions/runner/issues/2033>`__. The third step involves giving the virtual machine permission to execute gradle tasks using ``./gradlew``. The final step runs ``./gradlew build`` to compile robot code and run any unit tests.
 
 Adding a Build Status Badge to a README.md File
 -----------------------------------------------


### PR DESCRIPTION
The current robot code CI example is broken due to [this Github Actions issue](https://github.com/actions/runner/issues/2033).  This PR adds a fix to the example CI to avoid this issue.