### PR TITLE
Add warning banner to Redux Robotics third-party CAN devices

### DIFF
--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -95,7 +95,9 @@ Playing With Fusion (PWF) offers the Venom integrated motor/controller as well a
 
 ## Redux Robotics
 
-Redux Robotics currently offers the HELIUM Canandmag :term:`CAN` + :term:`PWM` magnetic encoder and the BORON Canandgyro :term:`CAN`-enabled gyro.
+.. warning:: Redux Robotics is shutting down. While their devices remain legal for FRC use and software support will be provided for the 2026 season, no new hardware will be available.
+
+Redux Robotics offers the HELIUM Canandmag :term:`CAN` + :term:`PWM` magnetic encoder and the BORON Canandgyro :term:`CAN`-enabled gyro.
 
 ### Redux Sensors
 


### PR DESCRIPTION
## Summary
Adds a warning banner to the Redux Robotics section in the third-party CAN devices documentation to inform users that the company is shutting down.

## Changes
- Added warning banner noting Redux Robotics shutdown
- Clarifies that devices remain legal for FRC use
- Notes that software support will be provided for 2026 season
- Mentions no new hardware will be available

## Rationale
Per [Chief Delphi discussion](https://www.chiefdelphi.com/t/the-end-of-redux-robotics/506991/39), Redux Robotics is shutting down but will provide software support for the 2026 season. This keeps the documentation available for teams that already have Redux hardware while warning teams about the company's status.

Related to #3152 - separated out per reviewer request to keep device removals and warnings in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)