### PR TITLE
Remove NetworkTables 3 protocol spec link

### DIFF
--- a/source/docs/contributing/wpilib/index.rst
+++ b/source/docs/contributing/wpilib/index.rst
@@ -32,4 +32,3 @@ Below is a list of instructions that guide you through cloning, building, publis
    :maxdepth: 1
 
    NetworkTables 4 Protocol Spec <https://github.com/wpilibsuite/allwpilib/blob/main/ntcore/doc/networktables4.adoc>
-   NetworkTables 3 Protocol Spec <https://github.com/wpilibsuite/allwpilib/blob/main/ntcore/doc/networktables3.adoc>


### PR DESCRIPTION
Shouldn't be used for new development and would still be linked in the previous years documentation