### PR TITLE
Add guidance for Enable Desktop Support checkbox in XRP projects

### DIFF
--- a/source/docs/xrp-robot/programming-xrp.rst
+++ b/source/docs/xrp-robot/programming-xrp.rst
@@ -30,6 +30,8 @@ Next, a list of examples will appear. Scroll through the list to find the "XRP R
 
 Fill out the rest of the fields in the "New Project Creator" and click "Generate Project" to create the new robot project.
 
+.. note:: **Enable Desktop Support** - This option can be left checked or unchecked for Java and Python XRP projects, as it has no effect. For C++ XRP projects, it must be checked to enable simulation support (which the XRP requires to run).
+
 ### Running an XRP Program
 
 Once the robot project is generated, it is essentially ready to run. The project has a pre-built ``Drivetrain`` class and associated default command that lets you drive the XRP around using a joystick.


### PR DESCRIPTION
## Summary
Adds clarification about the "Enable Desktop Support" checkbox when creating XRP projects, addressing user confusion reported in issue #3146.

## Changes
Added a note in the "Creating a New WPILib XRP Project" section explaining:
- **Java and Python**: The "Enable Desktop Support" checkbox has no effect and can be left checked or unchecked
- **C++**: Must be checked to enable simulation support (which XRP requires to run)

## Context
Users following the XRP Java Programming Part 1 course were confused about whether to enable this option. According to ThadHouse's comment on the issue, the flag does nothing for Java projects, but the documentation didn't explain this.

This change helps users understand:
1. They don't need to worry about this setting for Java/Python
2. C++ users must enable it for XRP to work properly

Fixes #3146