### PR TITLE
Add additional 3rd party CAN devices

### DIFF
--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -121,7 +121,7 @@ Redux Robotics currently offers the Canandcoder :term:`CAN` + :term:`PWM` magnet
     - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandcolor/Canandcolor.html), [C++](https://apidocs.reduxrobotics.com/current/cpp/classredux_1_1sensors_1_1canandcolor_1_1Canandcolor.html))
     - [Technical Manual](https://docs.reduxrobotics.com/canandcolor/index.html)
 
-- **BORON CANandgyro**
+- **BORON Canandgyro**
 
     - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandgyro/package-summary), [C++](https://apidocs.reduxrobotics.com/current/cpp/namespaceredux_1_1sensors_1_1canandgyro))
     - [Technical Manual](https://docs.reduxrobotics.com/canandgyro/)

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -120,6 +120,7 @@ Redux Robotics currently offers the Canandcoder :term:`CAN` + :term:`PWM` magnet
 
     - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandcolor/Canandcolor.html), [C++](https://apidocs.reduxrobotics.com/current/cpp/classredux_1_1sensors_1_1canandcolor_1_1Canandcolor.html))
     - [Technical Manual](https://docs.reduxrobotics.com/canandcolor/index.html)
+
 - **BORON CANandgyro**
 
     - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandgyro/package-summary), [C++](https://apidocs.reduxrobotics.com/current/cpp/namespaceredux_1_1sensors_1_1canandgyro))

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -107,7 +107,7 @@ Playing With Fusion (PWF) offers the Venom integrated motor/controller as well a
 
 ## Redux Robotics
 
-Redux Robotics currently offers the Canandcoder :term:`CAN` + :term:`PWM` magnetic encoder, the Canandcolor :term:`CAN`-enabled color sensor, and the Canandgyro :term:`CAN`-enabled gyro.
+Redux Robotics currently offers the HELIUM Canandmag :term:`CAN` + :term:`PWM` magnetic encoder, the Canandcolor :term:`CAN`-enabled color sensor, and the Canandgyro :term:`CAN`-enabled gyro.
 
 ### Redux Sensors
 

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -107,7 +107,7 @@ Playing With Fusion (PWF) offers the Venom integrated motor/controller as well a
 
 ## Redux Robotics
 
-Redux Robotics currently offers the HELIUM Canandmag :term:`CAN` + :term:`PWM` magnetic encoder, the Canandcolor :term:`CAN`-enabled color sensor, and the Canandgyro :term:`CAN`-enabled gyro.
+Redux Robotics currently offers the HELIUM Canandmag :term:`CAN` + :term:`PWM` magnetic encoder and the BORON Canandgyro :term:`CAN`-enabled gyro.
 
 ### Redux Sensors
 
@@ -115,11 +115,6 @@ Redux Robotics currently offers the HELIUM Canandmag :term:`CAN` + :term:`PWM` m
 
     - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandmag/package-summary), [C++](https://apidocs.reduxrobotics.com/current/cpp/namespaceredux_1_1sensors_1_1canandmag))
     - [Technical Manual](https://docs.reduxrobotics.com/canandmag)
-
-- **Canandcolor**
-
-    - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandcolor/Canandcolor.html), [C++](https://apidocs.reduxrobotics.com/current/cpp/classredux_1_1sensors_1_1canandcolor_1_1Canandcolor.html))
-    - [Technical Manual](https://docs.reduxrobotics.com/canandcolor/index.html)
 
 - **BORON Canandgyro**
 

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -107,16 +107,31 @@ Playing With Fusion (PWF) offers the Venom integrated motor/controller as well a
 
 ## Redux Robotics
 
-Redux Robotics currently offers the Canandcoder :term:`CAN` + :term:`PWM` magnetic encoder and the Canandcolor :term:`CAN`-enabled color sensor.
+Redux Robotics currently offers the Canandcoder :term:`CAN` + :term:`PWM` magnetic encoder, the Canandcolor :term:`CAN`-enabled color sensor, and the Canandgyro :term:`CAN`-enabled gyro.
 
 ### Redux Sensors
 
-- **Canandcoder**
+- **HELIUM Canandmag**
 
-    - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandcoder/Canandcoder.html), [C++](https://apidocs.reduxrobotics.com/current/cpp/classredux_1_1sensors_1_1canandcoder_1_1Canandcoder.html))
-    - [Technical Manual](https://docs.reduxrobotics.com/canandcoder/index.html)
+    - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandmag/package-summary), [C++](https://apidocs.reduxrobotics.com/current/cpp/namespaceredux_1_1sensors_1_1canandmag))
+    - [Technical Manual](https://docs.reduxrobotics.com/canandmag)
 
 - **Canandcolor**
 
     - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandcolor/Canandcolor.html), [C++](https://apidocs.reduxrobotics.com/current/cpp/classredux_1_1sensors_1_1canandcolor_1_1Canandcolor.html))
     - [Technical Manual](https://docs.reduxrobotics.com/canandcolor/index.html)
+- **BORON CANandgyro**
+
+    - API Documentation ([Java](https://apidocs.reduxrobotics.com/current/java/com/reduxrobotics/sensors/canandgyro/package-summary), [C++](https://apidocs.reduxrobotics.com/current/cpp/namespaceredux_1_1sensors_1_1canandgyro))
+    - [Technical Manual](https://docs.reduxrobotics.com/canandgyro/)
+
+## Grapple Robotics
+
+Grapple Robotics currently offers the LaserCAN :term:`CAN`-enabled range finding sensor
+
+## Grapple Sensors
+
+- **LaserCAN**
+  
+    - API Documentation ([Java](https://github.com/GrappleRobotics/LaserCAN/blob/master/docs/example-java.md), [C++](https://github.com/GrappleRobotics/LaserCAN/blob/master/docs/example-cpp.md))
+    - [Technical Manual](https://github.com/GrappleRobotics/LaserCAN/blob/master/docs/getting-started.md)

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -21,7 +21,7 @@ CTR Electronics (CTRE) offers several CAN peripherals with external libraries. G
 
 - **Talon FX (with Falcon 500 Motor, Kraken x60 motor, and Kraken x44)**
 
-    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_f_x.html) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_talon_f_x.html))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_f_x.html))
     - Hardware User's Manual ([Falcon 500](https://ctre.download/files/user-manual/Falcon%20500%20v3%20User's%20Guide.pdf), [Kraken x60](https://docs.wcproducts.com/kraken-x60), [Kraken x44](https://docs.wcproducts.com/kraken-x44))
     - [Software Documentation](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/talonfx/index.html)
 
@@ -41,13 +41,13 @@ CTR Electronics (CTRE) offers several CAN peripherals with external libraries. G
 
 - **CANcoder**
 
-    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/CANcoder.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a13b25ca6c3f7037c0f6e13b59cc1e571) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/CANcoder.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_c_a_ncoder.html))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/CANcoder.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a13b25ca6c3f7037c0f6e13b59cc1e571))
     - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/CANCoder%20User's%20Guide.pdf)
     - [Software Documentation](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/cancoder/index.html)
 
 - **Pigeon 2.0**
 
-    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a7bd5c8d59e1daa07d31aa1d7116c5c64) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_pigeon2.html))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a7bd5c8d59e1daa07d31aa1d7116c5c64))
     - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/Pigeon2%20User's%20Guide.pdf)
     - [Software Documentation6](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/pigeon2/index.html)
 

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -19,48 +19,48 @@ CTR Electronics (CTRE) offers several CAN peripherals with external libraries. G
 
 ### CTRE Motor Controllers
 
