### PR TITLE
Create Python Script + CI to check for language coverage in code blocks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -186,3 +186,18 @@ jobs:
     - name: Format
       run: |
         black --check .
+
+  check-codeblock-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Check Coverage
+        run: |
+          python scripts/check_codeblock_coverage.py --dir=source/docs/software --wordy --output=codeblock_coverage.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: codeblock-coverage
+          path: codeblock_coverage.txt

--- a/scripts/check_codeblock_coverage.py
+++ b/scripts/check_codeblock_coverage.py
@@ -1,4 +1,4 @@
-import sys, os, re
+import sys, os, re, argparse
 from dataclasses import dataclass
 
 @dataclass
@@ -6,7 +6,6 @@ class CodeBlock:
     start: int
     file: str
     langs: list[str]
-    block: str
 
 
 
@@ -23,45 +22,64 @@ def is_codeblock(line: str):
     return line.startswith(".. tab-set-code::") or line.startswith(".. tab-set::")
 
 def get_blocks_from_rst_file(file: str):
-    lang_regex = re.compile("(java|python|cpp)")
     blocks = []
     with(open(file, 'r', encoding='utf8')) as f:
-        block_text = ''
-        found_block = False
         block_start = None
         langs = []
         for index, line in enumerate(f):
             if is_codeblock(line):
-                found_block = True
-                block_text += line
-                block_start = index + 1
-            elif found_block:
-                if line.startswith(' ') or line.startswith('\t'):
-                    lang = re.search("(`{3}|:language: )(java|python|cpp|c\\+\\+)", line)
-                    if(lang is not None):
-                        langs.append(lang.group(2))
-                    block_text += line
-                else:
-                    if langs != []:        
+                if langs != []:        
                         blocks.append(
                             CodeBlock(
-                                block=block_text,
                                 start=block_start,
                                 file=file,
                                 langs=langs
                                 )
                             )
 
-                    block_text = ''
-                    block_start = None
-                    found_block = False
-                    langs = []
+                block_start = index + 1
+                langs = []
+            else:
+                if line.startswith(' ') or line.startswith('\t'):
+                    lang = re.search("(`{3}|:language: )(java|python|c\\+\\+)", line.lower())
+                    if(lang is not None):
+                        langs.append(lang.group(2))
     return blocks
 
+def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool):
+    stream = sys.stdout
+    if wordy:
+        stream = open("output.txt", "w")
+
+    blocks_count = len(blocks)
+    langs_coverage = {lang: 0 for lang in langs}
+    for block in blocks:
+        for lang in langs:
+            if lang in block.langs:
+                langs_coverage[lang] += 1
+    print(f"Total code blocks: {blocks_count}", file=stream)
+    for lang, coverage in langs_coverage.items():
+        print(f"{lang} coverage: {coverage}/{blocks_count} ({coverage/blocks_count*100:.2f}%)", file=stream)
+
+    if wordy:
+        print("\n\nMissing code blocks:", file=stream)
+        for block in blocks:
+            missing_langs = [lang for lang in langs if lang not in block.langs]
+            if missing_langs:
+                print(f"File: {block.file}, Line: {block.start}", file=stream)
+                print(f"Missing languages: {missing_langs}", file=stream)
+
+        stream.close()
+
 def main():
-    # dir = sys.argv[1]
-    dir = "source"
-    files = get_all_rst_files(dir=dir)
+    parser = argparse.ArgumentParser(description='Check code block coverage in FRC docs')
+    parser.add_argument('--dir', type=str, help='Directory to search for rst files')
+    parser.add_argument('--wordy', action='store_true', help='Outputs which code blocks are missing languages')
+
+    args = parser.parse_args()
+    print(args.wordy)
+
+    files = get_all_rst_files(dir=args.dir)
     blocks = []
     for file in files:
         file_blocks = get_blocks_from_rst_file(file)
@@ -69,9 +87,9 @@ def main():
             continue
         else: 
             blocks.extend(file_blocks)
