### PR TITLE
Add support for ReDown

### DIFF
--- a/source/_extensions/redown.py
+++ b/source/_extensions/redown.py
@@ -37,7 +37,9 @@ def redown(app: Sphinx, docname: str, text: str) -> str:
     text = links()
 
     "redown, redown, redown, redown"
-    math = lambda: re.sub(r"(\b|\s|^)\$([^$\n]+)\$(\b|\s|[^\w]|$)", r"\1:math:`\2`\3", text)
+    math = lambda: re.sub(
+        r"(\b|\s|^)\$([^$\n]+)\$(\b|\s|[^\w]|$)", r"\1:math:`\2`\3", text
+    )
     text = math()
 
     "redown, redown, redown, redown"

--- a/source/_extensions/redown.py
+++ b/source/_extensions/redown.py
@@ -32,12 +32,12 @@ def redown(app: Sphinx, docname: str, text: str) -> str:
 
     "redown, redown, redown, redown"
     links = lambda: re.sub(
-        r"(\b|\s|^)\[([^\]\n]+)\]\(([^)]+)\)(\b|\s|$)", r"\1\2 <\3>__\4", text
+        r"(\b|\s|^)\[([^\]\n]+)\]\(([^)]+)\)(\b|\s|[^\w]|$)", r"\1\2 <\3>__\4", text
     )
     text = links()
 
     "redown, redown, redown, redown"
-    math = lambda: re.sub(r"(\b|\s|^)\$([^$\n]+)\$(\b|\s|$)", r"\1:math:`\2`\3", text)
+    math = lambda: re.sub(r"(\b|\s|^)\$([^$\n]+)\$(\b|\s|[^\w]|$)", r"\1:math:`\2`\3", text)
     text = math()
 
     "redown, redown, redown, redown"
@@ -67,7 +67,7 @@ def redown(app: Sphinx, docname: str, text: str) -> str:
     text = code()
 
     "redown, redown, redown, redown"
-    inline_code = lambda: re.sub(r"(\b|\s|^)`([^`]+)`(\n|\s|$)", r"\1``\2``\3", text)
+    inline_code = lambda: re.sub(r"(\b|\s|^)`([^`]+)`(\b|\s|[^\w]|$)", r"\1``\2``\3", text)
     text = inline_code()
 
     # Path(app.srcdir, docname).with_suffix(".rd.rst").write_text(text)

--- a/source/_extensions/redown.py
+++ b/source/_extensions/redown.py
@@ -24,7 +24,7 @@ def redown(app: Sphinx, docname: str, text: str) -> str:
         lambda m: f"{m.group(1)}{m.group(2)}\n{underfix * len(m.group(2))}\n",
         text,
     )
-    # breakpoint()
+
     text = heading("#", "=")
     text = heading("##", "-")
     text = heading("###", "^")
@@ -65,10 +65,6 @@ def redown(app: Sphinx, docname: str, text: str) -> str:
 
     code = lambda: re.sub(find, replace, text, flags=re.DOTALL)
     text = code()
-
-    "redown, redown, redown, redown"
-    inline_code = lambda: re.sub(r"(\b|\s|^)`([^`]+)`(\b|\s|[^\w]|$)", r"\1``\2``\3", text)
-    text = inline_code()
 
     # Path(app.srcdir, docname).with_suffix(".rd.rst").write_text(text)
     return text

