### PR TITLE
Add performance warning for VH-109 2.4GHz standalone mode

### DIFF
--- a/source/docs/zero-to-robot/step-3/radio-programming.rst
+++ b/source/docs/zero-to-robot/step-3/radio-programming.rst
@@ -105,6 +105,8 @@ To enable standalone mode:
 2. Flip DIP switch 3 to the "ON" position.
 3. Connect devices directly to the 2.4GHz network hosted by the radio, using the 2.4 GHz WPA/SAE key from configuration.
 
+.. warning:: Due to poor performance, Vivid-Hosting does not recommend using this method for practicing at home. You should only use this method in extreme cases. School campuses tend to have noisy 2.4GHz environments, which can significantly degrade wireless performance.
+
 Advantages:
 
 - Simple setup with no need for additional hardware.


### PR DESCRIPTION
## Summary
Adds a warning to the radio programming documentation about the poor performance of the VH-109's 2.4GHz standalone mode, based on recommendations from Vivid-Hosting's official documentation.

## Changes
- Added a warning in the "Enable 2.4GHz Wifi on the VH-109" section noting that Vivid-Hosting does not recommend this method for practicing at home due to poor performance
- Notes that school campuses tend to have noisy 2.4GHz environments which significantly degrade wireless performance
- Recommends this method should only be used in extreme cases

## Source
Information sourced from [Vivid-Hosting's official documentation](https://frc-radio.vivid-hosting.net/overview/practicing-at-home#id-2.4ghz-access-point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)