### PR TITLE
Fixed warning tag

### DIFF
--- a/source/docs/hardware/hardware-basics/wiring-pneumatics-ph.rst
+++ b/source/docs/hardware/hardware-basics/wiring-pneumatics-ph.rst
@@ -50,7 +50,7 @@ Analog
 
 An analog pressure switch (`REV-11-1107 <https://www.revrobotics.com/rev-11-1107/>`__ can be connected directly to the analog pressure sensor port 0 input terminals. Using an analog pressure sensor allows reading the pressure in the pneumatic system through code and setting custom trigger thresholds for turning on and off the compressor.
 
-..warning:: The Analog Pressure Sensor port is a very tight fit and requires special attention. See `REV Wiring an Analog Pressure Sensor <https://docs.revrobotics.com/rev-11-1852/pneumatic-hub-getting-started/wiring-the-pneumatic-hub#wiring-an-analog-pressure-sensor>`__ for more tips
+.. warning:: The Analog Pressure Sensor port is a very tight fit and requires special attention. See `REV Wiring an Analog Pressure Sensor <https://docs.revrobotics.com/rev-11-1852/pneumatic-hub-getting-started/wiring-the-pneumatic-hub#wiring-an-analog-pressure-sensor>`__ for more tips
 
 Solenoids
 ---------


### PR DESCRIPTION
There was a missing "space key"

What it looked like before:
![image](https://github.com/wpilibsuite/frc-docs/assets/65907299/f9d2fc17-7b05-4939-bd16-20405b49be23)
