### PR TITLE
Add intersphinx link to robotpy commands library

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -331,7 +331,10 @@ http.client.HTTPConnection.send = new_send
 
 intersphinx_mapping = {
     "robotpy": ("https://robotpy.readthedocs.io/projects/robotpy/en/stable/", None),
-    "commands2": ("https://robotpy.readthedocs.io/projects/commands-v2/en/stable/", None),
+    "commands2": (
+        "https://robotpy.readthedocs.io/projects/commands-v2/en/stable/",
+        None,
+    ),
 }
 
 # We recommend adding the following config value.

--- a/source/conf.py
+++ b/source/conf.py
@@ -331,6 +331,7 @@ http.client.HTTPConnection.send = new_send
 
 intersphinx_mapping = {
     "robotpy": ("https://robotpy.readthedocs.io/projects/robotpy/en/stable/", None),
+    "commands2": ("https://robotpy.readthedocs.io/projects/commands-v2/en/stable/", None),
 }
 
 # We recommend adding the following config value.


### PR DESCRIPTION
- Use :py:class:`Name <commands2:command2.XXX>`