### PR TITLE
Make NT Stale Data more discoverable

### DIFF
--- a/source/docs/software/dashboards/glass/networktables-connection.rst
+++ b/source/docs/software/dashboards/glass/networktables-connection.rst
@@ -24,3 +24,8 @@ The :guilabel:`NetworkTables` widget can be used to view all entries that are be
 .. image:: images/nt-widget.png
 
 Furthermore, you can view all connected NetworkTables clients under the :guilabel:`Connections` pane of the widget.
+
+Stale Data
+----------
+
+Glass uses :term:`NetworkTables` for communicating values between the robot and the driver station laptop. See :doc:`NetworkTables Stale Data </docs/software/networktables/stale-data>` for why Glass continues to show data that is no longer in the robot program.

--- a/source/docs/software/dashboards/shuffleboard/getting-started/shuffleboard-displaying-data.rst
+++ b/source/docs/software/dashboards/shuffleboard/getting-started/shuffleboard-displaying-data.rst
@@ -92,3 +92,8 @@ Normally :term:`NetworkTables` data automatically appears on one of the tabs and
 
 .. figure:: images/data-sources-2.png
    :alt:
+
+Stale Data
+----------
+
+Shuffleboard uses :term:`NetworkTables` for communicating values between the robot and the driver station laptop. See :doc:`NetworkTables Stale Data </docs/software/networktables/stale-data>` for why Shuffleboard continues to show data that is no longer in the robot program.

--- a/source/docs/software/dashboards/smartdashboard/displaying-expressions.rst
+++ b/source/docs/software/dashboards/smartdashboard/displaying-expressions.rst
@@ -56,8 +56,5 @@ Widgets are populated on the SmartDashboard automatically, no user intervention 
 
 Stale Data
 ----------
-SmartDashboard uses :term:`NetworkTables` for communicating values between the robot and the driver station laptop. NetworkTables acts as a distributed table of name and value pairs. If a name/value pair is added to either the client (laptop) or server (robot) it is replicated to the other. If a name/value pair is deleted from, say, the robot but the SmartDashboard or OutlineViewer are still running, then when the robot is restarted, the old values will still appear in the SmartDashboard and OutlineViewer because they never stopped running and continue to have those values in their tables. When the robot restarts, those old values will be replicated to the robot.
 
-To ensure that the SmartDashboard and OutlineViewer are showing current values, it is necessary to restart the NetworkTables clients and robot at the same time. That way, old values that one is holding won't get replicated to the others.
-
-This usually isn't a problem if the program isn't constantly changing, but if the program is in development and the set of keys being added to NetworkTables is constantly changing, then it might be necessary to do the restart of everything to accurately see what is current.
+SmartDashboard uses :term:`NetworkTables` for communicating values between the robot and the driver station laptop. See :doc:`NetworkTables Stale Data </docs/software/networktables/stale-data>` for why SmartDashboard continues to show data that is no longer in the robot program.

--- a/source/docs/software/dashboards/smartdashboard/smartdashboard-intro.rst
+++ b/source/docs/software/dashboards/smartdashboard/smartdashboard-intro.rst
@@ -63,3 +63,4 @@ Adding Widgets to the SmartDashboard
 ------------------------------------
 
 Widgets are automatically added to the SmartDashboard for each "key" sent by the robot code. For instructions on adding robot code to write to the SmartDashboard see :doc:`Displaying Expressions from Within the Robot Program <displaying-expressions>`.
+

--- a/source/docs/software/networktables/index.rst
+++ b/source/docs/software/networktables/index.rst
@@ -16,5 +16,6 @@ This section outlines the details of using the NetworkTables (v4) API to communi
    listening-for-change
    robot-program
    client-side-program
+   stale-data
    nt4-migration-guide
    reading-array-values-published-by-networktables

--- a/source/docs/software/networktables/stale-data.rst
+++ b/source/docs/software/networktables/stale-data.rst
@@ -1,0 +1,8 @@
+Stale Data
+==========
+
+NetworkTables acts as a distributed table of name and value pairs. If a name/value pair is added to either the server (robot) or any client (dashboard, co-processor, limelight, etc) it is replicated to all devices. If a name/value pair is deleted from, say, the robot but any NetworkTables clients are still running, then when the robot is restarted, the old values will still appear in the client because they never stopped running and continue to have those values in their tables. When the robot restarts, those old values will be replicated to the robot.
+
+To ensure that the robot and clients are showing current values, it is necessary to shut down all NetworkTables clients and robot at the same time. That way, old values that one is holding won't get replicated to the others. Once everything is shut down, the robot and clients can be restarted.
+
+This usually isn't a problem if the program isn't constantly changing, but if the program is in development and the set of keys being added to NetworkTables is constantly changing, then it might be necessary to do the restart of everything to accurately see what is current.


### PR DESCRIPTION
Move from a sub-section in SmartDashboard into NetworkTables, and add references in each dashboard