-    with(open("output.txt", 'w')) as f:
-                for block in blocks:
-                    f.write(f"Block: {block}\n")
+    generate_report(blocks=blocks, langs=["java", "python", "c++"], wordy=args.wordy)
+
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/check_codeblock_coverage.py
+++ b/scripts/check_codeblock_coverage.py
@@ -4,6 +4,7 @@ import re
 import argparse
 from dataclasses import dataclass
 
+
 @dataclass
 class CodeBlock:
     """
@@ -14,9 +15,11 @@ class CodeBlock:
         file (str): The file path of the .rst file.
         langs (list[str]): A list of languages found in the code block.
     """
+
     start: int
     file: str
     langs: list[str]
+
 
 def get_all_rst_files(dir: str) -> list[str]:
     """
@@ -35,6 +38,7 @@ def get_all_rst_files(dir: str) -> list[str]:
                 files.append(os.path.join(root, filename))
     return files
 
+
 def is_codeblock(line: str) -> bool:
     """
     Checks if a line in an .rst file indicates the start of a code block.
@@ -46,6 +50,7 @@ def is_codeblock(line: str) -> bool:
         bool: True if the line starts a code block, False otherwise.
     """
     return line.startswith(".. tab-set-code::") or line.startswith(".. tab-set::")
+
 
 def get_blocks_from_rst_file(file: str) -> list[CodeBlock]:
     """
@@ -69,12 +74,17 @@ def get_blocks_from_rst_file(file: str) -> list[CodeBlock]:
                 langs = []
             else:
                 if line.startswith(" ") or line.startswith("\t"):
-                    lang = re.search("(`{3}|:language: )(java|python|c\\+\\+)", line.lower())
+                    lang = re.search(
+                        "(`{3}|:language: )(java|python|c\\+\\+)", line.lower()
+                    )
                     if lang is not None:
                         langs.append(lang.group(2))
     return blocks
 
