### PR TITLE
Fix C++ code snipet for runIntakeCommand(double percentage)

### DIFF
--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -30,11 +30,11 @@ The easiest and most expressive way to do this is with a ``StartEndCommand``:
 .. tab-set-code::
 
   ```java
-  Command runIntake = Commands.startEnd(() -> intake.set(1), () -> intake.set(0), intake);
+  Command runIntake = Commands.startEnd(() -> intake.set(1.0), () -> intake.set(0.0), intake);
   ```
 
   ```c++
-  frc2::CommandPtr runIntake = frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0); }, {&intake});
+  frc2::CommandPtr runIntake = frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0.0); }, {&intake});
   ```
 
 This is sufficient for commands that are only used once. However, for a command like this that might get used in many different autonomous routines and button bindings, inline commands everywhere means a lot of repetitive code:
@@ -43,8 +43,8 @@ This is sufficient for commands that are only used once. However, for a command 
 
   ```java
   // RobotContainer.java
-  intakeButton.whileTrue(Commands.startEnd(() -> intake.set(1.0), () -> intake.set(0), intake));
-  Command intakeAndShoot = Commands.startEnd(() -> intake.set(1.0), () -> intake.set(0), intake)
+  intakeButton.whileTrue(Commands.startEnd(() -> intake.set(1.0), () -> intake.set(0.0), intake));
+  Command intakeAndShoot = Commands.startEnd(() -> intake.set(1.0), () -> intake.set(0.0), intake)
       .alongWith(new RunShooter(shooter));
   Command autonomousCommand = Commands.sequence(
       Commands.startEnd(() -> intake.set(1.0), () -> intake.set(0.0), intake).withTimeout(5.0),
@@ -54,13 +54,13 @@ This is sufficient for commands that are only used once. However, for a command 
   ```
 
   ```c++
-  intakeButton.WhileTrue(frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0); }, {&intake}));
-  frc2::CommandPtr intakeAndShoot = frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0); }, {&intake})
+  intakeButton.WhileTrue(frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0.0); }, {&intake}));
+  frc2::CommandPtr intakeAndShoot = frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0.0); }, {&intake})
       .AlongWith(RunShooter(&shooter).ToPtr());
   frc2::CommandPtr autonomousCommand = frc2::cmd::Sequence(
-    frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0); }, {&intake}).WithTimeout(5.0_s),
+    frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0.0); }, {&intake}).WithTimeout(5.0_s),
     frc2::cmd::Wait(3.0_s),
-    frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0); }, {&intake}).WithTimeout(5.0_s)
+    frc2::cmd::StartEnd([&intake] { intake.Set(1.0); }, [&intake] { intake.Set(0.0); }, {&intake}).WithTimeout(5.0_s)
   );
   ```
 
@@ -90,7 +90,7 @@ For example, a command like the intake-running command is conceptually related t
   ```c++
   frc2::CommandPtr Intake::RunIntakeCommand() {
     // implicitly requires `this`
-    return this->StartEnd([this] { this->Set(1.0); }, [this] { this->Set(0); });
+    return this->StartEnd([this] { this->Set(1.0); }, [this] { this->Set(0.0); });
   }
   ```
 
@@ -133,9 +133,9 @@ Adding a parameter to the ``runIntakeCommand`` method to provide the exact perce
   ```
 
   ```c++
-  frc2::CommandPtr Intake::RunIntakeCommand() {
+  frc2::CommandPtr Intake::RunIntakeCommand(double percent) {
     // implicitly requires `this`
-    return this->StartEnd([this, percent] { this->Set(percent); }, [this] { this->Set(0); });
+    return this->StartEnd([this, percent] { this->Set(percent); }, [this] { this->Set(0.0); });
   }
   ```
 


### PR DESCRIPTION
In Organizing Command Based Robot Projects in the Command-Based Programming Section.
The C++ example code for parsing a percentage into the runIntakeCommand is missing  (```double percentage```) .
Also numerous compiler type conversions from ```int``` to ```double``` will be required because speeds are entered as ```1``` and ```0``` instead of ```1.0``` and ```0.0``` in many of the examples in both C++ and Java throughout the section.