### PR TITLE
Remove limitation on linkcheck workers

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -172,7 +172,6 @@ linkcheck_anchors_ignore_for_url = [
 # Sets linkcheck timeout in seconds
 linkcheck_timeout = 30
 linkcheck_retries = 3
-linkcheck_workers = 1
 linkcheck_report_timeouts_as_broken = False
 
 # Specify a standard user agent, as Sphinx default is blocked on some sites


### PR DESCRIPTION
It was added in #583 to get around github rate limits, but those should be resolved with #2950 and #2108