### PR TITLE
Add REV Servo Hub to Status Light Quick Reference

### DIFF
--- a/source/docs/hardware/hardware-basics/status-lights-ref.rst
+++ b/source/docs/hardware/hardware-basics/status-lights-ref.rst
@@ -600,7 +600,7 @@ Each channel has a corresponding status LED that will indicate the sensed state 
 
 ## REV Robotics Servo Hub
 
-[REV Servo Hub Status LED Patterns](https://docs.revrobotics.com/servo-hub/status-led)
+[REV Servo Hub Status LED Patterns](https://docs.revrobotics.com/rev-crossover-products/servo/servo-hub/servo-hub-status-led-patterns)
 
 ### General Status LED
 


### PR DESCRIPTION
## Summary
Adds the REV Robotics Servo Hub status LED patterns to the Status Light Quick Reference documentation.

## Changes
- Added new section for REV Robotics Servo Hub with general status LED patterns
- Includes link to REV documentation for complete details

Fixes #2976