### PR TITLE
Fix AdvantageScope link on dashboard intro page

### DIFF
--- a/source/docs/software/dashboards/dashboard-intro.rst
+++ b/source/docs/software/dashboards/dashboard-intro.rst
@@ -28,7 +28,7 @@ Specific Dashboards (oldest to newest)
 
 :ref:`Glass <docs/software/dashboards/glass/index:Glass>` (Programming) - robot data visualization tool. Its GUI is extremely similar to that of the :ref:`Simulation GUI <docs/software/wpilib-tools/robot-simulation/simulation-gui:Simulation Specific User Interface Elements>`. In its current state, it is meant to be used as a programmer's tool rather than a proper dashboard in a competition environment, with a focus on high performance real time plotting.
 
-:ref:`AdvantageScope <docs/software/dashboards/glass/index:Glass>` (Programming) - robot diagnostics, log review/analysis, and data visualization application.  It reads the WPILib Data Log (``.wpilog``) and Driver Station Log (``.dslog`` / ``.dsevents``) file formats, plus live robot data viewing.
+:ref:`AdvantageScope <docs/software/dashboards/advantagescope:AdvantageScope>` (Programming) - robot diagnostics, log review/analysis, and data visualization application.  It reads the WPILib Data Log (``.wpilog``) and Driver Station Log (``.dslog`` / ``.dsevents``) file formats, plus live robot data viewing.
 
 Third Party Dashboards
 ----------------------


### PR DESCRIPTION
I believe Glass was used as a placeholder since the AdvantageScope docs weren't merged yet when the page was written.