### PR TITLE
Use Python 3.10 in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
         cache: 'pip'
     - name: Install Python Dependencies
       run: |
@@ -41,7 +41,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
         cache: 'pip'
     - name: Install Python Dependencies
       run: |
@@ -75,7 +75,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
         cache: 'pip'
     - name: Install Python Dependencies
       run: |
@@ -102,7 +102,7 @@ jobs:
   #      uses: tj-actions/changed-files@v41
   #    - uses: actions/setup-python@v5
   #      with:
-  #        python-version: 3.9
+  #        python-version: "3.10"
   #    - name: Install Dependencies
   #      run: pip install -r source/requirements.txt
   #    - name: Run linkcheck on .rst files
@@ -126,7 +126,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install Dependencies
       run: |
         pip install -r source/requirements.txt
@@ -140,7 +140,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install Dependencies
       run: |
         pip install -r source/requirements.txt
@@ -168,7 +168,7 @@ jobs:
         git fetch origin main --depth=1
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install Dependencies
       run: |
         pip install -r source/requirements.txt
@@ -185,7 +185,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install Python Dependencies
       run: |
         pip install -r source/requirements.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,9 +6,9 @@ sphinx:
   fail_on_warning: true
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - librsvg2-bin
   jobs:


### PR DESCRIPTION
Python 3.9 will be out of support soon
Update RTD to Ubuntu 22.04 since 20.04 is out of support