### PR TITLE
Add DogLog to 3rd party telemetry libraries list

### DIFF
--- a/source/docs/software/telemetry/3rd-party-libraries.rst
+++ b/source/docs/software/telemetry/3rd-party-libraries.rst
@@ -8,3 +8,4 @@ Several third-party logging utilities and frameworks exist that provide function
   * `AdvantageKit <https://github.com/Mechanical-Advantage/AdvantageKit>`__ (Java only): "Log everything"-based logging framework with hooks for replaying logged data in :ref:`simulation <docs/software/wpilib-tools/robot-simulation/introduction:Introduction to Robot Simulation>`.
   * `Monologue <https://github.com/shueja/Monologue/wiki>`__ (Java only): annotation-based logging library.  Extensive telemetry and on-robot logging can be added to your robot code with minimal code footprint and design restrictions.
   * `DSLOG <https://github.com/orangelight/DSLOG-Reader/tree/master>`__: An alternate driver station log viewer.
+  * `DogLog <https://doglog.dev>`__: (Java only): A simple logging library for Java.

--- a/source/docs/software/telemetry/3rd-party-libraries.rst
+++ b/source/docs/software/telemetry/3rd-party-libraries.rst
@@ -8,4 +8,4 @@ Several third-party logging utilities and frameworks exist that provide function
   * `AdvantageKit <https://github.com/Mechanical-Advantage/AdvantageKit>`__ (Java only): "Log everything"-based logging framework with hooks for replaying logged data in :ref:`simulation <docs/software/wpilib-tools/robot-simulation/introduction:Introduction to Robot Simulation>`.
   * `Monologue <https://github.com/shueja/Monologue/wiki>`__ (Java only): annotation-based logging library.  Extensive telemetry and on-robot logging can be added to your robot code with minimal code footprint and design restrictions.
   * `DSLOG <https://github.com/orangelight/DSLOG-Reader/tree/master>`__: An alternate driver station log viewer.
-  * `DogLog <https://doglog.dev>`__: (Java only): A simple logging library for Java.
+  * `DogLog <https://doglog.dev>`__ (Java only): A simple logging library for Java.


### PR DESCRIPTION
Add [DogLog](https://doglog.dev) to the 3rd party telemetry libraries list