### PR TITLE
game-data: Copy Java/C++ control flow structure to Python

### DIFF
--- a/source/docs/yearly-overview/2026-game-data.rst
+++ b/source/docs/yearly-overview/2026-game-data.rst
@@ -73,9 +73,19 @@ In C++, Java, and Python the Game Data is accessed by using the GetGameSpecificM
   ```python
   data = wpilib.DriverStation.getGameSpecificMessage()
   if data:
-     # Set the robot gamedata property and set a network tables value
-     self.gameData = data
-     self.sd.putString("gameData", self.gameData)
+      match data:
+          case "B":
+              # Blue case code
+              ...
+          case "R":
+              # Red case code
+              ...
+          case _:
+              # This is corrupt data
+              ...
+  else:
+      # Code for no data received yet
+      ...
   ```
 
 ### LabVIEW


### PR DESCRIPTION
This makes the example Python snippet look similar to the Java and C++ snippets in structure, using [the match statement](https://peps.python.org/pep-0636/). The ellipses are present to ensure the snippet is valid Python code.