### PR TITLE
Update build/deploy instructions

### DIFF
--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -12,7 +12,7 @@ To build a robot project, do one of:
 
 ## Deploy
 
-To deploy a robot program, select :guilabel:`Deploy Robot Code` from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to Systemcore.
+To deploy a robot program, select :guilabel:`Deploy Robot Code` from any of the three locations from the previous instructions (or press :kbd:`shift+f5`). That will build (if necessary) and deploy the robot program to Systemcore.
 
 .. image:: images/deploying-robot-code/building-code-options.png
 

--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -28,7 +28,7 @@ If successful, we will see a "Build Successful" message (1) and the RioLog will 
 
 Choosing to deploy robot code will first build the code if it has not been built since the last change. If the code has already been built, it will skip the build step and deploy the existing build artifacts to Systemcore. You can force a rebuild by selecting :guilabel:`Build Robot Code` before deploying. There are some differences when running the :guilabel:`Build Robot Code` command vs the :guilabel:`Deploy Robot Code` command:
 
-* :guilabel:`Build Robot Code` will download dependencies from the internet, while :guilabel:`Deploy Robot Code` will not. If you have not built the code before (for example, if you are working with a new project or you have recently cloned the repository, or you have added or changed a vendordep), you must run :guilabel:`Build Robot Code` at least once to download dependencies before you can deploy.
+* :guilabel:`Build Robot Code` will download dependencies from the internet, while :guilabel:`Deploy Robot Code` will not. If you have not built the code before (for example, if you are working with a new project or you have recently cloned the repository, or you have added or changed a vendordep), you must run :guilabel:`Build Robot Code` while connected to the internet to download dependencies before you can deploy.
 * :guilabel:`Build Robot Code` will run unit tests, if your project has unit tests, while :guilabel:`Deploy Robot Code` will not.
 
 ## Clean

--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -2,13 +2,17 @@
 
 Robot projects must be compiled ("built") and deployed in order to run on Systemcore.  Since the code is not compiled natively on the robot controller, this is known as "cross-compilation."
 
+## Build
+
 To build a robot project, do one of:
 
-1. Open the Command Palette and enter/select "Build Robot Code"
-2. Open the shortcut menu indicated by the ellipses in the top right corner of the VS Code window and select "Build Robot Code"
-3. Right-click on the build.gradle file in the project hierarchy and select "Build Robot Code"
+1. In Visual Studio Code, click the WPILib logo in the top right to launch the WPILib Command Palette (or type :kbd:`ctrl+shift+p` and then type WPILib) and enter/select :guilabel:`Build Robot Code`
+2. Open the shortcut menu indicated by the ellipses in the top right corner of the VS Code window and select :guilabel:`Build Robot Code`
+3. Right-click on the build.gradle file in the project hierarchy and select :guilabel:`Build Robot Code`
 
-To deploy instead, select "Deploy Robot Code" from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to Systemcore.
+## Deploy
+
+To deploy a robot program, select :guilabel:`Deploy Robot Code` from any of the three locations from the previous instructions. That will build (if necessary) and deploy the robot program to Systemcore.
 
 .. image:: images/deploying-robot-code/building-code-options.png
 
@@ -17,3 +21,16 @@ To deploy instead, select "Deploy Robot Code" from any of the three locations fr
 If successful, we will see a "Build Successful" message (1) and the RioLog will open with the console output from the robot program as it runs (2).
 
 .. image:: images/deploying-robot-code/build-successful.png
+
+.. note:: The run button in VS Code's debug view is not used to run robot code. Instead, use the :guilabel:`Deploy Robot Code` command as described above. The debug view's run button is used for running and debugging code on the local machine in simulation, which is not applicable for robot code that runs on Systemcore.
+
+## Build vs Deploy
+
+Choosing to deploy robot code will first build the code if it has not been built since the last change. If the code has already been built, it will skip the build step and deploy the existing build artifacts to Systemcore. You can force a rebuild by selecting :guilabel:`Build Robot Code` before deploying. There are some differences when running the :guilabel:`Build Robot Code` command vs the :guilabel:`Deploy Robot Code` command:
+
+1. :guilabel:`Build Robot Code` will download dependencies from the internet, while :guilabel:`Deploy Robot Code` will not. If you have not built the code before (for example, if you are working with a new project or you have recently cloned the repository, or you have added or changed a vendordep), you must run :guilabel:`Build Robot Code` at least once to download dependencies before you can deploy.
+2. :guilabel:`Build Robot Code` will run unit tests, if your project has unit tests, while :guilabel:`Deploy Robot Code` will not.
+
+## Clean
+
+If you want to force a full rebuild of the code, you can select :guilabel:`Run Gradle Clean` the WPILib Menu. This will delete all build artifacts and force a full rebuild the next time you build or deploy.

