### PR TITLE
Replace deprecated feedforward.calculate(velocity, acceleration) (2027)

### DIFF
--- a/source/docs/software/advanced-controls/controllers/profiled-pidcontroller.rst
+++ b/source/docs/software/advanced-controls/controllers/profiled-pidcontroller.rst
@@ -86,7 +86,7 @@ The returned setpoint might then be used as in the following example:
 
    .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/3f88c287d6007f6be9fc5409aa9c42d41a504005/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/snippets/profiledpidfeedforward/Robot.java
       :language: java
-      :lines: 37-44
+      :lines: 37-42
       :lineno-match:
 
    .. remoteliteralinclude:: https://raw.githubusercontent.com/wpilibsuite/allwpilib/3f88c287d6007f6be9fc5409aa9c42d41a504005/wpilibcExamples/src/main/cpp/snippets/ProfiledPIDFeedforward/cpp/Robot.cpp


### PR DESCRIPTION
* Replace deprecated feedforward.calculate(velocity, acceleration)

Update ProfiledPIDController documentation to use the recommended feedforward.calculate(currentVelocity, nextVelocity) overload instead of the deprecated (velocity, acceleration) version.

This eliminates manual acceleration calculations and uses the newer API that calculates acceleration internally from velocity change.

Fixes #2963

* Convert ProfiledPIDController feedforward example to use snippets

Replace inline code blocks with RLIs to snippets from allwpilib. Java and C++ examples now reference compilable snippet code that will be tested in every allwpilib build.

Python remains as inline code block since Python snippets are maintained in robotpy repository.

Related: wpilibsuite/allwpilib#8280

* Manually update RLI

---------