### PR TITLE
Update Status Light Reference for CTRE devices

### DIFF
--- a/source/docs/hardware/hardware-basics/status-lights-ref.rst
+++ b/source/docs/hardware/hardware-basics/status-lights-ref.rst
@@ -289,7 +289,7 @@ These LEDs are lit red if the Solenoid channel is enabled and not lit if it is d
 These motor controllers use Phoenix 5. For the most up-to-date information, see the `CTRE Phoenix 5 Documentation <https://v5.docs.ctr-electronics.com/en/stable/ch13_MC.html>`__.
 
 
-### Status LEDs During Normal Operation
+### Talon SRX/Victor SPX Status LEDs During Normal Operation
 
 +------------------------------+----------------+--------------------------------------------+
 | LEDs                         | Colors         | Device State                               |
@@ -317,7 +317,7 @@ These motor controllers use Phoenix 5. For the most up-to-date information, see 
 | LED1 Only (closest to M+/V+) | Green/Orange   | In Boot-loader                             |
 +------------------------------+----------------+--------------------------------------------+
 
-### Status LEDs During Calibration
+### Talon SRX/Victor SPX Status LEDs During Calibration
 
 +------------------------+------------------------+
 | Status LEDs Blink Code | Device State           |
@@ -329,7 +329,7 @@ These motor controllers use Phoenix 5. For the most up-to-date information, see 
 | Blinking Red           | Failed Calibration     |
 +------------------------+------------------------+
 
-### B/C CAL Blink Codes
+### Talon SRX/Victor SPX B/C CAL Blink Codes
 
 +----------------------+--------------+
 | B/C CAL Button Color | Device State |
@@ -344,7 +344,7 @@ These motor controllers use Phoenix 5. For the most up-to-date information, see 
 The Talon FX uses Phoenix 6. For the most up-to-date information, see the `CTRE Phoenix 6 Documentation <https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/talonfx/index.html#status-light-reference>`__.
 
 
-### Status LEDs
+### Talon FX Status LEDs
 
 +------------------------------+-------------------------------------+
 | LED State                    | Meaning                             |
@@ -375,7 +375,7 @@ The Talon FX uses Phoenix 6. For the most up-to-date information, see the `CTRE 
 | Green/Orange                 |                                     |
 +------------------------------+-------------------------------------+
 
-### B/C CAL Blink Codes
+### Talon FX B/C CAL Blink Codes
 
 +----------------------+--------------+
 | B/C CAL Button Color | Device State |


### PR DESCRIPTION
## Summary
Updates the CTRE motor controller status light documentation to reflect Phoenix 6 patterns and adds a link to the official CTRE documentation.

## Changes
- Updated Talon SRX/Victor SPX/Talon FX status light patterns to match Phoenix 6
- Added link to official CTRE Phoenix 6 documentation for most up-to-date information
- Simplified and modernized the status LED table
- Removed outdated calibration mode section

Fixes #2659