### PR TITLE
Require explicit redirects.txt entries for all renamed/moved pages

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -113,8 +113,10 @@ rediraffe_branch = "origin/main"
 # File containing redirects
 rediraffe_redirects = "redirects.txt"
 
-# Required accuracy for redirect writer
-rediraffe_auto_redirect_perc = 80
+# Set above 100 so the checker never auto-approves renamed files based on
+# content similarity — every moved/deleted page must have an explicit entry
+# in redirects.txt. Use "make rediraffewrites" to auto-generate entries.
+rediraffe_auto_redirect_perc = 101
 
 # Configure OpenGraph support
 ogp_site_url = "https://docs.wpilib.org/en/stable/"


### PR DESCRIPTION
## Summary

- Sets `rediraffe_auto_redirect_perc = 101` in `conf.py` so the redirect checker never silently auto-approves a renamed/moved file based on content similarity
- Adds a comment explaining why the value is above 100 and pointing contributors to `make rediraffewrites` for auto-generating entries

## Background

`rediraffecheckdiff` uses content similarity to avoid false positives: if a deleted file has a highly similar counterpart in the current branch, it considers the redirect "handled" without requiring an explicit `redirects.txt` entry. With the previous value of `80`, a pure rename (100% identical content) would pass the check even with no redirect entry — meaning no redirect page would actually be built for the old URL.

This was noticed in #3305, where `docs/contributing/frc-docs/todo.rst` was renamed to `docs/contributing/wpilib-docs/todo.rst` without a `redirects.txt` entry, yet the CI redirect check passed.

## Effect on contributors

Any PR that renames or moves an RST file without an explicit `redirects.txt` entry will now fail the `check-redirects` CI job. Contributors can run `make rediraffewrites` (already available via the Makefile catch-all) to auto-generate the required entries.

## Test plan

- [ ] Verify `make rediraffecheckdiff` fails on a branch that renames an RST file without a `redirects.txt` entry
- [ ] Verify `make rediraffecheckdiff` passes after running `make rediraffewrites` and committing the generated entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)