### PR TITLE
Set default image width/alignment in LaTeX build

### DIFF
--- a/source/_extensions/default_latex_image_settings.py
+++ b/source/_extensions/default_latex_image_settings.py
@@ -19,14 +19,14 @@ class DefaultLaTeXImageSettingsTransform(SphinxPostTransform):
         if not self.app.tags.has("latex"):
             return
 
-        width = self.app.config["default_image_width_latex"]
+        width = self.app.config["default_latex_image_width"]
 
         for node in self.document.findall(nodes.image):
             if "width" not in node.attributes:
                 node.attributes["width"] = width
 
             if (
-                self.app.config["default_image_centered"]
+                self.app.config["default_latex_image_centered"]
                 and "align" not in node.attributes
             ):
                 node.attributes["align"] = "center"

--- a/source/_extensions/default_latex_image_settings.py
+++ b/source/_extensions/default_latex_image_settings.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict
+
+from docutils import nodes
+
+from sphinx.transforms.post_transforms import SphinxPostTransform
+from sphinx.application import Sphinx
+
+
+class DefaultLaTeXImageSettingsTransform(SphinxPostTransform):
+    """
+    Set a default image width for images which do not have a width attribute
+    manually set. Also center images which are not centered. This only applies
+    to LaTeX builds.
+    """
+
+    default_priority = 100  # chosen arbitrarily
+
+    def run(self, **kwargs: Any) -> None:
+        if not self.app.tags.has("latex"):
+            return
+
+        width = self.app.config["default_image_width_latex"]
+
+        for node in self.document.findall(nodes.image):
+            if "width" not in node.attributes:
+                node.attributes["width"] = width
+
+            if (
+                self.app.config["default_image_centered"]
+                and "align" not in node.attributes
+            ):
+                node.attributes["align"] = "center"
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_config_value("default_latex_image_width", "20em", True)
+    app.add_config_value("default_latex_image_centered", True, True)
+    app.add_post_transform(DefaultLaTeXImageSettingsTransform)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/source/_extensions/default_latex_image_settings.py
+++ b/source/_extensions/default_latex_image_settings.py
@@ -33,7 +33,7 @@ class DefaultLaTeXImageSettingsTransform(SphinxPostTransform):
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
-    app.add_config_value("default_latex_image_width", "20em", True)
+    app.add_config_value("default_latex_image_width", "25em", True)
     app.add_config_value("default_latex_image_centered", True, True)
     app.add_post_transform(DefaultLaTeXImageSettingsTransform)
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -65,6 +65,7 @@ local_extensions = [
     "_extensions.localization",
     "_extensions.controls_js_sim",
     "_extensions.wpilib_release",
+    "_extensions.default_latex_image_settings",
 ]
 
 extensions += local_extensions


### PR DESCRIPTION
This produces much better looking presentation for the PDF build of gm0, and perhaps a similar idea can be applicable here. However, it will likely require some tweaking to better match the different style of content.