### PR TITLE
fix typo "tean" -> "team" in radio-programming page in zero-to-robot section

### DIFF
--- a/source/docs/zero-to-robot/step-3/radio-programming.rst
+++ b/source/docs/zero-to-robot/step-3/radio-programming.rst
@@ -64,7 +64,7 @@ This section is used for configuring the VH-109 radio outside of competition. At
 
 ## Access Point Radio Configuration
 
-On the Access Point Radio, follow all of the same steps as the robot radio configuration instead choosing :guilabel:`Access Point Mode` at the top of the configuration page. Ensure you use the exact same settings for tean number, suffix, and WPA/SAE keys.
+On the Access Point Radio, follow all of the same steps as the robot radio configuration instead choosing :guilabel:`Access Point Mode` at the top of the configuration page. Ensure you use the exact same settings for team number, suffix, and WPA/SAE keys.
 
 ## Alternative Setup Discussion
 


### PR DESCRIPTION
there's a typo on line 67 where it says "tean" instead of "team" (lol)