### PR TITLE
Fixed typo

### DIFF
--- a/source/docs/software/telemetry/datalog.rst
+++ b/source/docs/software/telemetry/datalog.rst
@@ -134,7 +134,7 @@ The LogEntry classes can be used in conjunction with DataLogManager to record va
       frc::DataLogManager::Start();
       // Set up custom log entries
       wpi::log::DataLog& log = frc::DataLogManager::GetLog();
-      myBooleanLog = wpi::Log::BooleanLogEntry(log, "/my/boolean");
+      myBooleanLog = wpi::log::BooleanLogEntry(log, "/my/boolean");
       myDoubleLog = wpi::log::DoubleLogEntry(log, "/my/double");
       myStringLog = wpi::log::StringLogEntry(log, "/my/string");
     }


### PR DESCRIPTION
from wpi::Log::BooleanLogEntry to wpi::log::BooleanLogEntry for C++
Supersedes #2740 