### PR TITLE
Ensure addVisionMeasurement() is included

### DIFF
--- a/source/docs/software/advanced-controls/state-space/state-space-pose-estimators.rst
+++ b/source/docs/software/advanced-controls/state-space/state-space-pose-estimators.rst
@@ -44,7 +44,7 @@ Add vision pose measurements occasionally by calling ``AddVisionMeasurement()``.
 
   .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/v2024.1.1-beta-4/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/differentialdriveposeestimator/Drivetrain.java
     :language: java
-    :lines: 236-241
+    :lines: 236-245
     :linenos:
     :lineno-start: 236
 


### PR DESCRIPTION
Java example is cut short:
![image](https://github.com/wpilibsuite/frc-docs/assets/1387843/de1fd27e-b34f-48cb-bcdc-f9ba5b5e9978)

C++ example is not:
![image](https://github.com/wpilibsuite/frc-docs/assets/1387843/f42b19eb-3158-4c98-9d81-8d80e5f17c2b)
