### PR TITLE
Fix missing Python robotInit in CameraServer on RIO

### DIFF
--- a/source/docs/software/vision-processing/roborio/using-the-cameraserver-on-the-roborio.rst
+++ b/source/docs/software/vision-processing/roborio/using-the-cameraserver-on-the-roborio.rst
@@ -20,7 +20,7 @@ The following program starts automatic capture of a USB camera like the Microsof
 
    .. rli:: https://raw.githubusercontent.com/robotpy/examples/4e7b525b47246e55ad617a66f2c3d9fda34484a3/QuickVision/robot.py
       :language: python
-      :lines: 8-17
+      :lines: 8-20
       :linenos:
 
 


### PR DESCRIPTION
Before:

![Screenshot From 2025-03-08 16-37-16](https://github.com/user-attachments/assets/a13d5090-2ba8-410b-b65e-12415cea9ea3)

This thoroughly confused a rookie team at the Southern Cross Regional over the weekend.