### PR TITLE
Add correct header to non-static command factories

### DIFF
--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -261,7 +261,7 @@ Then, elsewhere in our code, we can instantiate an single instance of this class
 
     Command driveAndIntake = autoRoutines.driveAndIntake();
     Command driveThenIntake = autoRoutines.driveThenIntake();
-    
+
     Command drivingAndIntakingSequence = Commands.sequence(
       autoRoutines.driveAndIntake(),
       autoRoutines.driveThenIntake()

--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -206,7 +206,7 @@ Instance factory methods work great for single-subsystem commands.  However, com
     // TODO
 
 Non-Static Command Factories
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If we want to avoid the verbosity of adding required subsystems as parameters to our factory methods, we can instead construct an instance of our `AutoRoutines` class and inject our subsystems through the constructor:
 
 .. tabs::
@@ -236,7 +236,7 @@ If we want to avoid the verbosity of adding required subsystems as parameters to
                 )
             );
         }
-        
+
         public Command driveThenIntake() {
             return Commands.sequence(
                 drivetrain.driveCommand(0.5, 0.5).withTimeout(5.0),
@@ -262,19 +262,19 @@ Then, elsewhere in our code, we can instantiate an single instance of this class
         private Drivetrain drivetrain;
 
         private Intake intake;
-        
+
         private AutoRoutines autoRoutines;
 
         public RobotContainer(Drivetrain drivetrain, Intake intake) {
           this.drivetrain = new Drivetrain();
           this.intake = new Intake();
-          
+
           this.autoRoutines = new AutoRoutines(this.drivetrain, this.intake);
-          
+
           Command driveAndIntake = autoRoutines.driveAndIntake();
           Command driveThenIntake = autoRoutines.driveThenIntake();
         }
-        
+
         // [other RobotContainer code]
 
     }

--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -257,27 +257,15 @@ Then, elsewhere in our code, we can instantiate an single instance of this class
 
   .. code-tab:: java
 
-    public class RobotContainer {
+    AutoRoutines autoRoutines = new AutoRoutines(this.drivetrain, this.intake);
 
-        private Drivetrain drivetrain;
-
-        private Intake intake;
-
-        private AutoRoutines autoRoutines;
-
-        public RobotContainer(Drivetrain drivetrain, Intake intake) {
-          this.drivetrain = new Drivetrain();
-          this.intake = new Intake();
-
-          this.autoRoutines = new AutoRoutines(this.drivetrain, this.intake);
-
-          Command driveAndIntake = autoRoutines.driveAndIntake();
-          Command driveThenIntake = autoRoutines.driveThenIntake();
-        }
-
-        // [other RobotContainer code]
-
-    }
+    Command driveAndIntake = autoRoutines.driveAndIntake();
+    Command driveThenIntake = autoRoutines.driveThenIntake();
+    
+    Command drivingAndIntakingSequence = Commands.sequence(
+      autoRoutines.driveAndIntake(),
+      autoRoutines.driveThenIntake()
+    );
 
   .. code-tab:: c++
 

--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -205,6 +205,8 @@ Instance factory methods work great for single-subsystem commands.  However, com
 
     // TODO
 
+Non-Static Command Factories
+~~~~~~~~~~~~~~~~~~~~~~~~
 If we want to avoid the verbosity of adding required subsystems as parameters to our factory methods, we can instead construct an instance of our `AutoRoutines` class and inject our subsystems through the constructor:
 
 .. tabs::
@@ -234,6 +236,47 @@ If we want to avoid the verbosity of adding required subsystems as parameters to
                 )
             );
         }
+        
+        public Command driveThenIntake() {
+            return Commands.sequence(
+                drivetrain.driveCommand(0.5, 0.5).withTimeout(5.0),
+                drivetrain.stopCommand(),
+                intake.runIntakeCommand(1.0).withTimeout(5.0),
+                intake.stopCommand()
+            );
+        }
+    }
+
+  .. code-tab:: c++
+
+    // TODO
+
+Then, elsewhere in our code, we can instantiate an single instance of this class and use it to produce several commands:
+
+.. tabs::
+
+  .. code-tab:: java
+
+    public class RobotContainer {
+
+        private Drivetrain drivetrain;
+
+        private Intake intake;
+        
+        private AutoRoutines autoRoutines;
+
+        public RobotContainer(Drivetrain drivetrain, Intake intake) {
+          this.drivetrain = new Drivetrain();
+          this.intake = new Intake();
+          
+          this.autoRoutines = new AutoRoutines(this.drivetrain, this.intake);
+          
+          Command driveAndIntake = autoRoutines.driveAndIntake();
+          Command driveThenIntake = autoRoutines.driveThenIntake();
+        }
+        
+        // [other RobotContainer code]
+
     }
 
   .. code-tab:: c++
@@ -366,7 +409,7 @@ Summary
      - Relatively verbose
      - Excels at them
      - Yes; may be more natural than other approaches
-   * - Static Factory Methods
+   * - Static and Instance Command Factories
      - Multi-subsystem commands
      - Yes
      - Yes

--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -207,7 +207,7 @@ Instance factory methods work great for single-subsystem commands.  However, com
 
 Non-Static Command Factories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If we want to avoid the verbosity of adding required subsystems as parameters to our factory methods, we can instead construct an instance of our `AutoRoutines` class and inject our subsystems through the constructor:
+If we want to avoid the verbosity of adding required subsystems as parameters to our factory methods, we can instead construct an instance of our ``AutoRoutines`` class and inject our subsystems through the constructor:
 
 .. tabs::
 


### PR DESCRIPTION
The "Static Command Factories" subheader mistakenly has an example of non-static command factories under it as well. This adds the proper header and makes the example a bit clearer.