### PR TITLE
Replace frc2::PIDController with frc::PIDController

### DIFF
--- a/source/docs/software/advanced-controls/controllers/pidcontroller.rst
+++ b/source/docs/software/advanced-controls/controllers/pidcontroller.rst
@@ -27,7 +27,7 @@ In order to use WPILib's PID control functionality, users must first construct a
   .. code-tab:: c++
 
     // Creates a PIDController with gains kP, kI, and kD
-    frc2::PIDController pid{kP, kI, kD};
+    frc::PIDController pid{kP, kI, kD};
 
 An optional fourth parameter can be provided to the constructor, specifying the period at which the controller will be run.  The ``PIDController`` object is intended primarily for synchronous use from the main robot loop, and so this value is defaulted to 20ms.
 

--- a/source/docs/software/advanced-controls/trajectories/holonomic.rst
+++ b/source/docs/software/advanced-controls/trajectories/holonomic.rst
@@ -26,7 +26,7 @@ The final parameter is a ``ProfiledPIDController`` for the rotation of the robot
    .. code-tab:: c++
 
       frc::HolonomicDriveController controller{
-        frc2::PIDController{1, 0, 0}, frc2::PIDController{1, 0, 0},
+        frc::PIDController{1, 0, 0}, frc::PIDController{1, 0, 0},
         frc::ProfiledPIDController<units::radian>{
           1, 0, 0, frc::TrapezoidProfile<units::radian>::Constraints{
             6.28_rad_per_s, 3.14_rad_per_s / 1_s}}};

--- a/source/docs/software/advanced-controls/trajectories/troubleshooting.rst
+++ b/source/docs/software/advanced-controls/trajectories/troubleshooting.rst
@@ -200,8 +200,8 @@ If your feedforwards are bad then the P controllers for each side of the robot w
     auto rightRef = table->GetEntry("right_reference");
     auto rightMeas = table->GetEntry("right_measurement");
 
-    frc2::PIDController leftController(DriveConstants::kPDriveVel, 0, 0);
-    frc2::PIDController rightController(DriveConstants::kPDriveVel, 0, 0);
+    frc::PIDController leftController(DriveConstants::kPDriveVel, 0, 0);
+    frc::PIDController rightController(DriveConstants::kPDriveVel, 0, 0);
     frc2::RamseteCommand ramseteCommand(
         exampleTrajectory, [this]() { return m_drive.GetPose(); },
         frc::RamseteController(AutoConstants::kRamseteB,

--- a/source/docs/software/convenience-features/scheduling-functions.rst
+++ b/source/docs/software/convenience-features/scheduling-functions.rst
@@ -45,7 +45,7 @@ The ``addPeriodic()`` (Java) / ``AddPeriodic()`` (C++) method takes in a lambda 
               frc::Joystick m_joystick{0};
               frc::Encoder m_encoder{1, 2};
               frc::Spark m_motor{1};
-              frc2::PIDController m_controller{1.0, 0.0, 0.5, 10_ms};
+              frc::PIDController m_controller{1.0, 0.0, 0.5, 10_ms};
 
               Robot();
 


### PR DESCRIPTION
The latter already exists as a typedef to the new class, and the former is being removed by wpilibsuite/allwpilib#5640.