### PR TITLE
[docs] Make C++ example for advantagescope swerve states compilable

### DIFF
--- a/source/docs/software/kinematics-and-odometry/swerve-drive-kinematics.rst
+++ b/source/docs/software/kinematics-and-odometry/swerve-drive-kinematics.rst
@@ -303,14 +303,12 @@ By recording a set of swerve module states using :ref:`NetworkTables <docs/softw
 
         void Periodic() {
           // Periodically send a set of module states
-          swervePublisher.Set(
-            std::vector{
-              frontLeftState,
-              frontRightState,
-              backLeftState,
-              backRightState
-            }
-          );
+          std::vector states_vec = {m_frontLeft.GetState(), m_frontRight.GetState(),
+                            m_rearLeft.GetState(), m_rearRight.GetState()};
+         std::span<frc::SwerveModuleState, 4> states(states_vec.begin(),
+                                              states_vec.end());
+
+         publisher.Set(states);
         }
       };
 


### PR DESCRIPTION
When I was initially implementing this in my codebase the example in the docs confused me because although it seemed straightforward it wouldn’t actually compile. The publisher needs a std::span of states rather than a vector as indicated by the docs. While this is definitely not the most concise implementation, (it’s ripped from our season code) it’s a lot more helpful in my opinion.