--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -6,9 +6,9 @@ Robot projects must be compiled ("built") and deployed in order to run on System
 
 To build a robot project, do one of:
 
-1. In Visual Studio Code, click the WPILib logo in the top right to launch the WPILib Command Palette (or press :kbd:`ctrl+shift+p` and then type WPILib) and enter/select :guilabel:`Build Robot Code`
-2. Open the shortcut menu indicated by the ellipses in the top right corner of the VS Code window and select :guilabel:`Build Robot Code`
-3. Right-click on the build.gradle file in the project hierarchy and select :guilabel:`Build Robot Code`
+* In Visual Studio Code, click the WPILib logo in the top right to launch the WPILib Command Palette (or press :kbd:`ctrl+shift+p` and then type WPILib) and enter/select :guilabel:`Build Robot Code`
+* Open the shortcut menu indicated by the ellipses in the top right corner of the VS Code window and select :guilabel:`Build Robot Code`
+* Right-click on the build.gradle file in the project hierarchy and select :guilabel:`Build Robot Code`
 
 ## Deploy
 
@@ -28,8 +28,8 @@ If successful, we will see a "Build Successful" message (1) and the RioLog will 
 
 Choosing to deploy robot code will first build the code if it has not been built since the last change. If the code has already been built, it will skip the build step and deploy the existing build artifacts to Systemcore. You can force a rebuild by selecting :guilabel:`Build Robot Code` before deploying. There are some differences when running the :guilabel:`Build Robot Code` command vs the :guilabel:`Deploy Robot Code` command:
 
-1. :guilabel:`Build Robot Code` will download dependencies from the internet, while :guilabel:`Deploy Robot Code` will not. If you have not built the code before (for example, if you are working with a new project or you have recently cloned the repository, or you have added or changed a vendordep), you must run :guilabel:`Build Robot Code` at least once to download dependencies before you can deploy.
-2. :guilabel:`Build Robot Code` will run unit tests, if your project has unit tests, while :guilabel:`Deploy Robot Code` will not.
+* :guilabel:`Build Robot Code` will download dependencies from the internet, while :guilabel:`Deploy Robot Code` will not. If you have not built the code before (for example, if you are working with a new project or you have recently cloned the repository, or you have added or changed a vendordep), you must run :guilabel:`Build Robot Code` at least once to download dependencies before you can deploy.
+* :guilabel:`Build Robot Code` will run unit tests, if your project has unit tests, while :guilabel:`Deploy Robot Code` will not.
 
 ## Clean
 

--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -33,4 +33,4 @@ Choosing to deploy robot code will first build the code if it has not been built
 
 ## Clean
 
-If you want to force a full rebuild of the code, you can select :guilabel:`Run Gradle Clean` the WPILib Menu. This will delete all build artifacts and force a full rebuild the next time you build or deploy.
+If you want to force a full rebuild of the code, you can select :guilabel:`Run Gradle Clean` from the WPILib Menu. This will delete all build artifacts and force a full rebuild the next time you build or deploy.

--- a/source/docs/software/vscode-overview/deploying-robot-code.rst
+++ b/source/docs/software/vscode-overview/deploying-robot-code.rst
@@ -6,7 +6,7 @@ Robot projects must be compiled ("built") and deployed in order to run on System
 
 To build a robot project, do one of:
 
