### PR TITLE
Remove incorrect heading in command event listeners

### DIFF
--- a/source/docs/software/commandbased/command-scheduler.rst
+++ b/source/docs/software/commandbased/command-scheduler.rst
@@ -169,9 +169,6 @@ Command Event Methods
 
 Occasionally, it is desirable to have the scheduler execute a custom action whenever a certain command event (initialization, execution, or ending) occurs.  This can be done with the following methods:
 
-onCommandInitialize
-^^^^^^^^^^^^^^^^^^^
-
 - ``onCommandInitialize`` (`Java <https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj2/command/CommandScheduler.html#onCommandInitialize(java.util.function.Consumer)>`__, `C++ <https://github.wpilib.org/allwpilib/docs/release/cpp/classfrc2_1_1_command_scheduler.html#a5f983f0e45b0500c96eebe52780324d4>`__) runs a specified action whenever a command is initialized.
 
 - ``onCommandExecute`` (`Java <https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj2/command/CommandScheduler.html#onCommandExecute(java.util.function.Consumer)>`__, `C++ <https://github.wpilib.org/allwpilib/docs/release/cpp/classfrc2_1_1_command_scheduler.html#a58c538f4b8dd95e266e4a99167aa7f99>`__) runs a specified action whenever a command is executed.


### PR DESCRIPTION
This heading is left over from when this section had a separate heading for each method. That isn't the case now.