### PR TITLE
Update commands.rst

### DIFF
--- a/source/docs/software/commandbased/commands.rst
+++ b/source/docs/software/commandbased/commands.rst
@@ -159,10 +159,11 @@ The ``run`` factory, backed by the ``RunCommand`` ([Java](https://github.wpilib.
   frc2::RunCommand(
     [this] {
       m_drive.ArcadeDrive(
-          -m_driverController.GetLeftY(),
-          m_driverController.GetRightX());
-    },
-    {&m_drive}))
+        -m_driverController.GetLeftY(),
+        m_driverController.GetRightX()
+      );
+    }, {&m_drive}
+  )
   ```
 
   ```python


### PR DESCRIPTION
Fixed the incorrect syntax in the RunCommand ArcadeDrive example in the "Commands" article in the "Command-Based Programming" section.