### PR TITLE
Set linkcheck_report_timeouts_as_broken to false

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -165,6 +165,7 @@ linkcheck_anchors_ignore_for_url = [
 linkcheck_timeout = 30
 linkcheck_retries = 3
 linkcheck_workers = 1
+linkcheck_report_timeouts_as_broken = False
 
 # Specify a standard user agent, as Sphinx default is blocked on some sites
 user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"


### PR DESCRIPTION
Allows more granularity in linkcheck results