-def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool, output: str):
+
+def generate_report(
+    blocks: list[CodeBlock], langs: list[str], wordy: bool, output: str
+):
     """
     Generates a report of code block coverage and writes it to the specified output.
 
@@ -100,7 +110,10 @@ def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool, outp
     # Print the coverage summary
     print(f"Total code blocks: {blocks_count}", file=stream)
     for lang, coverage in langs_coverage.items():
-        print(f"{lang} coverage: {coverage}/{blocks_count} ({coverage/blocks_count*100:.2f}%)", file=stream)
+        print(
+            f"{lang} coverage: {coverage}/{blocks_count} ({coverage/blocks_count*100:.2f}%)",
+            file=stream,
+        )
 
     # If wordy flag is set, print detailed information about missing code blocks
     if wordy:
@@ -115,12 +128,15 @@ def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool, outp
         if stream is not sys.stdout:
             stream.close()
 
+
 def main():
     """
     The main entry point of the script.
     """
     # Set up argument parsing
-    parser = argparse.ArgumentParser(description="Check code block coverage in FRC docs")
+    parser = argparse.ArgumentParser(
+        description="Check code block coverage in FRC docs"
+    )
     parser.add_argument("--dir", type=str, help="Directory to search for rst files")
     parser.add_argument(
         "--wordy",
@@ -152,11 +168,12 @@ def main():
             continue
         else:
             blocks.extend(file_blocks)
-    
+
     # Generate the report based on the collected code blocks
     generate_report(
         blocks=blocks, langs=args.langs, wordy=args.wordy, output=args.output
     )
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/check_codeblock_coverage.py
+++ b/scripts/check_codeblock_coverage.py
@@ -46,10 +46,10 @@ def get_blocks_from_rst_file(file: str):
                         langs.append(lang.group(2))
     return blocks
 
-def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool):
+def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool, output: str):
     stream = sys.stdout
     if wordy:
-        stream = open("output.txt", "w")
+        stream = open(output, "w")
 
     blocks_count = len(blocks)
     langs_coverage = {lang: 0 for lang in langs}
@@ -75,6 +75,8 @@ def main():
     parser = argparse.ArgumentParser(description='Check code block coverage in FRC docs')
     parser.add_argument('--dir', type=str, help='Directory to search for rst files')
     parser.add_argument('--wordy', action='store_true', help='Outputs which code blocks are missing languages')
+    parser.add_argument('--output', type=str, default='output.txt', help='Output file for missing code blocks')
+    parser.add_argument('--langs', nargs='+', default=["java", "python", "c++"], help='Languages to check for')
 
     args = parser.parse_args()
     print(args.wordy)
@@ -87,7 +89,7 @@ def main():
             continue
         else: 
             blocks.extend(file_blocks)
-    generate_report(blocks=blocks, langs=["java", "python", "c++"], wordy=args.wordy)
+    generate_report(blocks=blocks, langs=args.langs, wordy=args.wordy, output=args.output)
 
 
 

--- a/scripts/check_codeblock_coverage.py
+++ b/scripts/check_codeblock_coverage.py
@@ -1,0 +1,57 @@
+import sys, os
+from dataclasses import dataclass
+
+@dataclass
+class CodeBlock:
+    block: str
+    start: int
+    file: str
+
+
+def get_all_rst_files(dir):
+    files = []
+    for root, dirs, filenames in os.walk(dir):
+        for filename in filenames:
+            if filename.endswith('.rst'):
+                files.append(os.path.join(root, filename))
+
+    return files
+
+def get_blocks_from_rst_file(file):
+    blocks = []
+    with(open(file, 'r')) as f:
+        block_text = ''
+        found_block = False
+        block_start = None
+        for linenum, line in enumerate(f):
+            if line.startswith(".. tab-set-code::"):
+                found_block = True
+                block_text += line
+                block_start = linenum
+            elif found_block:
+                if line.startswith(' ') or line.startswith('\t'):
+                    block_text += line
+                else:
+                    blocks.append(CodeBlock(block=block_text, start=block_start, file=file))
+                    block_text = ''
+                    block_start = None
+                    found_block = False
+    return blocks
+
+def main():
+    dir = sys.argv[1]
+    files = get_all_rst_files(dir=dir)
+    for file in files:
+        blocks = get_blocks_from_rst_file(file)
+        if len(blocks) == 0: continue
+        else: 
+            with(open("output.txt", 'w')) as f:
+                for block in blocks:
+                    f.write(f"File: {block.file}\n")
+                    f.write(f"Block: {block.block}\n")
+                    f.write(f"Start: {block.start}\n")
+                    f.write("\n")
+                break
+
+if __name__ == '__main__':
+    main()

--- a/scripts/check_codeblock_coverage.py
+++ b/scripts/check_codeblock_coverage.py
@@ -1,6 +1,7 @@
 import sys, os, re, argparse
 from dataclasses import dataclass
 
+
 @dataclass
 class CodeBlock:
     start: int
@@ -8,45 +9,45 @@ class CodeBlock:
     langs: list[str]
 
 
-
 def get_all_rst_files(dir):
     files = []
     for root, dirs, filenames in os.walk(dir):
         for filename in filenames:
-            if filename.endswith('.rst'):
+            if filename.endswith(".rst"):
                 files.append(os.path.join(root, filename))
 
     return files
 
+
 def is_codeblock(line: str):
     return line.startswith(".. tab-set-code::") or line.startswith(".. tab-set::")
 
+
 def get_blocks_from_rst_file(file: str):
     blocks = []
-    with(open(file, 'r', encoding='utf8')) as f:
+    with (open(file, "r", encoding="utf8")) as f:
         block_start = None
         langs = []
         for index, line in enumerate(f):
             if is_codeblock(line):
-                if langs != []:        
-                        blocks.append(
-                            CodeBlock(
-                                start=block_start,
-                                file=file,
-                                langs=langs
-                                )
-                            )
+                if langs != []:
+                    blocks.append(CodeBlock(start=block_start, file=file, langs=langs))
 
                 block_start = index + 1
                 langs = []
             else:
-                if line.startswith(' ') or line.startswith('\t'):
-                    lang = re.search("(`{3}|:language: )(java|python|c\\+\\+)", line.lower())
-                    if(lang is not None):
+                if line.startswith(" ") or line.startswith("\t"):
+                    lang = re.search(
+                        "(`{3}|:language: )(java|python|c\\+\\+)", line.lower()
+                    )
+                    if lang is not None:
                         langs.append(lang.group(2))
     return blocks
 
-def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool, output: str):
+
+def generate_report(
+    blocks: list[CodeBlock], langs: list[str], wordy: bool, output: str
+):
     stream = sys.stdout
     if wordy:
         stream = open(output, "w")
@@ -59,7 +60,10 @@ def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool, outp
                 langs_coverage[lang] += 1
     print(f"Total code blocks: {blocks_count}", file=stream)
     for lang, coverage in langs_coverage.items():
-        print(f"{lang} coverage: {coverage}/{blocks_count} ({coverage/blocks_count*100:.2f}%)", file=stream)
+        print(
+            f"{lang} coverage: {coverage}/{blocks_count} ({coverage/blocks_count*100:.2f}%)",
+            file=stream,
+        )
 
     if wordy:
         print("\n\nMissing code blocks:", file=stream)
@@ -71,12 +75,29 @@ def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool, outp
 
         stream.close()
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Check code block coverage in FRC docs')
-    parser.add_argument('--dir', type=str, help='Directory to search for rst files')
-    parser.add_argument('--wordy', action='store_true', help='Outputs which code blocks are missing languages')
-    parser.add_argument('--output', type=str, default='output.txt', help='Output file for missing code blocks')
-    parser.add_argument('--langs', nargs='+', default=["java", "python", "c++"], help='Languages to check for')
+    parser = argparse.ArgumentParser(
+        description="Check code block coverage in FRC docs"
+    )
+    parser.add_argument("--dir", type=str, help="Directory to search for rst files")
+    parser.add_argument(
+        "--wordy",
+        action="store_true",
+        help="Outputs which code blocks are missing languages",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="output.txt",
+        help="Output file for missing code blocks",
+    )
+    parser.add_argument(
+        "--langs",
+        nargs="+",
+        default=["java", "python", "c++"],
+        help="Languages to check for",
+    )
 
     args = parser.parse_args()
     print(args.wordy)
@@ -85,13 +106,14 @@ def main():
     blocks = []
     for file in files:
         file_blocks = get_blocks_from_rst_file(file)
-        if len(file_blocks) == 0: 
+        if len(file_blocks) == 0:
             continue
-        else: 
+        else:
             blocks.extend(file_blocks)
-    generate_report(blocks=blocks, langs=args.langs, wordy=args.wordy, output=args.output)
+    generate_report(
+        blocks=blocks, langs=args.langs, wordy=args.wordy, output=args.output
+    )
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/check_codeblock_coverage.py
+++ b/scripts/check_codeblock_coverage.py
@@ -1,11 +1,13 @@
-import sys, os
+import sys, os, re
 from dataclasses import dataclass
 
 @dataclass
 class CodeBlock:
-    block: str
     start: int
     file: str
+    langs: list[str]
+    block: str
+
 
 
 def get_all_rst_files(dir):
@@ -17,41 +19,58 @@ def get_all_rst_files(dir):
 
     return files
 
-def get_blocks_from_rst_file(file):
+def is_codeblock(line: str):
+    return line.startswith(".. tab-set-code::") or line.startswith(".. tab-set::")
+
+def get_blocks_from_rst_file(file: str):
+    lang_regex = re.compile("(java|python|cpp)")
     blocks = []
-    with(open(file, 'r')) as f:
+    with(open(file, 'r', encoding='utf8')) as f:
         block_text = ''
         found_block = False
         block_start = None
-        for linenum, line in enumerate(f):
-            if line.startswith(".. tab-set-code::"):
+        langs = []
+        for index, line in enumerate(f):
+            if is_codeblock(line):
                 found_block = True
                 block_text += line
-                block_start = linenum
+                block_start = index + 1
             elif found_block:
                 if line.startswith(' ') or line.startswith('\t'):
+                    lang = re.search("(`{3}|:language: )(java|python|cpp|c\+\+)", line)
+                    if(lang is not None):
+                        langs.append(lang.group(2))
                     block_text += line
                 else:
-                    blocks.append(CodeBlock(block=block_text, start=block_start, file=file))
+                    if langs != []:        
+                        blocks.append(
+                            CodeBlock(
+                                block=block_text,
+                                start=block_start,
+                                file=file,
+                                langs=langs
+                                )
+                            )
+
                     block_text = ''
                     block_start = None
                     found_block = False
     return blocks
 
 def main():
-    dir = sys.argv[1]
+    # dir = sys.argv[1]
+    dir = "source"
     files = get_all_rst_files(dir=dir)
+    blocks = []
     for file in files:
-        blocks = get_blocks_from_rst_file(file)
-        if len(blocks) == 0: continue
+        file_blocks = get_blocks_from_rst_file(file)
+        if len(file_blocks) == 0: 
+            continue
         else: 
-            with(open("output.txt", 'w')) as f:
+            blocks.extend(file_blocks)
+    with(open("output.txt", 'w')) as f:
                 for block in blocks:
-                    f.write(f"File: {block.file}\n")
-                    f.write(f"Block: {block.block}\n")
-                    f.write(f"Start: {block.start}\n")
-                    f.write("\n")
-                break
+                    f.write(f"Block: {block}\n")
 
 if __name__ == '__main__':
     main()

--- a/scripts/check_codeblock_coverage.py
+++ b/scripts/check_codeblock_coverage.py
@@ -1,70 +1,108 @@
-import sys, os, re, argparse
+import sys
+import os
+import re
+import argparse
 from dataclasses import dataclass
-
 
 @dataclass
 class CodeBlock:
+    """
+    A class representing a code block in an .rst file.
+
+    Attributes:
+        start (int): The starting line number of the code block.
+        file (str): The file path of the .rst file.
+        langs (list[str]): A list of languages found in the code block.
+    """
     start: int
     file: str
     langs: list[str]
 
+def get_all_rst_files(dir: str) -> list[str]:
+    """
+    Recursively searches a directory for .rst files.
 