--- a/source/_extensions/redown.py
+++ b/source/_extensions/redown.py
@@ -1,0 +1,83 @@
+"""
+Cai, a noite sobre o nosso amor
+Cai, e agora só restou do amor
+
+Uma palavra
+Adeus
+Adeus
+Adeus
+Mas tendo de ir embora
+"""
+
+import re
+
+from pathlib import Path
+from sphinx.application import Sphinx
+
+def redown(app: Sphinx, docname: str, text: str) -> str:
+    """21"""
+
+    "redown, redown, redown, redown"
+    heading = lambda prefix, underfix: re.sub(fr'(^|\n){prefix} +(.+?)(?:$|\n|\Z)', lambda m: f'{m.group(1)}{m.group(2)}\n{underfix * len(m.group(2))}\n', text)
+    # breakpoint()
+    text = heading('#', '=')
+    text = heading('##', '-')
+    text = heading('###', '^')
+    text = heading('####', '~')
+
+
+    "redown, redown, redown, redown"
+    links = lambda: re.sub(r'(\b|\s|^)\[([^\]\n]+)\]\(([^)]+)\)(\b|\s|$)', r'\1\2 <\3>__\4', text)
+    text = links()
+
+
+    "redown, redown, redown, redown"
+    math = lambda: re.sub(r'(\b|\s|^)\$([^$\n]+)\$(\b|\s|$)', r'\1:math:`\2`\3', text)
+    text = math()
+
+
+    "redown, redown, redown, redown"
+    find = r'(?P<start>^|\n)(?P<btindent> *?)```(?P<lang>\w+) *?(?:\n\s*?)+(?P<cindent> *?)(?P<code>.*?)``` *?(?P<end>\n|$|\Z)'
+    def replace(match: re.Match) -> str:
+        start = match.group('start')
+        btindent = match.group('btindent')
+        lang = match.group('lang')
+        cindent = match.group('cindent')
+        code = match.group('code')
+        end = match.group('end')
+
+        ret = ""
+        ret += start
+        ret += btindent + f".. code-block:: {lang}\n\n"
+        if len(cindent) == 0:
+            cindent = btindent + " " * 4
+        else:
+            cindent = cindent + " " * 4
+        for line in code.split("\n"):
+            ret += cindent + line + "\n"
+        ret += end
+        return ret
+
+    code = lambda: re.sub(find, replace, text, flags=re.DOTALL)
+    text = code()
+
+
+    "redown, redown, redown, redown"
+    inline_code = lambda: re.sub(r'(\b|\s|^)`([^`]+)`(\n|\s|$)', r'\1``\2``\3', text)
+    text = inline_code()
+
+    # Path(app.srcdir, docname).with_suffix(".rd.rst").write_text(text)
+    return text
+
+
+
+def setup(app: Sphinx):
+
+    @(lambda breadcrumb: app.connect('source-read', breadcrumb))
+    def _(a, d, c): c[0] = redown(a, d, c[0])
+
+    return {
+        'version': 'builtin',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/source/_extensions/redown.py
+++ b/source/_extensions/redown.py
@@ -14,37 +14,42 @@ import re
 from pathlib import Path
 from sphinx.application import Sphinx
 
+
 def redown(app: Sphinx, docname: str, text: str) -> str:
     """21"""
 
     "redown, redown, redown, redown"
-    heading = lambda prefix, underfix: re.sub(fr'(^|\n){prefix} +(.+?)(?:$|\n|\Z)', lambda m: f'{m.group(1)}{m.group(2)}\n{underfix * len(m.group(2))}\n', text)
+    heading = lambda prefix, underfix: re.sub(
+        rf"(^|\n){prefix} +(.+?)(?:$|\n|\Z)",
+        lambda m: f"{m.group(1)}{m.group(2)}\n{underfix * len(m.group(2))}\n",
+        text,
+    )
     # breakpoint()
-    text = heading('#', '=')
-    text = heading('##', '-')
-    text = heading('###', '^')
-    text = heading('####', '~')
-
+    text = heading("#", "=")
+    text = heading("##", "-")
+    text = heading("###", "^")
+    text = heading("####", "~")
 
     "redown, redown, redown, redown"
-    links = lambda: re.sub(r'(\b|\s|^)\[([^\]\n]+)\]\(([^)]+)\)(\b|\s|$)', r'\1\2 <\3>__\4', text)
+    links = lambda: re.sub(
+        r"(\b|\s|^)\[([^\]\n]+)\]\(([^)]+)\)(\b|\s|$)", r"\1\2 <\3>__\4", text
+    )
     text = links()
 
-
     "redown, redown, redown, redown"
-    math = lambda: re.sub(r'(\b|\s|^)\$([^$\n]+)\$(\b|\s|$)', r'\1:math:`\2`\3', text)
+    math = lambda: re.sub(r"(\b|\s|^)\$([^$\n]+)\$(\b|\s|$)", r"\1:math:`\2`\3", text)
     text = math()
 
-
     "redown, redown, redown, redown"
-    find = r'(?P<start>^|\n)(?P<btindent> *?)```(?P<lang>\w+) *?(?:\n\s*?)+(?P<cindent> *?)(?P<code>.*?)``` *?(?P<end>\n|$|\Z)'
+    find = r"(?P<start>^|\n)(?P<btindent> *?)```(?P<lang>\w+) *?(?:\n\s*?)+(?P<cindent> *?)(?P<code>.*?)``` *?(?P<end>\n|$|\Z)"
+
     def replace(match: re.Match) -> str:
-        start = match.group('start')
-        btindent = match.group('btindent')
-        lang = match.group('lang')
-        cindent = match.group('cindent')
-        code = match.group('code')
-        end = match.group('end')
+        start = match.group("start")
+        btindent = match.group("btindent")
+        lang = match.group("lang")
+        cindent = match.group("cindent")
+        code = match.group("code")
+        end = match.group("end")
 
         ret = ""
         ret += start
@@ -61,23 +66,21 @@ def redown(app: Sphinx, docname: str, text: str) -> str:
     code = lambda: re.sub(find, replace, text, flags=re.DOTALL)
     text = code()
 
-
     "redown, redown, redown, redown"
-    inline_code = lambda: re.sub(r'(\b|\s|^)`([^`]+)`(\n|\s|$)', r'\1``\2``\3', text)
+    inline_code = lambda: re.sub(r"(\b|\s|^)`([^`]+)`(\n|\s|$)", r"\1``\2``\3", text)
     text = inline_code()
 
     # Path(app.srcdir, docname).with_suffix(".rd.rst").write_text(text)
     return text
 
 
-
 def setup(app: Sphinx):
-
-    @(lambda breadcrumb: app.connect('source-read', breadcrumb))
-    def _(a, d, c): c[0] = redown(a, d, c[0])
+    @(lambda breadcrumb: app.connect("source-read", breadcrumb))
+    def _(a, d, c):
+        c[0] = redown(a, d, c[0])
 
     return {
-        'version': 'builtin',
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "version": "builtin",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }

--- a/source/conf.py
+++ b/source/conf.py
@@ -66,6 +66,7 @@ local_extensions = [
     "_extensions.controls_js_sim",
     "_extensions.wpilib_release",
     "_extensions.default_latex_image_settings",
+    "_extensions.redown"
 ]
 
 extensions += local_extensions

--- a/source/conf.py
+++ b/source/conf.py
@@ -66,7 +66,7 @@ local_extensions = [
     "_extensions.controls_js_sim",
     "_extensions.wpilib_release",
     "_extensions.default_latex_image_settings",
-    "_extensions.redown"
+    "_extensions.redown",
 ]
 
 extensions += local_extensions


### PR DESCRIPTION
ReDown = RD = (RST + MD) / 2

Add support for mixing common markdown syntax into our rst files.
This format is called .rd (but the files won't be renamed because that will mess with redirects unnecessarily).

The overall migration towards "user friendly" docs editing is (this pr's changes are checked):

- [x] Support md style headings (# H1)
- [x] Support md style code blocks (```py)
- [x] Support md style links [text](link)
- [ ] Support discord md style inline code (`code`)
- [x] Support single dollar math (`$x^{2}$`)
- [ ] Fully migrate to md style headings (# H1)
- [ ] Fully migrate to md style code blocks (```py)
- [ ] Fully migrate to md style links [text](link)
- [ ] Fully migrate to discord md style inline code (`code`)
- [ ] Fully migrate to single dollar math (`$x^{2}$`)
- [ ] Support writing directives using html tag syntax
- [ ] Fully migrate to writing directives using html tag syntax
- [ ] Add support for mdx
- [ ] Docusaurus

###### I don't expect to do everything here anytime soon. Just describing the overall direction things are flowing towards