### PR TITLE
Update field oriented inversion example snippet

### DIFF
--- a/source/docs/software/basic-programming/coordinate-system.rst
+++ b/source/docs/software/basic-programming/coordinate-system.rst
@@ -265,7 +265,7 @@ A simple way to deal with field oriented driving is to check the alliance color 
 
       // The origin is always blue. When our alliance is red, X and Y need to be inverted
       var alliance = DriverStation.getAlliance();
-      var invert = 0;
+      var invert = 1;
       if (alliance.isPresent() && alliance.get() == Alliance.Red) {
           invert = -1;
       }
@@ -280,7 +280,7 @@ A simple way to deal with field oriented driving is to check the alliance color 
    .. code-block:: c++
 
       // The origin is always blue. When our alliance is red, X and Y need to be inverted
-      int invert = 0;
+      int invert = 1;
       if (frc::DriverStation::GetAlliance() == frc::DriverStation::Alliance::kRed) {
           invert = -1;
       }
@@ -295,7 +295,7 @@ A simple way to deal with field oriented driving is to check the alliance color 
    .. code-block:: python
 
        # The origin is always blue. When our alliance is red, X and Y need to be inverted
-       invert = 0
+       invert = 1
        if wpilib.DriverStation.getAlliance() == wpilib.DriverStation.Alliance.kRed:
            invert = -1
 


### PR DESCRIPTION
Previously, the field-oriented inversion example would multiply chassis speeds to zero if the driver station alliance was blue. Now it properly multiplies by one if the alliance is blue and by negative one if the alliance is red.