### PR TITLE
Fix links to CTRE API docs

### DIFF
--- a/source/docs/software/can-devices/third-party-devices.rst
+++ b/source/docs/software/can-devices/third-party-devices.rst
@@ -20,46 +20,46 @@ CTR Electronics (CTRE) offers several CAN peripherals with external libraries. G
 ### CTRE Motor Controllers
 
 - **Talon FX (with Falcon 500 Motor, Kraken x60 motor, and Kraken x44)**
-    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/classctre_1_1phoenix6_1_1hardware_1_1_talon_f_x.html))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/stable/java/com/ctre/phoenix6/hardware/TalonFX.html), [C++](https://api.ctr-electronics.com/phoenix6/stable/cpp/classctre_1_1phoenix6_1_1hardware_1_1_talon_f_x.html))
     - Hardware User's Manual ([Falcon 500](https://ctre.download/files/user-manual/Falcon%20500%20v3%20User's%20Guide.pdf), [Kraken x60](https://docs.wcproducts.com/kraken-x60), [Kraken x44](https://docs.wcproducts.com/kraken-x44))
     - [Software Documentation](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/talonfx/index.html)
 
 - **Talon SRX**
-    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_w_p_i___talon_s_r_x.html))
+    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/stable/java/com/ctre/phoenix/motorcontrol/can/WPI_TalonSRX.html), [C++](https://api.ctr-electronics.com/phoenix/stable/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_w_p_i___talon_s_r_x.html))
     - [Hardware User's Manual](https://ctre.download/files/user-manual/Talon%20SRX%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch13_MC.html)
 
 - **Victor SPX**
-    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/motorcontrol/can/WPI_VictorSPX.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_w_p_i___victor_s_p_x.html))
+    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/stable/java/com/ctre/phoenix/motorcontrol/can/WPI_VictorSPX.html), [C++](https://api.ctr-electronics.com/phoenix/stable/cpp/classctre_1_1phoenix_1_1motorcontrol_1_1can_1_1_w_p_i___victor_s_p_x.html))
     - [Hardware User's Manual](https://ctre.download/files/user-manual/Victor%20SPX%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch13_MC.html)
 
 ### CTRE Sensors
 
 - **CANcoder**
-    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/CANcoder.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a13b25ca6c3f7037c0f6e13b59cc1e571))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/stable/java/com/ctre/phoenix6/hardware/CANcoder.html), [C++](https://api.ctr-electronics.com/phoenix6/stable/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a13b25ca6c3f7037c0f6e13b59cc1e571))
     - [Hardware User's Manual](https://ctre.download/files/user-manual/CANCoder%20User's%20Guide.pdf)
     - [Software Documentation](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/cancoder/index.html)
 
 - **Pigeon 2.0**
-    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/hardware/Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenix6/release/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a7bd5c8d59e1daa07d31aa1d7116c5c64))
+    - API Documentation (v6: [Java](https://api.ctr-electronics.com/phoenix6/stable/java/com/ctre/phoenix6/hardware/Pigeon2.html), [C++](https://api.ctr-electronics.com/phoenix6/stable/cpp/namespacectre_1_1phoenix_1_1platform.html#ad0cac06e0817cbcfe20851a8619a19a8a7bd5c8d59e1daa07d31aa1d7116c5c64))
     - [Hardware User's Manual](https://ctre.download/files/user-manual/Pigeon2%20User's%20Guide.pdf)
     - [Software Documentation6](https://v6.docs.ctr-electronics.com/en/stable/docs/hardware-reference/pigeon2/index.html)
 
 - **Pigeon IMU**
-    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/sensors/WPI_PigeonIMU.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1sensors_1_1_w_p_i___pigeon_i_m_u.html))
+    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/stable/java/com/ctre/phoenix/sensors/WPI_PigeonIMU.html), [C++](https://api.ctr-electronics.com/phoenix/stable/cpp/classctre_1_1phoenix_1_1sensors_1_1_w_p_i___pigeon_i_m_u.html))
     - [Hardware User's Manual](https://ctre.download/files/user-manual/Pigeon%20IMU%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch11_BringUpPigeon.html)
 
 - **CANifier**
-    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/CANifier.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1_c_a_nifier.html))
+    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/stable/java/com/ctre/phoenix/CANifier.html), [C++](https://api.ctr-electronics.com/phoenix/stable/cpp/classctre_1_1phoenix_1_1_c_a_nifier.html))
     - [Hardware User's Manual](https://ctre.download/files/user-manual/CANifier%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch12_BringUpCANifier.html)
 
 ### CTRE Other CAN Devices
 
 - **CANdle LED Controller**
-    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/release/java/com/ctre/phoenix/led/CANdle.html), [C++](https://api.ctr-electronics.com/phoenix/release/cpp/classctre_1_1phoenix_1_1led_1_1_c_a_ndle.html))
+    - API Documentation ([Java](https://api.ctr-electronics.com/phoenix/stable/java/com/ctre/phoenix/led/CANdle.html), [C++](https://api.ctr-electronics.com/phoenix/stable/cpp/classctre_1_1phoenix_1_1led_1_1_c_a_ndle.html))
     - [Hardware User's Manual](https://ctre.download/files/user-manual/CANdle%20User's%20Guide.pdf)
     - [Software Documentation](https://v5.docs.ctr-electronics.com/en/stable/ch12b_BringUpCANdle.html)
 

--- a/source/docs/software/frc-glossary.rst
+++ b/source/docs/software/frc-glossary.rst
@@ -41,7 +41,7 @@
       A core concept in probability which states that when many independent variables are added up, the result tends to look like a "normal" (or Gaussian) distribution, regardless of whether the independent variables themselves are normally distributed. See [Central Limit Theorem](https://en.wikipedia.org/wiki/Central_limit_theorem) on Wikipedia for more info.
 
    CIM
-      CCL Industrial Motor, Limited - [Chiaphua Components Limited](https://www.cclmotors.com/website/eng/home) is the company that made the commonly used, relatively powerful, brushed motor.
+      CCL Industrial Motor, Limited - [Chiaphua Components Limited](https://www.cclmotors.com/) is the company that made the commonly used, relatively powerful, brushed motor.
 
    Classical Mechanics
       The branch of physics which studies and describes the motion of relatively large, relatively slow objects. See [Classical Mechanics](https://en.wikipedia.org/wiki/Classical_mechanics) on Wikipedia for more info.


### PR DESCRIPTION
Also fix link to CCL Motors in glossary