### PR TITLE
Fix downloadable HTML zip being one HTML page

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -17,8 +17,9 @@ build:
     build:
       htmlzip:
         - mkdir --parents _readthedocs/htmlzip
-        - python -m sphinx -T -W --keep-going -b readthedocssinglehtmllocalmedia -d _build/doctrees -D language=$READTHEDOCS_LANGUAGE source $READTHEDOCS_OUTPUT/out
-        - cd $READTHEDOCS_OUTPUT ; zip --recurse-path --symlinks htmlzip/$READTHEDOCS_PROJECT.zip out
+        # Output to an intermediate directory because RTD doesn't like extra content in the directory
+        - python -m sphinx -T -W --keep-going -b readthedocssinglehtmllocalmedia -d _build/doctrees -D language=$READTHEDOCS_LANGUAGE source $READTHEDOCS_OUTPUT/tmphtmlzip
+        - cd $READTHEDOCS_OUTPUT ; zip --recurse-path --symlinks htmlzip/$READTHEDOCS_PROJECT.zip tmphtmlzip
 
 formats:
   - htmlzip


### PR DESCRIPTION
One local build later, it turns out that RTD will actually run the build commands in the `source` directory, _unless_ you override the build command, where it just places you at the root repo, with the difference not being super obvious.

Just to be sure this works in RTD-land, I'm first going to add it as a `post_build` command, which _will_ execute on PRs and will actually give you a non-functional link that you can fix up to then use to download the docs. After we confirm that it spits out the ZIP correctly, then we can integrate it properly.