### PR TITLE
Remove note about Edge in RIO web dashboard article

### DIFF
--- a/source/docs/software/roborio-info/roborio-web-dashboard.rst
+++ b/source/docs/software/roborio-info/roborio-web-dashboard.rst
@@ -4,8 +4,8 @@ roboRIO Web Dashboard
 The roboRIO web dashboard is a webpage built into the roboRIO that can
 be used for checking status and updating settings of the roboRIO.
 
-Users may encounter issues using IE (compatibility)
-or Edge (mDNS site access). Alternate browsers such as Google Chrome or
+Users may encounter issues using IE (compatibility).
+Alternate browsers such as Google Chrome or
 Mozilla Firefox are recommended for the best experience.
 
 Opening the WebDash


### PR DESCRIPTION
Edge is chromium based now, and the mDNS issue seems to be resolved.