### PR TITLE
Update what-is-command-based.rst

### DIFF
--- a/source/docs/software/commandbased/what-is-command-based.rst
+++ b/source/docs/software/commandbased/what-is-command-based.rst
@@ -13,7 +13,11 @@ The command-based paradigm is also an example of :term:`declarative programming`
   ```
 
   ```c++
-  Trigger([&condition] { return condition.Get()).OnTrue(frc2::cmd::RunOnce([&piston] { piston.Set(frc::DoubleSolenoid::kForward)));
+  Trigger([&condition] {
+    return condition.Get().OnTrue(frc2::cmd::RunOnce(
+      [&piston] { piston.Set(frc::DoubleSolenoid::kForward); }
+    ));
+  })
   ```
 
   ```python


### PR DESCRIPTION
Fixed the incorrect syntax for the first code example in the "What is 'Command-Based' Programming?" article