### PR TITLE
Document AddressableLED single object limitation and workarounds

### DIFF
--- a/source/docs/software/hardware-apis/misc/addressable-leds.rst
+++ b/source/docs/software/hardware-apis/misc/addressable-leds.rst
@@ -8,9 +8,10 @@ LED strips have been commonly used by teams for several years for a variety of r
 
    - **Daisy-chain strips in series**: Connect multiple LED strips end-to-end as a single long strip, then use :ref:`buffer views <docs/software/hardware-apis/misc/addressable-leds:Controlling Sections of an LED Strip>` to control different sections independently
    - **Use PWM Y-cables**: If you need identical patterns on multiple strips, use PWM Y-cables to send the same signal to multiple strips simultaneously
-   - **Voltage considerations**: WS2812B LEDs are designed for 5V, but roboRIO PWM/Servo ports output 6V. While the LEDs will function, this may reduce their lifespan. Consider using a voltage regulator or level shifter if longevity is a concern.
 
 .. seealso:: For detailed information about powering and best practices for addressable LEDs, see the [Adafruit NeoPixel Überguide](https://learn.adafruit.com/adafruit-neopixel-uberguide/powering-neopixels).
+
+.. warning:: WS2812B LEDs are designed for 5V, but roboRIO PWM/Servo ports output 6V. While the LEDs will function, this may reduce their lifespan. Consider using a voltage regulator or level shifter if longevity is a concern.
 
 ## Instantiating the AddressableLED Object
 


### PR DESCRIPTION
## Summary
Documents the important limitation that roboRIO can only control one `AddressableLED` object at a time through its PWM ports, along with practical workarounds and voltage considerations.

## Changes
- Added important note at the top of the article explaining the single AddressableLED limitation
- Documents workarounds:
  - Daisy-chaining multiple strips as a single long strip with buffer views
  - Using PWM Y-cables for identical patterns on multiple strips
- Added voltage consideration note (6V roboRIO output vs 5V LED design)
- Added seealso link to Adafruit NeoPixel guide for powering/best practices

Fixes #2322