### PR TITLE
ADIS16470 fix wrong default port listed

### DIFF
--- a/source/docs/software/hardware-apis/sensors/gyros-software.rst
+++ b/source/docs/software/hardware-apis/sensors/gyros-software.rst
@@ -44,12 +44,12 @@ The ADIS16470 uses the :code:`ADIS16470_IMU` class (`Java <https://github.wpilib
 
     .. code-tab:: java
 
-        // ADIS16470 plugged into the MXP port
+        // ADIS16470 plugged into the SPI port
         ADIS16470_IMU gyro = new ADIS16470_IMU();
 
     .. code-tab:: c++
 
-        // ADIS16470 plugged into the MXP port
+        // ADIS16470 plugged into the SPI port
         ADIS16470_IMU gyro;
 
 ADXRS450_Gyro

--- a/source/docs/software/telemetry/writing-sendable-classes.rst
+++ b/source/docs/software/telemetry/writing-sendable-classes.rst
@@ -9,7 +9,7 @@ For example, here is the implementation of ``initSendable`` from WPILib's ``Bang
 
     .. group-tab:: Java
 
-        .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/main/wpimath/src/main/java/edu/wpi/first/math/controller/BangBangController.java
+        .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2023.4.3/wpimath/src/main/java/edu/wpi/first/math/controller/BangBangController.java
            :language: java
            :lines: 150-158
            :linenos:
@@ -17,7 +17,7 @@ For example, here is the implementation of ``initSendable`` from WPILib's ``Bang
 
     .. group-tab:: C++
 
-        .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/main/wpimath/src/main/native/cpp/controller/BangBangController.cpp
+        .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2023.4.3/wpimath/src/main/native/cpp/controller/BangBangController.cpp
            :language: cpp
            :lines: 58-72
            :linenos:
@@ -54,7 +54,7 @@ To help users ensure safety when interfacing with dashboard values, ``SendableBu
 
     .. group-tab:: Java
 
-        .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/main/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMMotorController.java
+        .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2023.4.3/wpilibj/src/main/java/edu/wpi/first/wpilibj/motorcontrol/PWMMotorController.java
            :language: java
            :lines: 118-124
            :linenos:
@@ -62,10 +62,10 @@ To help users ensure safety when interfacing with dashboard values, ``SendableBu
 
     .. group-tab:: C++
 
-        .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/main/wpilibc/src/main/native/cpp/motorcontrol/PWMMotorController.cpp
+        .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2023.4.3/wpilibc/src/main/native/cpp/motorcontrol/PWMMotorController.cpp
            :language: cpp
-           :lines: 54-60
+           :lines: 56-62
            :linenos:
-           :lineno-start: 54
+           :lineno-start: 56
 
 Additionally, users may call ``builder.setActuator(true)`` to mark any mechanism that might move as a result of ``Sendable`` input as an actuator.  Currently, this is used by :ref:`Shuffleboard <docs/software/dashboards/shuffleboard/getting-started/shuffleboard-tour:Tour of Shuffleboard>` to disable actuator widgets when not in :ref:`LiveWindow <docs/controls-overviews/control-system-software:LiveWindow>` mode.

--- a/source/docs/software/vision-processing/roborio/using-the-cameraserver-on-the-roborio.rst
+++ b/source/docs/software/vision-processing/roborio/using-the-cameraserver-on-the-roborio.rst
@@ -21,7 +21,7 @@ The following program starts automatic capture of a USB camera like the Microsof
 
    .. group-tab:: C++
 
-      .. rli:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/main/wpilibcExamples/src/main/cpp/examples/QuickVision/cpp/Robot.cpp
+      .. rli:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2023.4.3/wpilibcExamples/src/main/cpp/examples/QuickVision/cpp/Robot.cpp
          :language: cpp
          :lines: 7-8,16-18,20,25-31
 
@@ -43,7 +43,7 @@ In the following example a thread created in robotInit() gets the Camera Server 
 
    .. group-tab:: C++
 
-      .. rli:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/main/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
+      .. rli:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2023.4.3/wpilibcExamples/src/main/cpp/examples/IntermediateVision/cpp/Robot.cpp
          :language: cpp
          :lines: 5-20,23-56,58-61,63-64,69-76
 

--- a/source/docs/yearly-overview/known-issues.rst
+++ b/source/docs/yearly-overview/known-issues.rst
@@ -8,6 +8,13 @@ This article details known issues (and workarounds) for FRC\ |reg| Control Syste
 Open Issues
 -----------
 
+LabVIEW installation of RabbitMQ Fails
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Issue:** Some users have reported the following error during LabVIEW installation: ``An error occurred while installing a package: ni-skyline-rabbitmq-support (20.5.0.49152-0+f0)``.
+
+**Workaround:** NI has a `support article <https://knowledge.ni.com/KnowledgeArticleDetails?id=kA00Z000000kIbbSAE&l=en-US>`_ with several potential workarounds. Alternately, you can de-select :guilabel:`NI Web Server Development Support for LabVIEW 2020 32-bit` from the :guilabel:`Additional items you may wish to install` page to avoid installing the failing package.
+
 roboRIO 2.0 Ethernet Settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/docs/zero-to-robot/step-2/wpilib-setup.rst
+++ b/source/docs/zero-to-robot/step-2/wpilib-setup.rst
@@ -11,6 +11,8 @@ Supported Operating Systems and Architectures:
  * Ubuntu 22.04, 64 bit. Other Linux distributions with glibc >= 2.34 may work, but are unsupported
  * macOS 11 or higher, both Intel and Arm.
 
+.. warning:: For 2024, macOS 12 or higher will be required for C++
+
 .. warning:: The following OSes are no longer supported: macOS 10.15, Ubuntu 18.04 & 20.04, Windows 7, Windows 8.1, and any 32-bit Windows.
 
 WPILib is designed to install to different folders for different years, so that it is not necessary to uninstall a previous version before installing this year's WPILib.


### PR DESCRIPTION
The documentation says that the ADIS16470 is plugged into the MXP by default which is not true. It should say SPI Port

Reference: https://first.wpi.edu/wpilib/allwpilib/docs/release/java/src-html/edu/wpi/first/wpilibj/ADIS16470_IMU.html#line.281