### PR TITLE
Add comprehensive documentation for custom struct and protobuf serialization

### DIFF
--- a/source/docs/software/networktables/custom-serialization.rst
+++ b/source/docs/software/networktables/custom-serialization.rst
@@ -1,0 +1,486 @@
+# Custom Struct and Protobuf Serialization
+
+NetworkTables supports serialization of complex data types using Struct and Protobuf encoding formats. While many WPILib classes include built-in serializers, teams can create custom serializers for their own data types to send them over NetworkTables or log them with DataLog.
+
+## When to Use Custom Serialization
+
+Custom serialization is useful when you want to:
+
+* Send custom data types over NetworkTables to dashboards or coprocessors
+* Log custom data types with :doc:`DataLog </docs/software/telemetry/datalog>` or :doc:`Epilogue </docs/software/telemetry/robot-telemetry-with-annotations>`
+* Create efficient binary representations of your data structures
+* Maintain type safety when communicating complex data
+
+## Struct vs Protobuf
+
+**Struct serialization** is designed for fixed-size data structures and provides the fastest and most compact encoding. Use struct serialization when:
+
+* Your data type has a fixed size (no variable-length strings or arrays)
+* Performance and compact size are priorities
+* You have simple data structures with primitive types
+
+**Protobuf serialization** offers more flexibility for variable-size data. Use protobuf serialization when:
+
+* Your data type contains variable-length fields (strings, arrays, lists)
+* You need forward/backward compatibility
+* You have nested or complex data structures
+
+## Implementing Struct Serialization
+
+To implement struct serialization for a custom type, you need to:
+
+1. Make your class implement the ``StructSerializable`` interface
+2. Create a ``Struct`` implementation class
+3. Add a static ``struct`` field to your class
+
+### Example: Custom Robot State
+
+Here's a complete example of a custom ``RobotState`` class with struct serialization:
+
+.. tab-set::
+
+    .. tab-item:: Java
+       :sync: Java
+
+       First, define your custom class and make it implement ``StructSerializable``:
+
+       ```java
+       package frc.robot;
+
+       import edu.wpi.first.util.struct.StructSerializable;
+
+       public class RobotState implements StructSerializable {
+         public static final RobotStateStruct struct = new RobotStateStruct();
+
+         public double xPosition;
+         public double yPosition;
+         public double angle;
+         public boolean isEnabled;
+
+         public RobotState() {
+           this(0.0, 0.0, 0.0, false);
+         }
+
+         public RobotState(double xPosition, double yPosition, double angle, boolean isEnabled) {
+           this.xPosition = xPosition;
+           this.yPosition = yPosition;
+           this.angle = angle;
+           this.isEnabled = isEnabled;
+         }
+       }
+       ```
+
+       Next, create the ``Struct`` implementation:
+
+       ```java
+       package frc.robot;
+
+       import edu.wpi.first.util.struct.Struct;
+       import java.nio.ByteBuffer;
+
+       public class RobotStateStruct implements Struct<RobotState> {
+         @Override
+         public Class<RobotState> getTypeClass() {
+           return RobotState.class;
+         }
+
+         @Override
+         public String getTypeName() {
+           return "RobotState";
+         }
+
+         @Override
+         public int getSize() {
+           // 3 doubles (8 bytes each) + 1 boolean (1 byte) = 25 bytes
+           return Struct.kSizeDouble * 3 + Struct.kSizeBool;
+         }
+
+         @Override
+         public String getSchema() {
+           // Describe the structure of the data
+           return "double x;double y;double angle;bool enabled";
+         }
+
+         @Override
+         public RobotState unpack(ByteBuffer bb) {
+           // Read data from ByteBuffer in the same order as pack()
+           double x = bb.getDouble();
+           double y = bb.getDouble();
+           double angle = bb.getDouble();
+           boolean enabled = bb.get() != 0;
+           return new RobotState(x, y, angle, enabled);
+         }
+
+         @Override
+         public void pack(ByteBuffer bb, RobotState value) {
+           // Write data to ByteBuffer in the same order as unpack()
+           bb.putDouble(value.xPosition);
+           bb.putDouble(value.yPosition);
+           bb.putDouble(value.angle);
+           bb.put((byte) (value.isEnabled ? 1 : 0));
+         }
+       }
+       ```
+
+       Finally, use it with NetworkTables:
+
+       ```java
+       import edu.wpi.first.networktables.NetworkTableInstance;
+       import edu.wpi.first.networktables.StructPublisher;
+       import edu.wpi.first.networktables.StructTopic;
+
+       public class Robot extends TimedRobot {
+         private StructTopic<RobotState> stateTopic;
+         private StructPublisher<RobotState> statePublisher;
+
+         @Override
+         public void robotInit() {
+           // Get a struct topic and publisher
+           stateTopic = NetworkTableInstance.getDefault()
+               .getStructTopic("robot_state", RobotState.struct);
+           statePublisher = stateTopic.publish();
+         }
+
+         @Override
+         public void robotPeriodic() {
+           // Publish the current robot state
+           RobotState state = new RobotState(
+               drivetrain.getX(),
+               drivetrain.getY(),
+               drivetrain.getAngle(),
+               isEnabled()
+           );
+           statePublisher.set(state);
+         }
+       }
+       ```
+
+    .. tab-item:: C++
+       :sync: C++
+
+       First, define your custom struct:
+
+       ```cpp
+       #pragma once
+
+       #include <wpi/struct/Struct.h>
+
+       struct RobotState {
+         double xPosition;
+         double yPosition;
+         double angle;
+         bool isEnabled;
+       };
+
+       // Declare the struct template specialization
+       template <>
+       struct wpi::Struct<RobotState> {
+         static constexpr std::string_view GetTypeName() { return "RobotState"; }
+         static constexpr size_t GetSize() {
+           return 3 * sizeof(double) + sizeof(bool);
+         }
+         static constexpr std::string_view GetSchema() {
+           return "double x;double y;double angle;bool enabled";
+         }
+
+         static RobotState Unpack(std::span<const uint8_t> data);
+         static void Pack(std::span<uint8_t> data, const RobotState& value);
+       };
+       ```
+
+       Implement the Pack and Unpack functions:
+
+       ```cpp
+       #include "RobotState.h"
+       #include <wpi/struct/Struct.h>
+
+       RobotState wpi::Struct<RobotState>::Unpack(std::span<const uint8_t> data) {
+         wpi::UnpackHelper helper{data};
+         return RobotState{
+           helper.Unpack<double>(),  // xPosition
+           helper.Unpack<double>(),  // yPosition
+           helper.Unpack<double>(),  // angle
+           helper.Unpack<bool>()     // isEnabled
+         };
+       }
+
+       void wpi::Struct<RobotState>::Pack(std::span<uint8_t> data, const RobotState& value) {
+         wpi::PackHelper helper{data};
+         helper.Pack(value.xPosition);
+         helper.Pack(value.yPosition);
+         helper.Pack(value.angle);
+         helper.Pack(value.isEnabled);
+       }
+       ```
+
+       Use it with NetworkTables:
+
+       ```cpp
+       #include <frc/TimedRobot.h>
+       #include <networktables/NetworkTableInstance.h>
+       #include <networktables/StructTopic.h>
+       #include "RobotState.h"
+
+       class Robot : public frc::TimedRobot {
+        public:
+         void RobotInit() override {
+           auto inst = nt::NetworkTableInstance::GetDefault();
+           m_stateTopic = inst.GetStructTopic<RobotState>("robot_state");
+           m_statePublisher = m_stateTopic.Publish();
+         }
+
+         void RobotPeriodic() override {
+           RobotState state{
+             m_drivetrain.GetX(),
+             m_drivetrain.GetY(),
+             m_drivetrain.GetAngle(),
+             IsEnabled()
+           };
+           m_statePublisher.Set(state);
+         }
+
+        private:
+         nt::StructTopic<RobotState> m_stateTopic;
+         nt::StructPublisher<RobotState> m_statePublisher;
+       };
+       ```
+
+## Implementing Protobuf Serialization
+
+Protobuf serialization requires defining a ``.proto`` file and generating code from it. This is more complex but handles variable-sized data.
+
+### Example: Custom Target Information
+
+.. tab-set::
+
+    .. tab-item:: Java
+       :sync: Java
+
+       First, create a ``.proto`` file (e.g., ``target_info.proto``):
+
+       ```protobuf
+       syntax = "proto3";
+
+       package frc.robot;
+
+       message ProtobufTargetInfo {
+         double distance = 1;
+         double angle = 2;
+         string target_name = 3;
+         bool is_valid = 4;
+       }
+       ```
+
+       Use the protobuf compiler (``protoc``) to generate Java code from the ``.proto`` file. Consult the [Protocol Buffers documentation](https://protobuf.dev) for details.
+
+       Then implement the ``Protobuf`` interface:
+
+       ```java
+       package frc.robot;
+
+       import edu.wpi.first.util.protobuf.Protobuf;
+       import frc.robot.proto.ProtobufTargetInfo;
+       import us.hebi.quickbuf.ProtoMessage;
+
+       public class TargetInfoProto implements Protobuf<TargetInfo, ProtobufTargetInfo> {
+         @Override
+         public Class<TargetInfo> getTypeClass() {
+           return TargetInfo.class;
+         }
+
+         @Override
+         public ProtoMessage<?> createMessage() {
+           return ProtobufTargetInfo.newInstance();
+         }
+
+         @Override
+         public TargetInfo unpack(ProtobufTargetInfo msg) {
+           return new TargetInfo(
+               msg.getDistance(),
+               msg.getAngle(),
+               msg.getTargetName().toString(),
+               msg.getIsValid()
+           );
+         }
+
+         @Override
+         public void pack(ProtobufTargetInfo msg, TargetInfo value) {
+           msg.setDistance(value.distance)
+              .setAngle(value.angle)
+              .setTargetName(value.targetName)
+              .setIsValid(value.isValid);
+         }
+       }
+       ```
+
+       Create your ``TargetInfo`` class:
+
+       ```java
+       package frc.robot;
+
+       import edu.wpi.first.util.protobuf.ProtobufSerializable;
+
+       public class TargetInfo implements ProtobufSerializable {
+         public static final TargetInfoProto proto = new TargetInfoProto();
+
+         public double distance;
+         public double angle;
+         public String targetName;
+         public boolean isValid;
+
+         public TargetInfo(double distance, double angle, String targetName, boolean isValid) {
+           this.distance = distance;
+           this.angle = angle;
+           this.targetName = targetName;
+           this.isValid = isValid;
+         }
+       }
+       ```
+
+       Use it with NetworkTables:
+
+       ```java
+       import edu.wpi.first.networktables.NetworkTableInstance;
+       import edu.wpi.first.networktables.ProtobufPublisher;
+       import edu.wpi.first.networktables.ProtobufTopic;
+
+       // In your robot class
+       ProtobufTopic<TargetInfo> targetTopic =
+           NetworkTableInstance.getDefault()
+               .getProtobufTopic("vision/target", TargetInfo.proto);
+       ProtobufPublisher<TargetInfo> targetPublisher = targetTopic.publish();
+
+       // Publish target information
+       TargetInfo target = new TargetInfo(2.5, 15.3, "High Goal", true);
+       targetPublisher.set(target);
+       ```
+
+    .. tab-item:: C++
+       :sync: C++
+
+       C++ protobuf implementation follows a similar pattern:
+
+       Create your ``.proto`` file:
+
+       ```protobuf
+       syntax = "proto3";
+
+       package frc.robot;
+
+       message ProtobufTargetInfo {
+         double distance = 1;
+         double angle = 2;
+         string target_name = 3;
+         bool is_valid = 4;
+       }
+       ```
+
+       Generate C++ code using ``protoc``, then use it with NetworkTables:
+
+       ```cpp
+       #include <networktables/NetworkTableInstance.h>
+       #include <networktables/ProtobufTopic.h>
+       #include "TargetInfo.pb.h"
+
+       // In your robot class
+       auto inst = nt::NetworkTableInstance::GetDefault();
+       auto targetTopic = inst.GetProtobufTopic<frc::robot::ProtobufTargetInfo>("vision/target");
+       auto targetPublisher = targetTopic.Publish();
+
+       // Publish target information
+       frc::robot::ProtobufTargetInfo target;
+       target.set_distance(2.5);
+       target.set_angle(15.3);
+       target.set_target_name("High Goal");
+       target.set_is_valid(true);
+       targetPublisher.Set(target);
+       ```
+
+## Important Considerations
+
+### Struct Serialization
+
+* **Fixed Size**: All struct fields must have a fixed size. You cannot use variable-length strings or arrays.
+* **Byte Order**: Data is serialized in the order specified in ``pack()`` and must be deserialized in the same order in ``unpack()``.
+* **Alignment**: Be mindful of data alignment when calculating struct sizes.
+* **Schema String**: The schema string should accurately describe your data structure for debugging and introspection.
+
+### Protobuf Serialization
+
+* **Proto File**: You must create a ``.proto`` file and generate code using the protobuf compiler.
+* **Dependencies**: Ensure protobuf dependencies are properly configured in your build system.
+* **Version Compatibility**: Protobuf provides better forward/backward compatibility than struct serialization.
+* **Variable Size**: Protobuf handles variable-length data automatically but has more overhead than struct.
+
+## Using Custom Serialization with DataLog
+
+Both struct and protobuf serialized types can be logged with DataLog:
+
+.. tab-set::
+
+    .. tab-item:: Java
+       :sync: Java
+
+       ```java
+       import edu.wpi.first.util.datalog.DataLog;
+       import edu.wpi.first.util.datalog.StructLogEntry;
+
+       // Create a struct log entry
+       DataLog log = DataLogManager.getLog();
+       StructLogEntry<RobotState> stateLogger =
+           StructLogEntry.create(log, "robot_state", RobotState.struct);
+
+       // Log data
+       RobotState state = new RobotState(1.0, 2.0, 90.0, true);
+       stateLogger.append(state);
+       ```
+
+    .. tab-item:: C++
+       :sync: C++
+
+       ```cpp
+       #include <wpi/DataLog.h>
+       #include <wpi/struct/StructLogEntry.h>
+
+       // Create a struct log entry
+       wpi::log::DataLog& log = frc::DataLogManager::GetLog();
+       wpi::log::StructLogEntry<RobotState> stateLogger{log, "robot_state"};
+
+       // Log data
+       RobotState state{1.0, 2.0, 90.0, true};
+       stateLogger.Append(state);
+       ```
+
+## Using Custom Serialization with Epilogue
+
+Custom serialized types can be automatically logged using :doc:`Epilogue annotations </docs/software/telemetry/robot-telemetry-with-annotations>`:
+
+.. tab-set::
+
+    .. tab-item:: Java
+       :sync: Java
+
+       ```java
+       import edu.wpi.first.epilogue.Logged;
+       import edu.wpi.first.epilogue.Epilogue;
+
+       @Logged
+       public class Drivetrain {
+         private RobotState m_state = new RobotState();
+
+         public RobotState getState() {
+           return m_state;
+         }
+
+         // Epilogue will automatically log the RobotState using struct serialization
+       }
+       ```
+
+For Epilogue to recognize your custom type, ensure your class implements ``StructSerializable`` or ``ProtobufSerializable`` and has a static ``struct`` or ``proto`` field.
+
+## Additional Resources
+
+* [WPILib Struct API Documentation](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/util/struct/Struct.html)
+* [WPILib Protobuf API Documentation](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/util/protobuf/Protobuf.html)
+* [Protocol Buffers Documentation](https://protobuf.dev)
+* [NetworkTables Topics Documentation](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/networktables/NetworkTable.html)

--- a/source/docs/software/networktables/index.rst
+++ b/source/docs/software/networktables/index.rst
@@ -10,6 +10,7 @@ This section outlines the details of using the NetworkTables (v4) API to communi
    networktables-intro
    tables-and-topics
    publish-and-subscribe
+   custom-serialization
    multiple-instances
    networktables-networking
    listening-for-change

--- a/source/docs/software/networktables/networktables-intro.rst
+++ b/source/docs/software/networktables/networktables-intro.rst
@@ -16,7 +16,11 @@ First, let's define some terms:
 - **Entry**: a combined publisher and subscriber. The subscriber is always active, but the publisher is not created until a publish operation is performed (e.g. a value is "set", aka published, on the entry). This may be more convenient than maintaining a separate publisher and subscriber.
 - **Property**: named information (metadata) about a topic stored and updated separately from the topic's data. A topic may have any number of properties. A property's value can be any data type that can be represented in JSON.
 
-NetworkTables supports a range of data types, including :term:`boolean`, numeric, string, and arrays of those types. Supported numeric data types are single or double precision :term:`floating point`, or 64-bit integer. There is also the option of storing raw data (an array of bytes), which can be used for representing binary encoded structured data. Types are represented as strings for efficiency reasons. There is also an :term:`enumeration` for the most common types in the NetworkTables API.
+NetworkTables supports a range of data types, including :term:`boolean`, numeric, string, and arrays of those types. Supported numeric data types are single or double precision :term:`floating point`, or 64-bit integer. There is also the option of storing raw data (an array of bytes), which can be used for representing binary encoded structured data.
+
+NetworkTables also supports serialization of complex data types using **Struct** and **Protobuf** encoding formats. Struct serialization is designed for fixed-size data structures and provides fast, compact encoding. Protobuf serialization offers more flexibility for variable-size data. Many WPILib math and geometry classes (such as ``Pose2d``, ``Rotation2d``, ``Translation2d``, ``SwerveModuleState``, etc.) include built-in struct serializers and can be published and subscribed to directly via type-specific topics (``StructTopic``, ``StructArrayTopic``, ``ProtobufTopic``). Teams can also :doc:`implement custom struct or protobuf serializers <custom-serialization>` for their own data types.
+
+Types are represented as strings for efficiency reasons. There is also an :term:`enumeration` for the most common types in the NetworkTables API.
 
 Topics are created when the first publisher announces the topic and are removed when the last publisher stops publishing. It's possible to subscribe to a topic that has not yet been created/published.
 

--- a/source/docs/software/telemetry/robot-telemetry-with-annotations.rst
+++ b/source/docs/software/telemetry/robot-telemetry-with-annotations.rst
@@ -45,7 +45,7 @@ Currently, annotation logging supports the following data types:
 * Any type (class, interface, or enum) with a custom logger defined with a ``@CustomLoggerFor`` annotation (intended to be used for logging of third-party classes)
 * All primitive types (``byte``, ``char``, ``short``, ``int``, ``long``, ``float``, ``double``, and ``boolean``) (note: this excludes wrapper types like ``Byte``, ``Integer``, and ``Boolean``)
 * Strings
-* Any type that inherits from ``StructSerializable``, such as WPILib math types or custom user-defined types
+* Any type that inherits from ``StructSerializable``, such as WPILib math types or custom user-defined types (see :doc:`/docs/software/networktables/custom-serialization` for how to create custom struct serializers)
 * Any ``edu.wpi.first.units.Measure`` (logged as a double in terms of the base unit)
 * ``byte[]``, ``int[]``, ``long[]``, ``float[]``, ``double[]``, and ``boolean[]`` primitive arrays
 * ``String[]`` arrays

--- a/source/docs/software/telemetry/telemetry.rst
+++ b/source/docs/software/telemetry/telemetry.rst
@@ -11,7 +11,7 @@ WPILib supports several different ways to record and send telemetry data from ro
 
 At the most basic level, the :ref:`Riolog <docs/software/vscode-overview/viewing-console-output:Viewing Console Output>` provides support for viewing print statements from robot code.  This is useful for on-the-fly debugging of problematic code, but does not scale as console interfaces are not suitable for rich data streams.
 
-WPILib supports several :ref:`dashboards <docs/software/dashboards/index:Dashboards>` that allow users to more easily send rich telemetry data to the driver-station computer.  All WPILib dashboards communicate with the :ref:`NetworkTables <docs/software/networktables/networktables-intro:What is NetworkTables>` protocol, and so they are *to some degree* interoperable (telemetry logged with one dashboard will be visible on the others, but the specific widgets/formatting will generally not be compatible).  NetworkTables (and thus WPILib all dashboards) currently support the following data types:
+WPILib supports several :ref:`dashboards <docs/software/dashboards/index:Dashboards>` that allow users to more easily send rich telemetry data to the driver-station computer.  All WPILib dashboards communicate with the :ref:`NetworkTables <docs/software/networktables/networktables-intro:What is NetworkTables>` protocol, and so they are *to some degree* interoperable (telemetry logged with one dashboard will be visible on the others, but the specific widgets/formatting will generally not be compatible).  NetworkTables (and thus all WPILib dashboards) support the following primitive data types:
 
 * ``boolean``
 * ``boolean[]``
@@ -21,6 +21,8 @@ WPILib supports several :ref:`dashboards <docs/software/dashboards/index:Dashboa
 * ``string[]``
 * ``byte[]``
 
+In addition to these primitive types, NetworkTables supports serialization of complex data types using **Struct** and **Protobuf** formats. Struct serialization is designed for fixed-size data structures and provides the fastest and most compact encoding. Protobuf serialization offers more flexibility for variable-size data. Many WPILib classes (such as ``Pose2d``, ``Rotation2d``, ``SwerveModuleState``, and other geometry/math types) implement the ``StructSerializable`` interface and can be sent directly over NetworkTables. Teams can also :doc:`create custom struct and protobuf serializers </docs/software/networktables/custom-serialization>` for their own data types.
+
 Telemetry data can be sent to a WPILib dashboard using an associated WPILib method (for more details, see the documentation for the individual dashboard in question), or by :ref:`directly publishing to NetworkTables <docs/software/networktables/networktables-intro:what is networktables>`.
 
-While NetworkTables does not yet support serialization of complex data types (this is tentatively scheduled for 2024), *mutable* types from user code can be easily extended to interface directly with WPILib dashboards via the ``Sendable`` interface, whose usage is described in the next article.
+For *mutable* types from user code that need to interface directly with WPILib dashboards, the ``Sendable`` interface can be used, as described in the next article.


### PR DESCRIPTION
## Summary
Creates comprehensive documentation with canonical examples for implementing custom struct and protobuf serializers. This addresses the issue where teams currently need to reference WPILib source code to understand how to create their own serializers.

## Changes

### New Documentation
- **custom-serialization.rst**: Complete guide with step-by-step examples for both Java and C++
  - When to use struct vs protobuf serialization
  - Complete working example of custom struct implementation (RobotState class)
  - Complete working example of protobuf implementation (TargetInfo class)
  - How to use custom serializers with NetworkTables
  - How to use custom serializers with DataLog
  - How to use custom serializers with Epilogue annotations
  - Important considerations and best practices

### Updated Files
- **networktables-intro.rst**: Added explanation of struct/protobuf support with link to custom serialization docs
- **telemetry.rst**: Documented struct/protobuf support with link to custom serialization guide
- **robot-telemetry-with-annotations.rst**: Added link to custom serialization guide for StructSerializable types
- **index.rst**: Added custom-serialization.rst to NetworkTables documentation index

## Examples Provided

The documentation includes:
- Complete, copy-pasteable Java examples for struct serialization
- Complete C++ examples using template specialization
- Protobuf examples with .proto file definitions
- Real-world use cases (robot state, vision target info)
- Integration examples with NetworkTables, DataLog, and Epilogue

Fixes #2820