### PR TITLE
Add DataLog to list of major changes

### DIFF
--- a/source/docs/software/telemetry/datalog.rst
+++ b/source/docs/software/telemetry/datalog.rst
@@ -1,8 +1,6 @@
 On-Robot Telemetry Recording Into Data Logs
 ===========================================
 
-.. note:: The DataLog feature and Data Log Tool were added in WPILib 2022.4.1. The Data Log Tool is installed by the WPILib installer only (new tools are not installed when a robot project is upgraded).
-
 By default, no telemetry data is recorded (saved) on the robot. The ``DataLogManager`` class provides a convenient wrapper around the lower-level ``DataLog`` class for on-robot recording of telemetry data into data logs.  The WPILib data logs are binary for size and speed reasons.  In general, the data log facilities provided by WPILib have minimal overhead to robot code, as all file I/O is performed on a separate thread--the log operation consists of mainly a mutex acquisition and copying the data.
 
 Structure of Data Logs

--- a/source/docs/yearly-overview/yearly-changelog.rst
+++ b/source/docs/yearly-overview/yearly-changelog.rst
@@ -17,6 +17,7 @@ Major Changes (Java/C++)
 
 These changes contain *some* of the major changes to the library that it's important for the user to recognize. This does not include all of the breaking changes, see the other sections of this document for more changes.
 
+- Added support for :doc:`on-robot telemetry recording into data logs </docs/software/telemetry/datalog>`
 - ``LiveWindow`` telemetry is now disabled by default. This has been observed as a consistent source of loop overruns. Use ``LiveWindow.enableAllTelemetry`` to restore the previous behavior
 - Bundled Java version has been bumped to 17 from 11
 - GCC 12.1 with C++ 20 support. Visual Studio 2022 is required for running C++ Simulation on Windows


### PR DESCRIPTION
Remove 2022.4.1 note from DataLog page.