### PR TITLE
Add REV Servo Hub to Status Light Quick Reference

### DIFF
--- a/source/docs/hardware/hardware-basics/status-lights-ref.rst
+++ b/source/docs/hardware/hardware-basics/status-lights-ref.rst
@@ -582,7 +582,7 @@ When the center LED is off the device is operating in coast mode. When the cente
 
 ### Status LEDs
 
-Each channel has a corresponding status LED that will indicate the sensed state of the connected :term:`PWM` signal. The table below describes each state’s corresponding LED pattern.
+Each channel has a corresponding status LED that will indicate the sensed state of the connected :term:`PWM` signal. The table below describes each state's corresponding LED pattern.
 
 +-----------------------+----------------+
 | State                 | Pattern        |
@@ -597,6 +597,31 @@ Each channel has a corresponding status LED that will indicate the sensed state 
 +-----------------------+----------------+
 
 - 6V Power LED off, dim, or flickering with power applied = Over-current shutdown
+
+## REV Robotics Servo Hub
+
+[REV Servo Hub Status LED Patterns](https://docs.revrobotics.com/servo-hub/status-led)
+
+### General Status LED
+
++-------------------------+----------------------------------------------------------------+
+| LED Color               | Status                                                         |
++=========================+================================================================+
+| Magenta Blinking        | Powered on but not connected to a controller or                |
+|                         | the REV Hardware Client                                        |
++-------------------------+----------------------------------------------------------------+
+| Blue Solid              | Connected to REV Hardware Client                               |
++-------------------------+----------------------------------------------------------------+
+| Solid Cyan              | Connected to a roboRIO or CAN controller                       |
++-------------------------+----------------------------------------------------------------+
+| Green Solid             | Connected to a Control Hub or RS-485 controller                |
++-------------------------+----------------------------------------------------------------+
+| Orange/Cyan Blinking    | Battery voltage is lower than 5.5V                             |
++-------------------------+----------------------------------------------------------------+
+| Orange/Yellow Blinking  | CAN fault detected                                             |
++-------------------------+----------------------------------------------------------------+
+| Orange/Magenta Blinking | Overcurrent fault                                              |
++-------------------------+----------------------------------------------------------------+
 
 ## CANCoder Encoder
 


### PR DESCRIPTION
## Summary
Adds the REV Robotics Servo Hub status LED patterns to the Status Light Quick Reference documentation.

## Changes
- Added new section for REV Robotics Servo Hub with general status LED patterns
- Includes link to REV documentation for complete details

Fixes #2976