### PR TITLE
Remove note about Game Tools not officially supported on Win 11

### DIFF
--- a/source/docs/zero-to-robot/step-2/frc-game-tools.rst
+++ b/source/docs/zero-to-robot/step-2/frc-game-tools.rst
@@ -16,7 +16,7 @@ The LabVIEW runtime components required for the Driver Station and Imaging Tool 
 Requirements
 ------------
 
-- Windows 10 or higher (Windows 10, 11). Windows 11 is not officially supported by NI, but has been tested to work.
+- Windows 10 or higher (Windows 10, 11).
 
 - Download the `FRC Game Tools <https://www.ni.com/en-us/support/downloads/drivers/download.frc-game-tools.html>`__ from NI.
 


### PR DESCRIPTION
Game Tools download page indicates Windows 11 is supported