### PR TITLE
Build multipage HTML zip

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -14,7 +14,10 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
- 
+    build:
+      htmlzip:
+        - python -m sphinx -T -E -W --keep-going -b readthedocssinglehtmllocalmedia -d _build/doctrees -D language=$READTHEDOCS_LANGUAGE . $READTHEDOCS_OUTPUT/htmlzip
+
 formats:
   - htmlzip
   - pdf


### PR DESCRIPTION
Fixed up by overriding the htmlzip build: https://docs.readthedocs.com/platform/stable/build-customization.html#extend-or-override-the-build-process

This makes the htmlzip build command the same as before (instead of building singlehtml): <https://app.readthedocs.org/projects/frc-docs/builds/22213331/>