### PR TITLE
Clarify command scheduler FSM ordering for interrupted commands

### DIFF
--- a/source/docs/software/commandbased/command-scheduler.rst
+++ b/source/docs/software/commandbased/command-scheduler.rst
@@ -83,7 +83,7 @@ First, the scheduler runs the ``periodic()`` method of each registered ``Subsyst
 
 Secondly, the scheduler polls the state of all registered triggers to see if any new commands that have been bound to those triggers should be scheduled.  If the conditions for scheduling a bound command are met, the command is scheduled and its ``initialize()`` method is run.
 
-.. important:: If a newly-scheduled command has requirement conflicts with a currently-running command, the currently-running command is interrupted first. Critically, the ``end(true)`` method of the interrupted command is called **before** the ``initialize()`` method of the new command. This ordering is important for patterns like using a subsystem as a finite state machine, where commands represent states and the ``end()`` method performs state exit actions while ``initialize()`` performs state entry actions.
+.. note:: If a newly-scheduled command has requirement conflicts with a currently-running command, the currently-running command is interrupted first. The ``end(true)`` method of the interrupted command is called **before** the ``initialize()`` method of the new command.
 
 .. tab-set::
 


### PR DESCRIPTION
## Summary
Adds important note clarifying that when a newly-scheduled command interrupts a currently-running command, the interrupted command's `end(true)` method is called **before** the new command's `initialize()` method. This ordering is critical for patterns like using a subsystem as a finite state machine.

## Changes
- Added important note in "Step 2: Poll Command Scheduling Triggers" section
- Explains the `end(true)` → `initialize()` ordering for requirement conflicts
- Clarifies why this matters for FSM patterns (state exit before state entry)

Fixes #2297