### PR TITLE
Add CAN IDs for AM and VH

### DIFF
--- a/source/docs/software/can-devices/can-addressing.rst
+++ b/source/docs/software/can-devices/can-addressing.rst
@@ -66,7 +66,9 @@ Playing With Fusion   11
 Studica               12
 The Thrifty Bot       13
 Redux Robotics        14
-Reserved              15-255
+AndyMark              15
+Vivid Hosting         16
+Reserved              17-255
 ===================== ==========
 
 API/Message Identifier


### PR DESCRIPTION
Assign CAN IDs to AndyMark and Vivid Hosting