-def get_all_rst_files(dir):
+    Parameters:
+        dir (str): The directory path to search.
+
+    Returns:
+        list[str]: A list of file paths for .rst files.
+    """
     files = []
     for root, dirs, filenames in os.walk(dir):
         for filename in filenames:
             if filename.endswith(".rst"):
                 files.append(os.path.join(root, filename))
-
     return files
 
+def is_codeblock(line: str) -> bool:
+    """
+    Checks if a line in an .rst file indicates the start of a code block.
 
-def is_codeblock(line: str):
+    Parameters:
+        line (str): A line from the file.
+
+    Returns:
+        bool: True if the line starts a code block, False otherwise.
+    """
     return line.startswith(".. tab-set-code::") or line.startswith(".. tab-set::")
 
+def get_blocks_from_rst_file(file: str) -> list[CodeBlock]:
+    """
+    Extracts code blocks from a given .rst file.
 
-def get_blocks_from_rst_file(file: str):
+    Parameters:
+        file (str): The path to the .rst file.
+
+    Returns:
+        list[CodeBlock]: A list of CodeBlock instances representing the code blocks in the file.
+    """
     blocks = []
-    with (open(file, "r", encoding="utf8")) as f:
+    with open(file, "r", encoding="utf8") as f:
         block_start = None
         langs = []
         for index, line in enumerate(f):
             if is_codeblock(line):
                 if langs != []:
                     blocks.append(CodeBlock(start=block_start, file=file, langs=langs))
-
                 block_start = index + 1
                 langs = []
             else:
                 if line.startswith(" ") or line.startswith("\t"):
-                    lang = re.search(
-                        "(`{3}|:language: )(java|python|c\\+\\+)", line.lower()
-                    )
+                    lang = re.search("(`{3}|:language: )(java|python|c\\+\\+)", line.lower())
                     if lang is not None:
                         langs.append(lang.group(2))
     return blocks
 
+def generate_report(blocks: list[CodeBlock], langs: list[str], wordy: bool, output: str):
+    """
+    Generates a report of code block coverage and writes it to the specified output.
 
