### PR TITLE
Update field images link

### DIFF
--- a/source/docs/software/dashboards/glass/field2d-widget.rst
+++ b/source/docs/software/dashboards/glass/field2d-widget.rst
@@ -90,7 +90,7 @@ Once the widget appears, you can resize and place it on the Glass workspace as y
 
 When selecting :guilabel:`Choose image...` you can choose to either select an image file or a PathWeaver JSON file as long as the image file is in the same directory.  Choosing the JSON file will automatically import the correct location of the field in the image and the correct size of the field.
 
-.. note:: You can retrieve the latest field image and JSON files from `here <https://github.com/wpilibsuite/PathWeaver/tree/main/src/main/resources/edu/wpi/first/pathweaver>`__. This is the same image and JSON that are used when generating paths using :ref:`PathWeaver <docs/software/pathplanning/pathweaver/introduction:Introduction to PathWeaver>`.
+.. note:: You can retrieve the latest field image and JSON files from `here <https://github.com/wpilibsuite/allwpilib/tree/main/fieldImages/src/main/native/resources/edu/wpi/first/fields>`__. This is the same image and JSON that are used when generating paths using :ref:`PathWeaver <docs/software/pathplanning/pathweaver/introduction:Introduction to PathWeaver>`.
 
 .. image:: images/field2d-options.png
 


### PR DESCRIPTION
It currently links to the older Pathweaver repo, not the current one