-1. In Visual Studio Code, click the WPILib logo in the top right to launch the WPILib Command Palette (or type :kbd:`ctrl+shift+p` and then type WPILib) and enter/select :guilabel:`Build Robot Code`
+1. In Visual Studio Code, click the WPILib logo in the top right to launch the WPILib Command Palette (or press :kbd:`ctrl+shift+p` and then type WPILib) and enter/select :guilabel:`Build Robot Code`
 2. Open the shortcut menu indicated by the ellipses in the top right corner of the VS Code window and select :guilabel:`Build Robot Code`
 3. Right-click on the build.gradle file in the project hierarchy and select :guilabel:`Build Robot Code`
 
@@ -22,7 +22,7 @@ If successful, we will see a "Build Successful" message (1) and the RioLog will 
 
 .. image:: images/deploying-robot-code/build-successful.png
 
-.. note:: The run button in VS Code's debug view is not used to run robot code. Instead, use the :guilabel:`Deploy Robot Code` command as described above. The debug view's run button is used for running and debugging code on the local machine in simulation, which is not applicable for robot code that runs on Systemcore.
+.. note:: The run button in VS Code's debug view is not used to run robot code. Instead, use the :guilabel:`Deploy Robot Code` command as described above. The debug view's run button is used for running and debugging code on the local machine in simulation, which will not run the robot code on a Systemcore.
 
 ## Build vs Deploy
 

--- a/source/docs/zero-to-robot/step-4/creating-test-drivetrain-program-cpp-java-python.rst
+++ b/source/docs/zero-to-robot/step-4/creating-test-drivetrain-program-cpp-java-python.rst
@@ -11,7 +11,7 @@ Once everything is installed, we're ready to create a robot program.  WPILib com
 
 ## Creating a New WPILib Project (Java/C++)
 
-Bring up the Visual Studio Code command palette with :kbd:`Ctrl+Shift+P`. Then, type "WPILib" into the prompt.  Since all WPILib commands start with "WPILib", this will bring up the list of WPILib-specific VS Code commands. Now, select the "Create a new project" command:
+In Visual Studio Code, click the WPILib logo in the top right to launch the WPILib Command Palette. Select :guilabel:`Create a new project`:
 
 .. image:: /docs/software/vscode-overview/images/creating-robot-program/create-new-project.png
    :alt: Choose "WPILib: Create a new project".
@@ -540,5 +540,42 @@ Utility Mode is used for testing robot functionality or running other code that 
 
 ## Deploying the Project to a Robot
 
-* :ref:`Deploy Java/C++ code <docs/software/vscode-overview/deploying-robot-code:Building and Deploying Robot Code>`
-* :doc:`Deploy Python code </docs/software/python/subcommands/deploy>`
+.. tab-set::
+
+   .. tab-item:: Java/C++
+
+      In Visual Studio Code, click the WPILib logo in the top right to launch the WPILib Command Palette. Select :guilabel:`Deploy Robot Code` to deploy the code to the robot.
+
+      .. note:: The run button in VS Code's debug view is not used to run robot code. Instead, use the :guilabel:`Deploy Robot Code` command as described above. The debug view's run button is used for running and debugging code on the local machine in simulation, which is not applicable for robot code that runs on Systemcore.
+
+      For more detailed instructions, see :ref:`Deploy Java/C++ code <docs/software/vscode-overview/deploying-robot-code:Building and Deploying Robot Code>`.
+
+   .. tab-item:: Python
+
+      In the terminal, run the following command to deploy the code to the robot:
+
+      .. tab-set::
+
+         .. tab-item:: Windows
+            :sync: windows
+
+            ```sh
+            py -3 -m robotpy deploy
+            ```
+
+         .. tab-item:: macOS
+            :sync: macos
+
+            ```sh
+            python3 -m robotpy deploy
+            ```
+
+         .. tab-item:: Linux
+            :sync: linux
+
+            ```sh
+            python3 -m robotpy deploy
+            ```
+
+      For more detailed instructions, see :doc:`Deploy Python code </docs/software/python/subcommands/deploy>`.
+


### PR DESCRIPTION
Add short version to ZTR tutorial to avoid breaking up tutorial by linking to another section.
Add notes about the run button, since that was deploy for FTC. 
Add details about the differences between building and deploying 
Add details about clean