### PR TITLE
Enable sphinx nitpicky mode

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -209,6 +209,7 @@ hoverxref_mathjax = True
 # Use MathJax3 for better page loading times
 mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
 
+nitpicky = True
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/source/docs/zero-to-robot/step-2/python-setup.rst
+++ b/source/docs/zero-to-robot/step-2/python-setup.rst
@@ -118,7 +118,7 @@ Once you have installed Python, you can use pip to install RobotPy on your devel
 
          Our ARM wheels are built for Debian 12 (Bookworm) with GCC 12.
 
-      If you need to build with a specific compiler version, you can specify them using the :envvar:`CC` and :envvar:`CXX` environment variables:
+      If you need to build with a specific compiler version, you can specify them using the ``CC`` and ``CXX`` environment variables:
 
       ```sh
       export CC=gcc-12 CXX=g++-12


### PR DESCRIPTION
replace two usages of the envvar directive, which is supposed to be used to document an environment variable and have corresponding documentation https://www.sphinx-doc.org/en/master/usage/domains/standard.html#directive-envvar