### PR TITLE
ADUS16470 default port says MXP it should say SPI

### DIFF
--- a/source/docs/software/hardware-apis/sensors/gyros-software.rst
+++ b/source/docs/software/hardware-apis/sensors/gyros-software.rst
@@ -44,12 +44,12 @@ The ADIS16470 uses the :code:`ADIS16470_IMU` class (`Java <https://github.wpilib
 
     .. code-tab:: java
 
-        // ADIS16470 plugged into the MXP port
+        // ADIS16470 plugged into the SPI port
         ADIS16470_IMU gyro = new ADIS16470_IMU();
 
     .. code-tab:: c++
 
-        // ADIS16470 plugged into the MXP port
+        // ADIS16470 plugged into the SPI port
         ADIS16470_IMU gyro;
 
 ADXRS450_Gyro


### PR DESCRIPTION
The documentation says that the ADIS16470 is plugged into the MXP by default which is not true. It should say SPI Port

Reference: https://first.wpi.edu/wpilib/allwpilib/docs/release/java/src-html/edu/wpi/first/wpilibj/ADIS16470_IMU.html#line.281

