### PR TITLE
Document common causes of loop overruns

### DIFF
--- a/source/docs/software/vscode-overview/debugging-robot-program.rst
+++ b/source/docs/software/vscode-overview/debugging-robot-program.rst
@@ -48,7 +48,7 @@ Another way to debug your program is to use print statements in your code and vi
 
 ## Common Causes of Loop Overruns
 
-Loop overruns occur when the robot's periodic methods (``robotPeriodic()``, ``teleopPeriodic()``, etc.) take longer than 20ms to complete. When this happens, the Driver Station will display a warning and the robot code may behave unpredictably. Here are common causes:
+Loop overruns occur when the robot's periodic methods (``robotPeriodic()``, ``teleopPeriodic()``, etc.) take longer than 20ms to complete. When this happens, the Driver Station will display a warning like ``Loop time of 0.03s overrun`` and the robot code may behave unpredictably. Here are common causes:
 
 ### Blocking Operations
 
@@ -65,7 +65,7 @@ Loop overruns occur when the robot's periodic methods (``robotPeriodic()``, ``te
 ### Excessive Logging or Print Statements
 
 - **System.out.println() in loops**: Console output is slow, especially when called frequently
-- **Verbose NetworkTables updates**: Updating many NetworkTables entries every loop iteration
+- **Getting data to publish to NetworkTables**: While NetworkTables updates themselves are fast, retrieving complex data (e.g., vision processing results, large arrays) to publish can be slow
 - **Excessive Shuffleboard updates**: Sending large amounts of data to the dashboard
 
 ### Hardware/Sensor Issues
@@ -80,7 +80,7 @@ Loop overruns occur when the robot's periodic methods (``robotPeriodic()``, ``te
 - Profile your code to identify slow sections (see :ref:`docs/software/advanced-gradlerio/profiling-with-visualvm:profiling with visualvm`)
 - Remove or reduce print statements, especially in frequently-called code
 - Cache values that are expensive to compute rather than recalculating every loop
-- Use the Driver Station log to identify which periodic method is causing overruns
+- **Check the Driver Station log** to identify which periodic method is causing overruns. The log will show timestamps and which robot mode was active when the overrun occurred. Look for patterns - if overruns only happen during teleop, check ``teleopPeriodic()`` and subsystems used during teleop. If they occur consistently, check ``robotPeriodic()`` for code that runs regardless of mode.
 
 ## Learn More
 

--- a/source/docs/software/vscode-overview/debugging-robot-program.rst
+++ b/source/docs/software/vscode-overview/debugging-robot-program.rst
@@ -46,6 +46,42 @@ Another way to debug your program is to use print statements in your code and vi
 
 :doc:`NetworkTables </docs/software/networktables/networktables-intro>` can be used to share robot information with your debugging computer.  :term:`NetworkTables` can be viewed with your favorite Dashboard or :ref:`OutlineViewer <docs/software/wpilib-tools/outlineviewer/index:OutlineViewer>`.  One advantage of NetworkTables is that tools like :ref:`AdvantageScope <docs/software/dashboards/advantagescope:AdvantageScope>` can be used to graphically analyze the data over time. This is much more intuitive than simpler methods like printing to the console.
 
+## Common Causes of Loop Overruns
+
+Loop overruns occur when the robot's periodic methods (``robotPeriodic()``, ``teleopPeriodic()``, etc.) take longer than 20ms to complete. When this happens, the Driver Station will display a warning and the robot code may behave unpredictably. Here are common causes:
+
+### Blocking Operations
+
+- **Thread.sleep() or wait()**: Never use blocking sleep or wait calls in periodic methods
+- **Synchronous I/O**: Reading files, network operations, or other blocking I/O operations
+- **Busy-wait loops**: Loops that repeatedly check a condition without yielding (e.g., ``while(!sensor.isReady()) {}``)
+
+### Excessive Computation
+
+- **Complex calculations in periodic methods**: Move expensive calculations to separate threads or spread them across multiple loop iterations
+- **Large data structure operations**: Sorting, searching, or iterating over large arrays or lists
+- **Unoptimized algorithms**: O(n²) or worse algorithms running on large datasets
+
+### Excessive Logging or Print Statements
+
+- **System.out.println() in loops**: Console output is slow, especially when called frequently
+- **Verbose NetworkTables updates**: Updating many NetworkTables entries every loop iteration
+- **Excessive Shuffleboard updates**: Sending large amounts of data to the dashboard
+
+### Hardware/Sensor Issues
+
+- **Synchronous CAN calls**: Some motor controller methods may block waiting for a response
+- **I2C or SPI timeouts**: Faulty sensors or loose connections can cause communication timeouts
+- **USB device enumeration**: Plugging/unplugging USB devices during operation
+
+### Tips to Avoid Loop Overruns
+
+- Use :doc:`Notifier </docs/software/convenience-features/scheduling-functions>` for operations that need precise timing independent of the main loop
+- Profile your code to identify slow sections (see :ref:`docs/software/advanced-gradlerio/profiling-with-visualvm:profiling with visualvm`)
+- Remove or reduce print statements, especially in frequently-called code
+- Cache values that are expensive to compute rather than recalculating every loop
+- Use the Driver Station log to identify which periodic method is causing overruns
+
 ## Learn More
 
 - To learn more about debugging with VS Code see this [link](https://code.visualstudio.com/docs/editor/debugging).


### PR DESCRIPTION
## Summary
Adds a comprehensive "Common Causes of Loop Overruns" section to the debugging documentation, explaining what loop overruns are, their symptoms, common causes, and how to avoid/diagnose them.

## Changes
- New section explaining loop overruns (periodic methods taking >20ms)
- Documents common causes:
  - Blocking operations (Thread.sleep, synchronous I/O, busy-wait loops)
  - Excessive computation (complex calculations, large data structures, unoptimized algorithms)
  - Excessive logging (print statements, NetworkTables updates, Shuffleboard updates)
  - Hardware/sensor issues (CAN timeouts, I2C/SPI timeouts, USB enumeration)
- Provides tips for avoiding loop overruns (Notifier, profiling, caching, removing print statements)
- Links to VisualVM profiling documentation

Fixes #2315