-def generate_report(
-    blocks: list[CodeBlock], langs: list[str], wordy: bool, output: str
-):
+    Parameters:
+        blocks (list[CodeBlock]): A list of CodeBlock instances to analyze.
+        langs (list[str]): A list of languages to check for.
+        wordy (bool): Whether to include detailed missing code block information.
+        output (str): The path to the output file.
+    """
     stream = sys.stdout
     if wordy:
         stream = open(output, "w")
 
     blocks_count = len(blocks)
     langs_coverage = {lang: 0 for lang in langs}
+
+    # Calculate coverage for each language
     for block in blocks:
         for lang in langs:
             if lang in block.langs:
                 langs_coverage[lang] += 1
+
+    # Print the coverage summary
     print(f"Total code blocks: {blocks_count}", file=stream)
     for lang, coverage in langs_coverage.items():
-        print(
-            f"{lang} coverage: {coverage}/{blocks_count} ({coverage/blocks_count*100:.2f}%)",
-            file=stream,
-        )
+        print(f"{lang} coverage: {coverage}/{blocks_count} ({coverage/blocks_count*100:.2f}%)", file=stream)
 
+    # If wordy flag is set, print detailed information about missing code blocks
     if wordy:
         print("\n\nMissing code blocks:", file=stream)
         for block in blocks:
@@ -73,13 +111,16 @@ def generate_report(
                 print(f"File: {block.file}, Line: {block.start}", file=stream)
                 print(f"Missing languages: {missing_langs}", file=stream)
 
-        stream.close()
-
+        # Close the output file if it was opened
+        if stream is not sys.stdout:
+            stream.close()
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Check code block coverage in FRC docs"
-    )
+    """
+    The main entry point of the script.
+    """
+    # Set up argument parsing
+    parser = argparse.ArgumentParser(description="Check code block coverage in FRC docs")
     parser.add_argument("--dir", type=str, help="Directory to search for rst files")
     parser.add_argument(
         "--wordy",
@@ -99,9 +140,10 @@ def main():
         help="Languages to check for",
     )
 
+    # Parse the command line arguments
     args = parser.parse_args()
-    print(args.wordy)
 
+    # Get all .rst files from the specified directory
     files = get_all_rst_files(dir=args.dir)
     blocks = []
     for file in files:
@@ -110,10 +152,11 @@ def main():
             continue
         else:
             blocks.extend(file_blocks)
+    
+    # Generate the report based on the collected code blocks
     generate_report(
         blocks=blocks, langs=args.langs, wordy=args.wordy, output=args.output
     )
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/check_codeblock_coverage.py
+++ b/scripts/check_codeblock_coverage.py
@@ -37,7 +37,7 @@ def get_blocks_from_rst_file(file: str):
                 block_start = index + 1
             elif found_block:
                 if line.startswith(' ') or line.startswith('\t'):
-                    lang = re.search("(`{3}|:language: )(java|python|cpp|c\+\+)", line)
+                    lang = re.search("(`{3}|:language: )(java|python|cpp|c\\+\\+)", line)
                     if(lang is not None):
                         langs.append(lang.group(2))
                     block_text += line
@@ -55,6 +55,7 @@ def get_blocks_from_rst_file(file: str):
                     block_text = ''
                     block_start = None
                     found_block = False
+                    langs = []
     return blocks
 
 def main():


### PR DESCRIPTION
I wanted to build a quick tool that would allow people to view what percentage of code blocks contain which languages, as well as letting people know which blocks were missing languages.

This is a python script that I also added to run with the `CI.yml` workflow, although I'm not married to it running during CI, and would be fine if it was just a tool that can be ran.