### PR TITLE
CTRE Vendor Library URL Update

### DIFF
--- a/source/docs/software/vscode-overview/3rd-party-libraries.rst
+++ b/source/docs/software/vscode-overview/3rd-party-libraries.rst
@@ -78,7 +78,7 @@ Click these links to visit the vendor site to see whether they offer online inst
    ``https://copperforge.cc/files/dev/vendordeps/LibCu-latest.json``
 
 `CTRE Phoenix Framework <https://store.ctr-electronics.com/software/>`__ - Contains CANcoder, CANifier, Pigeon IMU, Talon FX, Talon SRX, and Victor SPX Libraries and Phoenix Tuner program for configuring CTRE CAN devices
-   ``https://maven.ctr-electronics.com/development/com/ctre/phoenix/Phoenix-frc2022-latest.json``
+   ``https://maven.ctr-electronics.com/release/com/ctre/phoenix/Phoenix-frc2022-latest.json``
 
 `Digilent <https://reference.digilentinc.com/dmc-60c/getting-started>`__ - DMC-60C library
    ``Offline only``


### PR DESCRIPTION
The existing URL hits a 404, updated to the latest from https://docs.ctre-phoenix.com/en/stable/ch05a_CppJava.html