### PR TITLE
Added REVLib 2024.2.0 link and vendor dep to 3rd Party libraries section

### DIFF
--- a/source/docs/software/vscode-overview/3rd-party-libraries.rst
+++ b/source/docs/software/vscode-overview/3rd-party-libraries.rst
@@ -123,8 +123,8 @@ Click these links to visit the vendor site to see whether they offer online inst
 `Kauai Labs <https://pdocs.kauailabs.com/navx-mxp/software/roborio-libraries/>`__ - Libraries for NavX-MXP, NavX-Micro, and Sensor Fusion
    Not yet available for 2024
 
-`REV Robotics REVLib <https://docs.revrobotics.com/sparkmax/software-resources/spark-max-api-information>`__ - Library for all REV devices including SPARK MAX and Color Sensor V3
-   Not yet available for 2024
+`REV Robotics REVLib <https://docs.revrobotics.com/brushless/spark-flex/revlib>`__ - Library for all REV devices including SPARK FlEX, SPARK MAX, and Color Sensor V3
+   ``https://software-metadata.revrobotics.com/REVLib-2024.json``
 
 Community Libraries
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
link leads to revlib for spark flex as the rev docs have max and flex under the brushless section