### PR TITLE
Remove warning about non-default PowerDistribution ID

### DIFF
--- a/source/docs/software/can-devices/power-distribution-module.rst
+++ b/source/docs/software/can-devices/power-distribution-module.rst
@@ -29,8 +29,6 @@ To use the either Power Distribution module, create an instance of the :code:`Po
 
 Note: it is not necessary to create a PowerDistribution object unless you need to read values from it. The board will work and supply power on all the channels even if the object is never created.
 
-.. warning:: To enable voltage and current logging in the Driver Station, the CAN ID for the CTRE Power Distribution Panel *must* be 0, and for the REV Power Distribution Hub it *must* be 1.
-
 ## Reading the Bus Voltage
 
 .. tab-set-code::


### PR DESCRIPTION
My team ran a REV PDH with a non-default ID and the DS logs still had voltage and current data.