### PR TITLE
Fix Python CameraServer example code errors

### DIFF
--- a/source/docs/software/vision-processing/wpilibpi/using-cameraserver.rst
+++ b/source/docs/software/vision-processing/wpilibpi/using-cameraserver.rst
@@ -13,9 +13,10 @@ The WPILibPi image comes with all the necessary libraries to make your own visio
    CameraServer.enableLogging()
    camera = CameraServer.startAutomaticCapture()
    camera.setResolution(width, height)
-   sink = cs.getVideo()
+   sink = CameraServer.getVideo()
+   input_img = np.zeros(shape=(height, width, 3), dtype=np.uint8)
    while True:
-      time, input_img = cvSink.grabFrame(input_img)
+      time, input_img = sink.grabFrame(input_img)
       if time == 0: # There is an error
          continue
    ```
@@ -37,12 +38,13 @@ Sometimes, you may want to send processed video frames back to the CameraServer 
    #
    # CameraServer initialization code here
    #
-   output = cs.putVideo("Name", width, height)
+   output = CameraServer.putVideo("Name", width, height)
+   input_img = np.zeros(shape=(height, width, 3), dtype=np.uint8)
    while True:
-      time, input_img = cvSink.grabFrame(input_img)
-         if time == 0: # There is an error
-            output.notifyError(sink.getError())
-            continue
+      time, input_img = sink.grabFrame(input_img)
+      if time == 0: # There is an error
+         output.notifyError(sink.getError())
+         continue
       #
       # Insert processing code here
       #


### PR DESCRIPTION
## Summary
Fixes multiple errors in Python CameraServer example code that prevented it from running.

## Changes
- Fixed `cs.getVideo()` → `CameraServer.getVideo()`
- Fixed `cs.putVideo()` → `CameraServer.putVideo()`
- Fixed `cvSink.grabFrame()` → `sink.grabFrame()`
- Added `input_img` initialization before use in both examples
- Fixed indentation in second example

Fixes #2754