-- **Talon FX (with Falcon 500 Motor)**
+- **Talon FX (with Falcon 500 Motor and Kraken x60 motor)**
 
-    - API Documentation (v5: [Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/motorcontrol/can/WPI_TalonFX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_w_p_i___talon_f_x.html) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_talon_f_x.html))
-    - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/Falcon%20500%20User%20Guide.pdf)
-    - Software Documentation ([v5](https://v5.docs.ctr-electronics.com/en/stable/ch13_MC.html), [Pro](https://pro.docs.ctr-electronics.com/en/stable/docs/api-reference/examples/quickstart.html))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_f_x.html) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_talon_f_x.html))
+    - Hardware User's Manual ([Falcon 500](https://ctre.download/files/user-manual/Falcon%20500%20v3%20User's%20Guide.pdf), [Kraken x60](https://docs.wcproducts.com/kraken-x60))
+    - [Software Documentation](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/talonfx/index.html)
 
 - **Talon SRX**
 
     - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_w_p_i___talon_s_r_x.html))
-    - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/Talon%20SRX%20User's%20Guide.pdf)
+    - [Hardware User's Manual](https://ctre.download/files/user-manual/Talon%20SRX%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch13_MC.html)
 
 - **Victor SPX**
 
     - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/motorcontrol/can/WPI_VictorSPX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_w_p_i___victor_s_p_x.html))
