### PR TITLE
Add a link to the reStructuredText extension

### DIFF
--- a/source/docs/contributing/frc-docs/style-guide.rst
+++ b/source/docs/contributing/frc-docs/style-guide.rst
@@ -14,7 +14,7 @@ For documents that will have an identical software/hardware name, append "Hardwa
 
 Suffix filenames with the ``.rst`` extension.
 
-.. note:: If you are having issues editing files with the ``.rst`` extension, the recommended text editor is VS Code with the rST extension.
+.. note:: If you are having issues editing files with the ``.rst`` extension, the recommended text editor is VS Code with the `reStructuredText extension <https://marketplace.visualstudio.com/items?itemName=lextudio.restructuredtext>`_.
 
 Text
 ----


### PR DESCRIPTION
Links the reStructuredText extension in Style Guide to make it more obvious which extension is being mentioned.