### PR TITLE
Update RobotPy pyproject.toml usage for 2026

### DIFF
--- a/source/docs/software/python/pyproject_toml.rst
+++ b/source/docs/software/python/pyproject_toml.rst
@@ -25,6 +25,7 @@ robotpy_extras = [
     # "cscore",
     # "romi",
     # "sim",
+    # "xrp",
 ]
 # Other pip packages to install
 requires = []


### PR DESCRIPTION
- Update repo URL and version
- Remove references to removed vendor extras, see https://github.com/robotpy/robotpy-meta/pull/39
- Add trailing commas, so uncommenting multiple lines doesn't break the TOML syntax
- Add missing `xrp` extra