### PR TITLE
Fix custom data logging example

### DIFF
--- a/source/docs/software/telemetry/datalog.rst
+++ b/source/docs/software/telemetry/datalog.rst
@@ -139,7 +139,7 @@ The LogEntry classes can be used in conjunction with DataLogManager to record va
           frc::DataLogManager::Start();
 
           // Set up custom log entries
-          wpi::log::DataLog& log = DataLogManager::GetLog();
+          wpi::log::DataLog& log = frc::DataLogManager::GetLog();
           myBooleanLog = wpi::Log::BooleanLogEntry(log, "/my/boolean");
           myDoubleLog = wpi::log::DoubleLogEntry(log, "/my/double");
           myStringLog = wpi::log::StringLogEntry(log, "/my/string");


### PR DESCRIPTION
DataLogManager should be accessed through the frc namespace.