-    - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/Victor%20SPX%20User's%20Guide.pdf)
+    - [Hardware User's Manual](https://ctre.download/files/user-manual/Victor%20SPX%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch13_MC.html)
 
 ### CTRE Sensors
 
 - **CANcoder**
 
-    - API Documentation (v5: [Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/sensors/WPI_CANCoder.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1sensors_1_1_w_p_i___c_a_n_coder.html) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/CANcoder.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_c_a_ncoder.html))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/CANcoder.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a13b25ca6c3f7037c0f6e13b59cc1e571) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/CANcoder.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_c_a_ncoder.html))
     - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/CANCoder%20User's%20Guide.pdf)
-    - Software Documentation ([v5](https://v5.docs.ctr-electronics.com/en/stable/ch12a_BringUpCANCoder.html), [Pro](https://pro.docs.ctr-electronics.com/en/stable/docs/api-reference/api-usage/index.html))
+    - [Software Documentation](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/cancoder/index.html)
 
 - **Pigeon 2.0**
 
-    - API Documentation (v5: [Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/sensors/WPI_Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1sensors_1_1_w_p_i___pigeon2.html) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_pigeon2.html))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a7bd5c8d59e1daa07d31aa1d7116c5c64) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_pigeon2.html))
     - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/Pigeon2%20User's%20Guide.pdf)
-    - Software Documentation ([v5](https://v5.docs.ctr-electronics.com/en/stable/ch11a_BringUpPigeon2.html), [Pro](https://pro.docs.ctr-electronics.com/en/stable/docs/api-reference/api-usage/index.html))
+    - [Software Documentation6](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/pigeon2/index.html)
 
 - **Pigeon IMU**
 
     - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/sensors/WPI_PigeonIMU.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1sensors_1_1_w_p_i___pigeon_i_m_u.html))
-    - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/Pigeon%20IMU%20User's%20Guide.pdf)
+    - [Hardware User's Manual](https://ctre.download/files/user-manual/Pigeon%20IMU%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch11_BringUpPigeon.html)
 
 - **CANifier**
 
     - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/CANifier.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1_c_a_nifier.html))
-    - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/CANifier%20User%27s%20Guide.pdf)
+    - [Hardware User's Manual](https://ctre.download/files/user-manual/CANifier%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch12_BringUpCANifier.html)
 
 ### CTRE Other CAN Devices
@@ -68,7 +68,7 @@ CTR Electronics (CTRE) offers several CAN peripherals with external libraries. G
 - **CANdle LED Controller**
 
     - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/led/CANdle.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1led_1_1_c_a_ndle.html))
