### PR TITLE
Add important note about Python deploy requirements

### DIFF
--- a/source/docs/zero-to-robot/step-2/python-setup.rst
+++ b/source/docs/zero-to-robot/step-2/python-setup.rst
@@ -155,9 +155,9 @@ If you already have a RobotPy robot project, you can use that to download the pi
       python3 -m robotpy init
       ```
 
-This will create a ``robot.py`` and ``pyproject.toml`` file. The ``robot.py`` file contains a basic robot program template. The ``pyproject.toml`` file should be customized and details the requirements needed to run your robot code, among other things.
+This will create a ``robot.py`` and ``pyproject.toml`` file. The ``robot.py`` file contains a skeleton structure to help you get started writing your robot code. The ``pyproject.toml`` file should be customized and details the requirements needed to run your robot code, among other things.
 
-.. important:: The ``robotpy deploy`` command requires that you have written working robot code in ``robot.py`` or created a robot project structure. You cannot deploy to the roboRIO until you have implemented your robot program. See the :doc:`RobotPy Programming Guide </docs/software/python/index>` for information on writing robot code.
+.. important:: The ``robotpy deploy`` command requires that you have written working robot code. The generated ``robot.py`` is just a starting point - you cannot deploy to the roboRIO until you have implemented your robot-specific code. See the :doc:`RobotPy Programming Guide </docs/software/python/index>` for information on writing robot code.
 
 .. seealso:: The default ``pyproject.toml`` created for you only contains the version of RobotPy installed on your computer. If you want to enable vendor packages or install other python packages from PyPI, see our :doc:`pyproject.toml documentation </docs/software/python/pyproject_toml>`
 


### PR DESCRIPTION
## Summary
Adds an important note clarifying that `robotpy deploy` requires working robot code in `robot.py` before it can be used. This prevents confusion for new teams who try to deploy immediately after running `robotpy init`.

## Changes
- Added important note after the `robotpy init` section
- Clarifies that deploy cannot happen until robot code is implemented
- References the RobotPy Programming Guide for help writing robot code

Fixes #2995