### PR TITLE
Clarify instructions about building and deploying code

### DIFF
--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -1,18 +1,18 @@
 # Building and Deploying Robot Code
 
-Robot projects must be compiled ("built") and deployed in order to run on the roboRIO.  Since the code is not compiled natively on the robot controller, this is known as "cross-compilation."
+Robot projects must be compiled ("built") and deployed in order to run on Systemcore.  Since the code is not compiled natively on the robot controller, this is known as "cross-compilation."
 
-To build and deploy a robot project, do one of:
+To build a robot project, do one of:
 
 1. Open the Command Palette and enter/select "Build Robot Code"
 2. Open the shortcut menu indicated by the ellipses in the top right corner of the VS Code window and select "Build Robot Code"
 3. Right-click on the build.gradle file in the project hierarchy and select "Build Robot Code"
 
+To deploy instead, select "Deploy Robot Code" from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to Systemcore.
+
 .. image:: images/deploying-robot-code/building-code-options.png
 
-Deploy robot code by selecting "Deploy Robot Code" from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to the roboRIO.
-
-.. warning:: Avoid powering off the robot while deploying robot code. Interrupting the deployment process can corrupt the roboRIO filesystem and prevent your code from working until the roboRIO is :doc:`re-imaged </docs/zero-to-robot/step-3/imaging-your-roborio>`.
+.. warning:: Avoid powering off the robot while deploying robot code. Interrupting the deployment process can corrupt the Systemcore filesystem and prevent your code from working until the Systemcore is :doc:`re-imaged </docs/zero-to-robot/step-3/imaging-your-roborio>`.
 
 If successful, we will see a "Build Successful" message (1) and the RioLog will open with the console output from the robot program as it runs (2).
 


### PR DESCRIPTION
The instructions described how to build and deploy code, but only gave instructions for building, then inserted a large image, _then_ specified how to deploy, which is really easy to miss. Reorder it so it's harder to miss. Also replace roboRIO with Systemcore.