### PR TITLE
Don't hide todos

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -142,7 +142,7 @@ hoverxref_role_types = {"term": "tooltip"}
 # TODO Directives omit a warning
 todo_emit_warnings = False
 
-# TODO Directives are not shown in output
+# TODO Directives are shown in output
 todo_include_todos = True
 
 # Disable following anchors in URLS for linkcheck

--- a/source/conf.py
+++ b/source/conf.py
@@ -143,7 +143,7 @@ hoverxref_role_types = {"term": "tooltip"}
 todo_emit_warnings = False
 
 # TODO Directives are not shown in output
-todo_include_todos = False
+todo_include_todos = True
 
 # Disable following anchors in URLS for linkcheck
 linkcheck_anchors = True

--- a/source/docs/contributing/frc-docs/index.rst
+++ b/source/docs/contributing/frc-docs/index.rst
@@ -10,3 +10,4 @@
    translations
    top-contributors
    top-translators
+   todo

--- a/source/docs/contributing/frc-docs/todo.rst
+++ b/source/docs/contributing/frc-docs/todo.rst
@@ -1,0 +1,3 @@
+# TODO List
+
+.. todolist::

--- a/source/docs/contributing/frc-docs/todo.rst
+++ b/source/docs/contributing/frc-docs/todo.rst
@@ -1,3 +1,5 @@
 # TODO List
 
+Want to help out? Fix one of the [Github Issues](https://github.com/wpilibsuite/frc-docs/issues) or one of the TODOs below.
+
 .. todolist::

--- a/source/docs/software/commandbased/organizing-command-based.rst
+++ b/source/docs/software/commandbased/organizing-command-based.rst
@@ -186,6 +186,8 @@ Instance factory methods work great for single-subsystem commands.  However, com
   // TODO
   ```
 
+.. todo:: implement C++ version of the above code
+
 #### Non-Static Command Factories
 If we want to avoid the verbosity of adding required subsystems as parameters to our factory methods, we can instead construct an instance of our ``AutoRoutines`` class and inject our subsystems through the constructor:
 
@@ -226,6 +228,8 @@ If we want to avoid the verbosity of adding required subsystems as parameters to
   // TODO
   ```
 
+.. todo:: implement C++ version of the above code
+
 Then, elsewhere in our code, we can instantiate an single instance of this class and use it to produce several commands:
 
 .. tab-set-code::
@@ -243,6 +247,8 @@ Then, elsewhere in our code, we can instantiate an single instance of this class
   ```c++
   // TODO
   ```
+
+.. todo:: implement C++ version of the above code
 
 #### Capturing State in Inline Commands
 
@@ -270,6 +276,8 @@ However, it is still possible to ergonomically write a stateful command composit
   ```c++
   // TODO
   ```
+
+.. todo:: implement C++ version of the above code
 
 This pattern works very well in Java so long as the captured state is "effectively final" - i.e., it is never reassigned.  This means that we cannot directly define and capture primitive types (e.g. `int`, `double`, `boolean`) - to circumvent this, we need to wrap any state primitives in a mutable container type (the same way `PIDController` wraps its internal `kP`, `kI`, and `kD` values).
 
@@ -307,6 +315,8 @@ Returning to our simple intake command from earlier, we could do this by creatin
   // TODO
   ```
 
+.. todo:: implement C++ version of the above code
+
 This, however, is just as cumbersome as the original repetitive code, if not more verbose. The only two lines that really matter in this entire file are the two calls to ``intake.set()``, yet there are over 20 lines of boilerplate code! Not to mention, doing this for a lot of robot actions quickly clutters up a robot project with dozens of small files. Nevertheless, this might feel more "natural," particularly for programmers who prefer to stick closely to an object-oriented model.
 
 This approach should be used for commands with internal state (not subsystem state!), as the class can have fields to manage said state. It may also be more intuitive to write commands with complex logic as classes, especially for those less experienced with command composition. As the command is detached from any specific subsystem class and the required subsystem objects are injected through the constructor, this approach deals well with commands involving multiple subsystems.
@@ -333,6 +343,8 @@ If we wish to write composite commands as their own classes, we may write a cons
   ```c++
   // TODO
   ```
+
+.. todo:: implement C++ version of the above code
 
 This is relatively short and minimizes boilerplate. It is also comfortable to use in a purely object-oriented paradigm and may be more acceptable to novice programmers. However, it has some downsides. For one, it is not immediately clear exactly what type of command group this is from the constructor definition: it is better to define this in a more inline and expressive way, particularly when nested command groups start showing up. Additionally, it requires a new file for every single command group, even when the groups are conceptually related.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -452,4 +452,3 @@ Community translations can be found in a variety of languages in the menu toward
 
    Report a Documentation Issue <https://github.com/wpilibsuite/frc-docs/issues>
 
-.. todolist::


### PR DESCRIPTION
Makes it visible when something is still to be done to users. Move todolist from index to separate article in contributing

<img width="1423" height="1162" alt="image" src="https://github.com/user-attachments/assets/40823b90-da2e-49b6-8a99-fe8abfb3ced2" />
