### PR TITLE
Make spelling check fail on error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,6 +152,7 @@ jobs:
         with:
           locale: "US"
           reporter: "github-check"
+          fail_on_error: "true"
           
   check-redirects:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise the fact that there's a spelling failure is hidden unless someone checks the files tab.