### PR TITLE
Fix documentation implying that no part of Rotation2d wraps

### DIFF
--- a/source/docs/software/advanced-controls/geometry/pose.rst
+++ b/source/docs/software/advanced-controls/geometry/pose.rst
@@ -14,7 +14,7 @@ Rotation in 2 dimensions is represented by WPILib's ``Rotation2d`` class ([Java]
 
 .. note:: ``Rotation2d`` uses the C++ Units library. The constructor in Java/Python accepts either the angle in radians, or the sine and cosine of the angle, but the ``fromDegrees`` method will construct a ``Rotation2d`` object from degrees.
 
-.. note:: ``Rotation2d`` does not wrap the value of the angle, so if a value of 400 degrees is passed into the constructor, then 400 degrees will be returned in subsequent value calls.
+.. note:: ``Rotation2d`` does not wrap the value of the angle, so if a value of 400 degrees is passed into the constructor, then 400 degrees will be returned in subsequent value calls. However, some method calls like ``plus`` and ``minus`` wrap the angle prior to the construction of the ``Rotation2d`` object. 
 
 ## Pose
 


### PR DESCRIPTION
The Rotation2d object multiple times states throughout documentation that it doesn't wrap, yet has methods that wrap prior to constructing the Rotation2d. This commit clarifies that in the documentation