### PR TITLE
Add Servo Controller CAN type

### DIFF
--- a/source/docs/software/can-devices/can-addressing.rst
+++ b/source/docs/software/can-devices/can-addressing.rst
@@ -33,7 +33,8 @@ Power Distribution Module 8
 Pneumatics Controller     9
 Miscellaneous             10
 IO Breakout               11
-Reserved                  12-30
+Servo Controller          12
+Reserved                  13-30
 Firmware Update           31
 ========================= =====
 


### PR DESCRIPTION
Reserves Device Type 12 for Servo Controllers on the CAN bus