-    - [Hardware User's Manual](https://store.ctr-electronics.com/content/user-manual/CANdle%20User's%20Guide.pdf)
+    - [Hardware User's Manual](https://ctre.download/files/user-manual/CANdle%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch12b_BringUpCANdle.html)
 
 ## REV Robotics
@@ -79,12 +79,12 @@ REV Robotics currently offers the SPARK MAX and SPARK Flex motor controllers whi
 
 - **SPARK MAX**
 
-    - API Documentation ([Java](https://codedocs.revrobotics.com/java/com/revrobotics/cansparkmax), [C++](https://codedocs.revrobotics.com/cpp/classrev_1_1_c_a_n_spark_max))
+    - API Documentation ([Java](https://codedocs.revrobotics.com/java/com/revrobotics/spark/sparkmax), [C++](https://codedocs.revrobotics.com/cpp/classrev_1_1spark_1_1_spark_max.html))
     - [Technical Manual](https://docs.revrobotics.com/brushless/spark-max/overview)
 
 - **SPARK Flex**
 
-    - API Documentation ([Java](https://codedocs.revrobotics.com/java/com/revrobotics/cansparkflex), [C++](https://codedocs.revrobotics.com/cpp/classrev_1_1_c_a_n_spark_flex))
+    - API Documentation ([Java](https://codedocs.revrobotics.com/java/com/revrobotics/spark/sparkflex), [C++](https://codedocs.revrobotics.com/cpp/classrev_1_1spark_1_1_spark_flex.html))
     - [Technical Manual](https://docs.revrobotics.com/brushless/spark-flex/overview)
 
 ## Playing With Fusion
@@ -125,7 +125,7 @@ Redux Robotics currently offers the HELIUM Canandmag :term:`CAN` + :term:`PWM` m
 
 Grapple Robotics currently offers the LaserCAN :term:`CAN`-enabled range finding sensor
 
-## Grapple Sensors
+### Grapple Sensors
 
 - **LaserCAN**
   

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -19,10 +19,10 @@ CTR Electronics (CTRE) offers several CAN peripherals with external libraries. G
 
 ### CTRE Motor Controllers
 
-- **Talon FX (with Falcon 500 Motor and Kraken x60 motor)**
+- **Talon FX (with Falcon 500 Motor, Kraken x60 motor, and Kraken x44)**
 
     - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_talon_f_x.html) | Pro: [Java](https://api.ctr-electronics.com/phoenixpro/release/java/com/ctre/phoenixpro/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenixpro/release/cpp/classctre_1_1phoenixpro_1_1hardware_1_1_talon_f_x.html))
-    - Hardware User's Manual ([Falcon 500](https://ctre.download/files/user-manual/Falcon%20500%20v3%20User's%20Guide.pdf), [Kraken x60](https://docs.wcproducts.com/kraken-x60))
+    - Hardware User's Manual ([Falcon 500](https://ctre.download/files/user-manual/Falcon%20500%20v3%20User's%20Guide.pdf), [Kraken x60](https://docs.wcproducts.com/kraken-x60), [Kraken x44](https://docs.wcproducts.com/kraken-x44))
     - [Software Documentation](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/talonfx/index.html)
 
 - **Talon SRX**

--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -128,6 +128,6 @@ Grapple Robotics currently offers the LaserCAN :term:`CAN`-enabled range finding
 ### Grapple Sensors
 
 - **LaserCAN**
-  
+
     - API Documentation ([Java](https://github.com/GrappleRobotics/LaserCAN/blob/master/docs/example-java.md), [C++](https://github.com/GrappleRobotics/LaserCAN/blob/master/docs/example-cpp.md))
     - [Technical Manual](https://github.com/GrappleRobotics/LaserCAN/blob/master/docs/getting-started.md)


### PR DESCRIPTION
Adds the grapple lasercan and Redux canandgyro. Also renames the canandcoder to its new name the canandgyro. Should I also remove the canandcolor since there no longer seems to be any documentation on it and the links on the page appear to be broken?