### PR TITLE
Update gyro docs

### DIFF
--- a/source/docs/software/hardware-apis/sensors/gyros-software.rst
+++ b/source/docs/software/hardware-apis/sensors/gyros-software.rst
@@ -12,7 +12,7 @@ There are getters the current angular rate and heading and functions for zeroing
 .. note:: It is crucial that the robot remain stationary while calibrating a gyro.
 
 ADIS16448
-^^^^^^^^^
+---------
 
 The ADIS16448 uses the :code:`ADIS16448_IMU` class (`Java <https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/ADIS16448_IMU.html>`__, `C++ <https://github.wpilib.org/allwpilib/docs/release/cpp/classfrc_1_1_a_d_i_s16448___i_m_u.html>`__).  See the `Analog Devices ADIS16448 documentation <https://wiki.analog.com/first/adis16448_imu_frc>`__ for additional information and examples.
 
@@ -31,7 +31,7 @@ The ADIS16448 uses the :code:`ADIS16448_IMU` class (`Java <https://github.wpilib
         ADIS16448_IMU gyro;
 
 ADIS16470
-^^^^^^^^^
+---------
 
 The ADIS16470 uses the :code:`ADIS16470_IMU` class (`Java <https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/ADIS16470_IMU.html>`__, `C++ <https://github.wpilib.org/allwpilib/docs/release/cpp/classfrc_1_1_a_d_i_s16470___i_m_u.html>`__).  See the `Analog Devices ADIS16470 documentation <https://wiki.analog.com/first/adis16470_imu_frc>`__ for additional information and examples.
 
@@ -50,7 +50,7 @@ The ADIS16470 uses the :code:`ADIS16470_IMU` class (`Java <https://github.wpilib
         ADIS16470_IMU gyro;
 
 ADXRS450_Gyro
-^^^^^^^^^^^^^
+-------------
 
 The :code:`ADXRS450_Gyro` class (`Java <https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/ADXRS450_Gyro.html>`__, `C++ <https://github.wpilib.org/allwpilib/docs/release/cpp/classfrc_1_1_a_d_x_r_s450___gyro.html>`__) provides support for the Analog Devices ADXRS450 gyro available in the kit of parts, which connects over the SPI bus.
 
@@ -69,7 +69,7 @@ The :code:`ADXRS450_Gyro` class (`Java <https://github.wpilib.org/allwpilib/docs
         frc::ADXRS450_Gyro gyro;
 
 AnalogGyro
-^^^^^^^^^^
+----------
 
 The :code:`AnalogGyro` class (`Java <https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/AnalogGyro.html>`__, `C++ <https://github.wpilib.org/allwpilib/docs/release/cpp/classfrc_1_1_analog_gyro.html>`__) provides support for any single-axis gyro with an analog output.
 
@@ -88,7 +88,7 @@ The :code:`AnalogGyro` class (`Java <https://github.wpilib.org/allwpilib/docs/re
         frc::AnalogGyro gyro{0};
 
 navX
-^^^^
+----
 
 The navX uses the :code:`AHRS` class.  See the `navX documentation <https://pdocs.kauailabs.com/navx-mxp/guidance/selecting-an-interface/>`__ for additional connection types.
 
@@ -105,7 +105,7 @@ The navX uses the :code:`AHRS` class.  See the `navX documentation <https://pdoc
         AHRS gyro{SPI::Port::kMXP};
 
 Pigeon
-^^^^^^
+------
 
 The Pigeon should use the :code:`WPI_PigeonIMU` class.  The Pigeon can either be connected with CAN or by data cable to a TalonSRX.  The `Pigeon IMU User's Guide <https://store.ctr-electronics.com/content/user-manual/Pigeon%20IMU%20User's%20Guide.pdf>`__ contains full details on using the Pigeon.
 

--- a/source/docs/software/hardware-apis/sensors/gyros-software.rst
+++ b/source/docs/software/hardware-apis/sensors/gyros-software.rst
@@ -5,12 +5,9 @@ Gyroscopes - Software
 
 .. note:: This section covers gyros in software.  For a hardware guide to gyros, see :ref:`docs/hardware/sensors/gyros-hardware:Gyroscopes - Hardware`.
 
-A gyroscope, or "gyro," is an angular rate sensor typically used in robotics to measure and/or stabilize robot headings.  WPILib natively provides specific support for the ADXRS450 gyro available in the kit of parts, as well as more general support for a wider variety of analog gyros through the `AnalogGyro`_ class. Most common 3rd party gyros inherit from the :code:`Gyro` interface making them easily usable too!
+A gyroscope, or "gyro," is an angular rate sensor typically used in robotics to measure and/or stabilize robot headings.  WPILib natively provides specific support for the ADXRS450 gyro available in the kit of parts, as well as more general support for a wider variety of analog gyros through the `AnalogGyro`_ class.
 
-The Gyro interface
-------------------
-
-All natively-supported gyro objects in WPILib implement the :code:`Gyro` interface (`Java <https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/interfaces/Gyro.html>`__, `C++ <https://github.wpilib.org/allwpilib/docs/release/cpp/classfrc_1_1_gyro.html>`__).  This interface provides methods for getting the current angular rate and heading, zeroing the current heading, and calibrating the gyro.
+There are getters the current angular rate and heading and functions for zeroing the current heading and calibrating the gyro.
 
 .. note:: It is crucial that the robot remain stationary while calibrating a gyro.
 
@@ -93,7 +90,7 @@ The :code:`AnalogGyro` class (`Java <https://github.wpilib.org/allwpilib/docs/re
 navX
 ^^^^
 
-The navX uses the :code:`AHRS` class and implements the :code:`Gyro` interface.  See the `navX documentation <https://pdocs.kauailabs.com/navx-mxp/guidance/selecting-an-interface/>`__ for additional connection types.
+The navX uses the :code:`AHRS` class.  See the `navX documentation <https://pdocs.kauailabs.com/navx-mxp/guidance/selecting-an-interface/>`__ for additional connection types.
 
 .. tabs::
 
@@ -110,7 +107,7 @@ The navX uses the :code:`AHRS` class and implements the :code:`Gyro` interface. 
 Pigeon
 ^^^^^^
 
-The Pigeon should use the :code:`WPI_PigeonIMU` class that implements :code:`Gyro`.  The Pigeon can either be connected with CAN or by data cable to a TalonSRX.  The `Pigeon IMU User's Guide <https://store.ctr-electronics.com/content/user-manual/Pigeon%20IMU%20User's%20Guide.pdf>`__ contains full details on using the Pigeon.
+The Pigeon should use the :code:`WPI_PigeonIMU` class.  The Pigeon can either be connected with CAN or by data cable to a TalonSRX.  The `Pigeon IMU User's Guide <https://store.ctr-electronics.com/content/user-manual/Pigeon%20IMU%20User's%20Guide.pdf>`__ contains full details on using the Pigeon.
 
 .. tabs::
 
@@ -138,7 +135,7 @@ Gyros are extremely useful in FRC for both measuring and controlling robot headi
 Displaying the robot heading on the dashboard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:ref:`Shuffleboard <docs/software/dashboards/shuffleboard/getting-started/shuffleboard-tour:Tour of Shuffleboard>` includes a widget for displaying heading data from a :code:`Gyro` in the form of a compass.  This can be helpful for viewing the robot heading when sight lines to the robot are obscured:
+:ref:`Shuffleboard <docs/software/dashboards/shuffleboard/getting-started/shuffleboard-tour:Tour of Shuffleboard>` includes a widget for displaying heading data from a gyro in the form of a compass.  This can be helpful for viewing the robot heading when sight lines to the robot are obscured:
 
 .. tabs::
 


### PR DESCRIPTION
The Gyro interface was deprecated in wpilibsuite/allwpilib#5445.