### PR TITLE
Add isHubActive 2026 game data code examples

### DIFF
--- a/source/docs/yearly-overview/2026-game-data.rst
+++ b/source/docs/yearly-overview/2026-game-data.rst
@@ -168,7 +168,6 @@ For example:
 
   def is_hub_active() -> bool:
       alliance = DriverStation.getAlliance()
-
       # If we have no alliance, we cannot be enabled, therefore no hub.
       if alliance is None:
           return False
@@ -177,7 +176,7 @@ For example:
       if DriverStation.isAutonomousEnabled():
           return True
 
-      # If we're not teleop enabled, there is no hub.
+      # At this point if we're not teleop enabled, there is no hub.
       if not DriverStation.isTeleopEnabled():
           return False
 
@@ -200,12 +199,16 @@ For example:
       if match_time > 130:
           return True  # Transition shift, hub is active
       elif match_time > 105:
+          # Shift 1
           return shift1_active
       elif match_time > 80:
+          # Shift 2
           return not shift1_active
       elif match_time > 55:
+          # Shift 3
           return shift1_active
       elif match_time > 30:
+          # Shift 4
           return not shift1_active
       else:
           return True  # End game, hub always active


### PR DESCRIPTION
This adds Java and Python examples for using this year's game data to determine whether the current alliance's hub is active, based off of @ThadHouse's initial snippet.

To keep the article flow going top to bottom, the section about practice mode (and hence match time at home) is moved to before the code examples, as [suggested in review](https://github.com/wpilibsuite/frc-docs/pull/3246#discussion_r2780132212).