### PR TITLE
Make redown handle code block options

### DIFF
--- a/source/_extensions/redown.py
+++ b/source/_extensions/redown.py
@@ -14,6 +14,7 @@ import re
 from pathlib import Path
 from sphinx.application import Sphinx
 from dataclasses import dataclass
+from sphinx.directives.code import CodeBlock
 
 
 LINK_CORE = r"""
@@ -73,7 +74,15 @@ def redown(text: str) -> str:
 
         for line in code.splitlines(keepends=True):
             if line.strip().startswith(":") and not firstCode:
-                ret += cindent + line
+                colon_start = line.find(":")
+                colon_end = line.rfind(":")
+                if colon_start != -1 and colon_end != -1 and colon_start < colon_end:
+                    option = line[colon_start + 1 : colon_end].strip()
+                    if option in CodeBlock.option_spec:
+                        ret += cindent + line
+                    else:
+                        ret += "\n" + cindent + line
+                        firstCode = True
             elif line.strip() == "":
                 if not firstCode:
                     firstCode = True

--- a/source/_extensions/redown.py
+++ b/source/_extensions/redown.py
@@ -67,13 +67,22 @@ def redown(text: str) -> str:
 
         ret = ""
         ret += start
-        ret += btindent + f".. code-block:: {lang}\n\n"
+        ret += btindent + f".. code-block:: {lang}\n"
         cindent = 3 * " "
+        firstCode = False
 
         for line in code.splitlines(keepends=True):
-            if line.strip() == "":
+            if line.strip().startswith(":") and not firstCode:
+                ret += cindent + line
+            elif line.strip() == "":
+                if not firstCode:
+                    firstCode = True
+                    ret += "\n"
                 ret += "\n"
             else:
+                if not firstCode:
+                    firstCode = True
+                    ret += "\n"
                 ret += cindent + line
 
         return ret


### PR DESCRIPTION
Don't automatically add 2 newlines after a code block, check to see if there's options after, and only add a newline after the options are added.
This fixes the code blocks in the stacktrace page. Fixes #2728