### PR TITLE
Don't run all of pub stable if env var not set

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'wpilibsuite' }}
+    if: ${{ github.repository_owner == 'wpilibsuite' }} && env.PUBLISH_STABLE == 'true'
+    env:
+      PUBLISH_STABLE: ${{ secrets.PUBLISH_STABLE }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,7 +36,5 @@ jobs:
 
       - name: Push
         if: env.PUBLISH_STABLE == 'true' || github.event.action == 'workflow_dispatch'
-        env:
-          PUBLISH_STABLE: ${{ secrets.PUBLISH_STABLE }}
         run: |
           git push origin stable


### PR DESCRIPTION
Should fix the failure here: https://github.com/wpilibsuite/frc-docs/actions/runs/10658336977/job/29539225269 now that stable isn't a FF from main.