### PR TITLE
Add VisualVM simulation profiling instructions

### DIFF
--- a/source/docs/software/advanced-gradlerio/profiling-with-visualvm.rst
+++ b/source/docs/software/advanced-gradlerio/profiling-with-visualvm.rst
@@ -6,7 +6,22 @@ This document is intended to familiarize the reader with the diagnostic tool tha
 
 To begin, [download VisualVM](https://visualvm.github.io/download.html) and unpack it to the WPILib installation folder. The folder is located at ``~/wpilib/`` where ``~`` indicates the users home directory. On Windows, this is ``C:\Users\Public\wpilib``.
 
-## Setting up Gradle
+## Profiling Simulation
+
+When profiling simulation, no additional Gradle configuration is needed. VisualVM can directly connect to any Java process running on your computer, including robot simulations.
+
+To profile simulation:
+
+1. Launch VisualVM (see :ref:`Running VisualVM <docs/software/advanced-gradlerio/profiling-with-visualvm:Running VisualVM>` below for instructions)
+2. Start your robot simulation from VS Code
+3. In VisualVM, the simulation process will automatically appear in the left sidebar under "Local" as a Java process
+4. Double-click the process to begin profiling
+
+Once connected, you can use all the same features described in this document: CPU sampling, heap dumps, memory monitoring, and more.
+
+.. tip:: You can also use the [VisualVM VSCode extension](https://marketplace.visualstudio.com/items?itemName=oracle-labs-graalvm.visualvm-vscode) for a more integrated experience.
+
+## Setting up Gradle for SystemCore Profiling
 
 GradleRIO supports passing JVM launch arguments, and this is what is necessary to enable remote debugging. Remote debugging is a feature that allows a local machine (such as the user's desktop) to view important information about a remote target (in our case, a SystemCore). To begin, locate the ``wpilibJava`` code block located in the projects ``build.gradle``. Below is what is looks like.
 


### PR DESCRIPTION
## Summary
Adds instructions for using VisualVM to profile robot code in simulation, clarifying that no Gradle configuration changes are needed for simulation profiling (unlike roboRIO profiling).

## Changes
- Added new "Profiling Simulation" section before "Setting up Gradle for roboRIO Profiling"
- Clarifies that Gradle changes are only needed for roboRIO profiling
- Provides step-by-step instructions for profiling simulation
- Mentions optional VisualVM VSCode extension

Fixes #2861